### PR TITLE
Remove duplicate linters and use gci for imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,9 +9,7 @@ linters:
     - exportloopref
     - importas
     - gci
-    - gofmt
     - gofumpt
-    - goimports
     - gocritic
     - gosec
     - govet
@@ -70,12 +68,6 @@ linters-settings:
       - default
       # Groups all imports with the specified Prefix.
       - prefix(github.com/envoyproxy/ai-gateway)
-  gofmt:
-    simplify: true
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/envoyproxy/ai-gateway
   govet:
     enable-all: true
     disable:

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,12 @@ lint: golangci-lint
 	@$(GOLANGCI_LINT) run --build-tags=$(LINT_BUILD_TAGS) ./...
 
 .PHONY: format
-format: goimports gofumpt
+format: gci gofumpt
 	@echo "format => *.go"
 	@find . -type f -name '*.go' | xargs gofmt -s -w
 	@find . -type f -name '*.go' | xargs $(GO_FUMPT) -l -w
-	@echo "goimports => *.go"
-	@for f in `find . -name '*.go'`; do \
-	    awk '/^import \($$/,/^\)$$/{if($$0=="")next}{print}' $$f > /tmp/fmt; \
-	    mv /tmp/fmt $$f; \
-	done
-	@$(GO_IMPORTS) -w -local github.com/envoyproxy/ai-gateway `find . -name '*.go'`
+	@echo "gci => *.go"
+	@$(GCI) write -s standard -s default -s "prefix(github.com/envoyproxy/ai-gateway)" `find . -name '*.go'`
 
 .PHONY: tidy
 tidy: ## Runs go mod tidy on every module

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -5,12 +5,12 @@ $(LOCALBIN):
 ## Tool binary names.
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GO_FUMPT = $(LOCALBIN)/gofumpt
-GO_IMPORTS = $(LOCALBIN)/goimports
+GCI = $(LOCALBIN)/gci
 
 ## Tool versions.
 GOLANGCI_LINT_VERSION ?= v1.60.1
 GO_FUMPT_VERSION ?= v0.6.0
-GO_IMPORTS_VERSION ?= v0.21.0
+GCI_VERSION ?= v0.13.5
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
@@ -22,10 +22,10 @@ gofumpt: $(GO_FUMPT)
 $(GO_FUMPT): $(LOCALBIN)
 	$(call go-install-tool,$(GO_FUMPT),mvdan.cc/gofumpt,$(GO_FUMPT_VERSION))
 
-.PHONY: goimports
-goimports: $(GO_IMPORTS)
-$(GO_IMPORTS): $(LOCALBIN)
-	$(call go-install-tool,$(GO_IMPORTS),golang.org/x/tools/cmd/goimports,$(GO_IMPORTS_VERSION))
+.PHONY: gci
+gci: $(GCI)
+$(GCI): $(LOCALBIN)
+	$(call go-install-tool,$(GCI),github.com/daixiang0/gci,$(GCI_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
Randomly was reading through this repo and found this potential cleanup, feel free to reject if not needed

- `gofmt` and `gofumpt` fully overlap, so remove `gofmt` linter since `gofumpt` is more advanced
- `gci` and `goimports` fully overlap, so remove `goimports` linter since `gci` is more avanced.
  - If wanting to use `goimports`, can do the reverse, but I don't recommend it since it formats much worse IMO
- Replace `goimports` with `gci` in Makefile to correspond to above change
  - Removes `awk` hack since not needed for `gci`
  - Should be reverted if picking `goimports` instead of `gci`, basically both Makefile and golangci.yml should define the same thing

A change that came to mind but was larger than the above was replacing manual invocation of `gofumpt` and `gci` in Makefile with `golangci-lint run --fix`, which works very similarly because it is configured for the two. I personally like it since it means no need to reproduce configuration from yaml file into Makefile (notably the local import prefix). The downside is it would be a bit slower, so also understand why not everyone would want to do that.