### PR TITLE
ci: do not push containers on PRs

### DIFF
--- a/.github/workflows/docker_builds_template.yaml
+++ b/.github/workflows/docker_builds_template.yaml
@@ -53,6 +53,7 @@ jobs:
       # * Only use the tag if the event is a tag event, otherwise use "latest".
       # * Build for both amd64 and arm64 platforms.
       - name: Build and Push Image
+        if: github.event_name == 'push'
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
Previously the containers were pushed regardless of whether
it is kicked by PRs or commits (push events).  This fixes that.