### PR TITLE
extproc: initial implementation

### DIFF
--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -8,6 +8,14 @@ package extprocconfig
 
 import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+// Config is the configuration for the external processor.
+type Config struct {
+	InputSchema             VersionedAPISchema `json:"inputSchema"`
+	ModelNameHeaderKey      string             `json:"modelNameHeaderKey"`
+	BackendRoutingHeaderKey string             `json:"backendRoutingHeaderKey"`
+	Rules                   []RouteRule        `json:"rules"`
+}
+
 // VersionedAPISchema corresponds to LLMAPISchema in api/v1alpha1/api.go.
 type VersionedAPISchema struct {
 	Schema  APISchema
@@ -22,14 +30,6 @@ const (
 	APISchemaAWSBedrock APISchema = "AWSBedrock"
 )
 
-// Config is the configuration for the external processor.
-type Config struct {
-	InputSchema             VersionedAPISchema
-	ModelNameHeaderKey      string
-	BackendRoutingHeaderKey string
-	Rules                   []RouteRule
-}
-
 // HeaderMatch is an alias for HTTPHeaderMatch of the Gateway API.
 type HeaderMatch = gwapiv1.HTTPHeaderMatch
 
@@ -37,18 +37,18 @@ type HeaderMatch = gwapiv1.HTTPHeaderMatch
 // besides the `Backends` field is modified to abstract the concept of a backend
 // at Envoy Gateway level to a simple name.
 type RouteRule struct {
-	Headers  []HeaderMatch
-	Backends []Backend
+	Headers  []HeaderMatch `json:"headers"`
+	Backends []Backend     `json:"backends"`
 }
 
 // Backend corresponds to LLMRouteRuleBackendRef in api/v1alpha1/api.go
-// besides this abstracts the concept of a backend at Envoy Gateway level to a simple name.
+// besides that this abstracts the concept of a backend at Envoy Gateway level to a simple name.
 type Backend struct {
 	// Name of the backend, which is the value in the final routing decision
 	// matching the header key specified in the [Config.BackendRoutingHeaderKey].
-	Name string
+	Name string `json:"name"`
 	// OutputSchema specifies the API schema of the output format of requests from.
-	OutputSchema VersionedAPISchema
+	OutputSchema VersionedAPISchema `json:"outputSchema"`
 	// Weight is the weight of the backend in the routing decision.
-	Weight int
+	Weight int `json:"weight"`
 }

--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -6,28 +6,71 @@
 // details.
 package extprocconfig
 
-import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
 
 // Config is the configuration for the external processor.
+//
+// The configuration is loaded from a file path specified via the command line flag -configPath to the external processor.
+//
+// # Example configuration:
+//
+//	inputSchema:
+//	  schema: OpenAI
+//	backendRoutingHeaderKey: x-backend-name
+//	modelNameHeaderKey: x-model-name
+//	rules:
+//	- backends:
+//	  - name: kserve
+//	    weight: 1
+//	    outputSchema:
+//	      schema: OpenAI
+//	  - name: awsbedrock
+//	    weight: 10
+//	    outputSchema:
+//	      schema: AWSBedrock
+//	  headers:
+//	  - name: x-model-name
+//	    value: llama3.3333
+//	- backends:
+//	  - name: openai
+//	    outputSchema:
+//	      schema: OpenAI
+//	  headers:
+//	  - name: x-model-name
+//	    value: gpt4.4444
+//
+// where the input of the external processor is in the OpenAI schema, the model name is populated in the header x-model-name,
+// The model name header `x-model-name` is used in the header matching to make the routing decision. **After** the routing decision is made,
+// the selected backend name is populated in the header `x-backend-name`. For example, when the model name is `llama3.3333`,
+// the request is routed to either backends `kserve` or `awsbedrock` with weights 1 and 10 respectively, and the selected
+// backend, say `awsbedrock`, is populated in the header `x-backend-name`.
+//
+// From Envoy configuration perspective, configuring the header matching based on `x-backend-name` is enough to route the request to the selected backend.
+// That is because the matching decision is made by the external processor and the selected backend is populated in the header `x-backend-name`.
 type Config struct {
 	// InputSchema specifies the API schema of the input format of requests to the external processor.
-	InputSchema VersionedAPISchema `json:"inputSchema"`
+	InputSchema VersionedAPISchema `yaml:"inputSchema"`
 	// ModelNameHeaderKey is the header key to be populated with the model name by the external processor.
-	ModelNameHeaderKey string `json:"modelNameHeaderKey"`
+	ModelNameHeaderKey string `yaml:"modelNameHeaderKey"`
 	// BackendRoutingHeaderKey is the header key to be populated with the backend name by the external processor
 	// **after** the routing decision is made by the external processor using Rules.
-	BackendRoutingHeaderKey string `json:"backendRoutingHeaderKey"`
+	BackendRoutingHeaderKey string `yaml:"backendRoutingHeaderKey"`
 	// Rules is the routing rules to be used by the external processor to make the routing decision.
 	// Inside the routing rules, the header ModelNameHeaderKey may be used to make the routing decision.
-	Rules []RouteRule `json:"rules"`
+	Rules []RouteRule `yaml:"rules"`
 }
 
 // VersionedAPISchema corresponds to LLMAPISchema in api/v1alpha1/api.go.
 type VersionedAPISchema struct {
 	// Schema is the API schema.
-	Schema APISchema `json:"schema"`
+	Schema APISchema `yaml:"schema"`
 	// Version is the version of the API schema. Optional.
-	Version string `json:"version,omitempty"`
+	Version string `yaml:"version,omitempty"`
 }
 
 // APISchema corresponds to APISchema in api/v1alpha1/api.go.
@@ -47,9 +90,9 @@ type HeaderMatch = gwapiv1.HTTPHeaderMatch
 type RouteRule struct {
 	// Headers is the list of headers to match for the routing decision.
 	// Currently, only exact match is supported.
-	Headers []HeaderMatch `json:"headers"`
+	Headers []HeaderMatch `yaml:"headers"`
 	// Backends is the list of backends to which the request should be routed to when the headers match.
-	Backends []Backend `json:"backends"`
+	Backends []Backend `yaml:"backends"`
 }
 
 // Backend corresponds to LLMRouteRuleBackendRef in api/v1alpha1/api.go
@@ -57,9 +100,22 @@ type RouteRule struct {
 type Backend struct {
 	// Name of the backend, which is the value in the final routing decision
 	// matching the header key specified in the [Config.BackendRoutingHeaderKey].
-	Name string `json:"name"`
+	Name string `yaml:"name"`
 	// OutputSchema specifies the API schema of the output format of requests from.
-	OutputSchema VersionedAPISchema `json:"outputSchema"`
+	OutputSchema VersionedAPISchema `yaml:"outputSchema"`
 	// Weight is the weight of the backend in the routing decision.
-	Weight int `json:"weight"`
+	Weight int `yaml:"weight"`
+}
+
+// UnmarshalConfigYaml reads the file at the given path and unmarshals it into a Config struct.
+func UnmarshalConfigYaml(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
 }

--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -30,11 +30,14 @@ type Config struct {
 	Rules                   []RouteRule
 }
 
+// HeaderMatch is an alias for HTTPHeaderMatch of the Gateway API.
+type HeaderMatch = gwapiv1.HTTPHeaderMatch
+
 // RouteRule corresponds to LLMRouteRule in api/v1alpha1/api.go
 // besides the `Backends` field is modified to abstract the concept of a backend
 // at Envoy Gateway level to a simple name.
 type RouteRule struct {
-	Headers  []gwapiv1.HTTPHeaderMatch
+	Headers  []HeaderMatch
 	Backends []Backend
 }
 

--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -10,16 +10,24 @@ import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 // Config is the configuration for the external processor.
 type Config struct {
-	InputSchema             VersionedAPISchema `json:"inputSchema"`
-	ModelNameHeaderKey      string             `json:"modelNameHeaderKey"`
-	BackendRoutingHeaderKey string             `json:"backendRoutingHeaderKey"`
-	Rules                   []RouteRule        `json:"rules"`
+	// InputSchema specifies the API schema of the input format of requests to the external processor.
+	InputSchema VersionedAPISchema `json:"inputSchema"`
+	// ModelNameHeaderKey is the header key to be populated with the model name by the external processor.
+	ModelNameHeaderKey string `json:"modelNameHeaderKey"`
+	// BackendRoutingHeaderKey is the header key to be populated with the backend name by the external processor
+	// **after** the routing decision is made by the external processor using Rules.
+	BackendRoutingHeaderKey string `json:"backendRoutingHeaderKey"`
+	// Rules is the routing rules to be used by the external processor to make the routing decision.
+	// Inside the routing rules, the header ModelNameHeaderKey may be used to make the routing decision.
+	Rules []RouteRule `json:"rules"`
 }
 
 // VersionedAPISchema corresponds to LLMAPISchema in api/v1alpha1/api.go.
 type VersionedAPISchema struct {
-	Schema  APISchema
-	Version string
+	// Schema is the API schema.
+	Schema APISchema `json:"schema"`
+	// Version is the version of the API schema. Optional.
+	Version string `json:"version,omitempty"`
 }
 
 // APISchema corresponds to APISchema in api/v1alpha1/api.go.
@@ -37,8 +45,11 @@ type HeaderMatch = gwapiv1.HTTPHeaderMatch
 // besides the `Backends` field is modified to abstract the concept of a backend
 // at Envoy Gateway level to a simple name.
 type RouteRule struct {
-	Headers  []HeaderMatch `json:"headers"`
-	Backends []Backend     `json:"backends"`
+	// Headers is the list of headers to match for the routing decision.
+	// Currently, only exact match is supported.
+	Headers []HeaderMatch `json:"headers"`
+	// Backends is the list of backends to which the request should be routed to when the headers match.
+	Backends []Backend `json:"backends"`
 }
 
 // Backend corresponds to LLMRouteRuleBackendRef in api/v1alpha1/api.go

--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -1,0 +1,51 @@
+// Package extprocconfig provides the configuration for the external processor.
+// This is a public package so that the external processor can be testable without
+// depending on the Envoy Gateway as well as it can be used outside the Envoy AI Gateway.
+//
+// This configuration must be decoupled from the Envoy Gateway types as well as its implementation
+// details.
+package extprocconfig
+
+import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+// VersionedAPISchema corresponds to LLMAPISchema in api/v1alpha1/api.go.
+type VersionedAPISchema struct {
+	Schema  APISchema
+	Version string
+}
+
+// APISchema corresponds to APISchema in api/v1alpha1/api.go.
+type APISchema string
+
+const (
+	APISchemaOpenAI     APISchema = "OpenAI"
+	APISchemaAWSBedrock APISchema = "AWSBedrock"
+)
+
+// Config is the configuration for the external processor.
+type Config struct {
+	InputSchema             VersionedAPISchema
+	ModelNameHeaderKey      string
+	BackendRoutingHeaderKey string
+	Rules                   []RouteRule
+}
+
+// RouteRule corresponds to LLMRouteRule in api/v1alpha1/api.go
+// besides the `Backends` field is modified to abstract the concept of a backend
+// at Envoy Gateway level to a simple name.
+type RouteRule struct {
+	Headers  []gwapiv1.HTTPHeaderMatch
+	Backends []Backend
+}
+
+// Backend corresponds to LLMRouteRuleBackendRef in api/v1alpha1/api.go
+// besides this abstracts the concept of a backend at Envoy Gateway level to a simple name.
+type Backend struct {
+	// Name of the backend, which is the value in the final routing decision
+	// matching the header key specified in the [Config.BackendRoutingHeaderKey].
+	Name string
+	// OutputSchema specifies the API schema of the output format of requests from.
+	OutputSchema VersionedAPISchema
+	// Weight is the weight of the backend in the routing decision.
+	Weight int
+}

--- a/extprocconfig/extprocconfig_test.go
+++ b/extprocconfig/extprocconfig_test.go
@@ -2,16 +2,15 @@ package extprocconfig
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalConfigYaml(t *testing.T) {
-	tmp := t.TempDir()
-	t.Run("ok", func(t *testing.T) {
-		path := tmp + "/config.yaml"
-		const config = `
+	configPath := path.Join(t.TempDir(), "config.yaml")
+	const config = `
 inputSchema:
   schema: OpenAI
 backendRoutingHeaderKey: x-backend-name
@@ -37,19 +36,18 @@ rules:
   - name: x-model-name
     value: gpt4.4444
 `
-		require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
-		cfg, err := UnmarshalConfigYaml(path)
-		require.NoError(t, err)
-		require.Equal(t, "OpenAI", string(cfg.InputSchema.Schema))
-		require.Equal(t, "x-backend-name", cfg.BackendRoutingHeaderKey)
-		require.Equal(t, "x-model-name", cfg.ModelNameHeaderKey)
-		require.Len(t, cfg.Rules, 2)
-		require.Equal(t, "llama3.3333", cfg.Rules[0].Headers[0].Value)
-		require.Equal(t, "gpt4.4444", cfg.Rules[1].Headers[0].Value)
-		require.Equal(t, "kserve", cfg.Rules[0].Backends[0].Name)
-		require.Equal(t, 10, cfg.Rules[0].Backends[1].Weight)
-		require.Equal(t, "AWSBedrock", string(cfg.Rules[0].Backends[1].OutputSchema.Schema))
-		require.Equal(t, "openai", cfg.Rules[1].Backends[0].Name)
-		require.Equal(t, "OpenAI", string(cfg.Rules[1].Backends[0].OutputSchema.Schema))
-	})
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+	cfg, err := UnmarshalConfigYaml(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "OpenAI", string(cfg.InputSchema.Schema))
+	require.Equal(t, "x-backend-name", cfg.BackendRoutingHeaderKey)
+	require.Equal(t, "x-model-name", cfg.ModelNameHeaderKey)
+	require.Len(t, cfg.Rules, 2)
+	require.Equal(t, "llama3.3333", cfg.Rules[0].Headers[0].Value)
+	require.Equal(t, "gpt4.4444", cfg.Rules[1].Headers[0].Value)
+	require.Equal(t, "kserve", cfg.Rules[0].Backends[0].Name)
+	require.Equal(t, 10, cfg.Rules[0].Backends[1].Weight)
+	require.Equal(t, "AWSBedrock", string(cfg.Rules[0].Backends[1].OutputSchema.Schema))
+	require.Equal(t, "openai", cfg.Rules[1].Backends[0].Name)
+	require.Equal(t, "OpenAI", string(cfg.Rules[1].Backends[0].OutputSchema.Schema))
 }

--- a/extprocconfig/extprocconfig_test.go
+++ b/extprocconfig/extprocconfig_test.go
@@ -1,0 +1,55 @@
+package extprocconfig
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalConfigYaml(t *testing.T) {
+	tmp := t.TempDir()
+	t.Run("ok", func(t *testing.T) {
+		path := tmp + "/config.yaml"
+		const config = `
+inputSchema:
+  schema: OpenAI
+backendRoutingHeaderKey: x-backend-name
+modelNameHeaderKey: x-model-name
+rules:
+- backends:
+  - name: kserve
+    weight: 1
+    outputSchema:
+      schema: OpenAI
+  - name: awsbedrock
+    weight: 10
+    outputSchema:
+      schema: AWSBedrock
+  headers:
+  - name: x-model-name
+    value: llama3.3333
+- backends:
+  - name: openai
+    outputSchema:
+      schema: OpenAI
+  headers:
+  - name: x-model-name
+    value: gpt4.4444
+`
+		require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+		cfg, err := UnmarshalConfigYaml(path)
+		require.NoError(t, err)
+		require.Equal(t, "OpenAI", string(cfg.InputSchema.Schema))
+		require.Equal(t, "x-backend-name", cfg.BackendRoutingHeaderKey)
+		require.Equal(t, "x-model-name", cfg.ModelNameHeaderKey)
+		require.Len(t, cfg.Rules, 2)
+		require.Equal(t, "llama3.3333", cfg.Rules[0].Headers[0].Value)
+		require.Equal(t, "gpt4.4444", cfg.Rules[1].Headers[0].Value)
+		require.Equal(t, "kserve", cfg.Rules[0].Backends[0].Name)
+		require.Equal(t, 10, cfg.Rules[0].Backends[1].Weight)
+		require.Equal(t, "AWSBedrock", string(cfg.Rules[0].Backends[1].OutputSchema.Schema))
+		require.Equal(t, "openai", cfg.Rules[1].Backends[0].Name)
+		require.Equal(t, "OpenAI", string(cfg.Rules[1].Backends[0].OutputSchema.Schema))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/envoyproxy/gateway v1.2.4
 	github.com/envoyproxy/go-control-plane v0.13.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	google.golang.org/grpc v1.67.1
 	k8s.io/apimachinery v0.32.0
 	sigs.k8s.io/controller-runtime v0.19.3
@@ -56,7 +57,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/envoyproxy/gateway v1.2.4
 	github.com/envoyproxy/go-control-plane v0.13.1
 	github.com/stretchr/testify v1.10.0
+	google.golang.org/grpc v1.67.1
 	k8s.io/apimachinery v0.32.0
 	sigs.k8s.io/controller-runtime v0.19.3
 	sigs.k8s.io/gateway-api v1.2.1
@@ -64,7 +65,6 @@ require (
 	golang.org/x/time v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 // indirect
-	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/cmd/extproc/main.go
+++ b/internal/cmd/extproc/main.go
@@ -1,7 +1,78 @@
 package main
 
-import "github.com/envoyproxy/ai-gateway/internal/version"
+import (
+	"context"
+	"flag"
+	"log"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/envoyproxy/ai-gateway/internal/extproc"
+	"github.com/envoyproxy/ai-gateway/internal/version"
+)
+
+var (
+	configPath = flag.String("configPath", "", "path to the configuration file. "+
+		"The file must be in YAML format speified in extprocconfig.Config type. The configuration file is watched for changes.")
+	// TODO: unix domain socket support.
+	extProcPort = flag.String("extProcPort", ":1063", "gRPC port for the external processor")
+	logLevel    = flag.String("logLevel", "info", "log level")
+)
 
 func main() {
-	println(version.Version)
+	flag.Parse()
+
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(*logLevel)); err != nil {
+		log.Fatalf("failed to unmarshal log level: %v", err)
+	}
+	l := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	}))
+
+	l.Info("starting external processor", slog.String("version", version.Version))
+
+	if *configPath == "" {
+		log.Fatal("configPath must be provided")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	signalsChan := make(chan os.Signal, 1)
+	signal.Notify(signalsChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-signalsChan
+		cancel()
+	}()
+
+	// TODO: unix domain socket support.
+	lis, err := net.Listen("tcp", *extProcPort)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	server, err := extproc.NewServer[*extproc.Processor](l, extproc.NewProcessor)
+	if err != nil {
+		log.Fatalf("failed to create external processor server: %v", err)
+	}
+
+	if err := extproc.StartConfigWatcher(ctx, *configPath, server, l, time.Second*5); err != nil {
+		log.Fatalf("failed to start config watcher: %v", err)
+	}
+
+	s := grpc.NewServer()
+	extprocv3.RegisterExternalProcessorServer(s, server)
+	grpc_health_v1.RegisterHealthServer(s, server)
+	go func() {
+		<-ctx.Done()
+		s.GracefulStop()
+	}()
+	_ = s.Serve(lis)
 }

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -1,0 +1,94 @@
+package extproc
+
+import (
+	"testing"
+
+	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
+)
+
+var (
+	_ translator.Translator = &mockTranslator{}
+	_ router.Router         = &mockRouter{}
+)
+
+// mockTranslator implements [translator.Translator] for testing.
+type mockTranslator struct {
+	t                 *testing.T
+	expHeaders        map[string]string
+	expRequestBody    router.RequestBody
+	expResponseBody   *extprocv3.HttpBody
+	retHeaderMutation *extprocv3.HeaderMutation
+	retBodyMutation   *extprocv3.BodyMutation
+	retOverride       *extprocv3http.ProcessingMode
+	retErr            error
+}
+
+// RequestBody implements [translator.Translator.RequestBody].
+func (m mockTranslator) RequestBody(body router.RequestBody) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, override *extprocv3http.ProcessingMode, err error) {
+	require.Equal(m.t, m.expRequestBody, body)
+	return m.retHeaderMutation, m.retBodyMutation, m.retOverride, m.retErr
+}
+
+// ResponseHeaders implements [translator.Translator.ResponseHeaders].
+func (m mockTranslator) ResponseHeaders(headers map[string]string) (headerMutation *extprocv3.HeaderMutation, err error) {
+	require.Equal(m.t, m.expHeaders, headers)
+	return m.retHeaderMutation, m.retErr
+}
+
+// ResponseBody implements [translator.Translator.ResponseBody].
+func (m mockTranslator) ResponseBody(body *extprocv3.HttpBody) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, usedToken uint32, err error) {
+	require.Equal(m.t, m.expResponseBody, body)
+	return m.retHeaderMutation, m.retBodyMutation, usedToken, m.retErr
+}
+
+// mockRouter implements [router.Router] for testing.
+type mockRouter struct {
+	t                     *testing.T
+	expHeaders            map[string]string
+	retBackendName        string
+	retVersionedAPISchema extprocconfig.VersionedAPISchema
+	retErr                error
+}
+
+// Calculate implements [router.Router.Calculate].
+func (m mockRouter) Calculate(headers map[string]string) (string, extprocconfig.VersionedAPISchema, error) {
+	require.Equal(m.t, m.expHeaders, headers)
+	return m.retBackendName, m.retVersionedAPISchema, m.retErr
+}
+
+// mockRequestBodyParser implements [router.RequestBodyParser] for testing.
+type mockRequestBodyParser struct {
+	t            *testing.T
+	expPath      string
+	expBody      []byte
+	retModelName string
+	retRb        router.RequestBody
+	retErr       error
+}
+
+// impl implements [router.RequestBodyParser].
+func (m *mockRequestBodyParser) impl(path string, body *extprocv3.HttpBody) (modelName string, rb router.RequestBody, err error) {
+	require.Equal(m.t, m.expPath, path)
+	require.Equal(m.t, m.expBody, body.Body)
+	return m.retModelName, m.retRb, m.retErr
+}
+
+// mockTranslatorFactory implements [translator.Factory] for testing.
+type mockTranslatorFactory struct {
+	t             *testing.T
+	expPath       string
+	retTranslator translator.Translator
+	retErr        error
+}
+
+// NewTranslator implements [translator.Factory].
+func (m mockTranslatorFactory) impl(path string) (translator.Translator, error) {
+	require.Equal(m.t, m.expPath, path)
+	return m.retTranslator, m.retErr
+}

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -1,0 +1,139 @@
+package extproc
+
+import (
+	"context"
+	"fmt"
+	"unicode/utf8"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
+)
+
+type processorConfig struct {
+	bodyParser                                  router.RequestBodyParser
+	router                                      router.Router
+	ModelNameHeaderKey, backendRoutingHeaderKey string
+	factories                                   map[extprocconfig.VersionedAPISchema]translator.Factory
+}
+
+// processor handles the processing of the request and response messages for a single stream.
+type processor struct {
+	config         *processorConfig
+	requestHeaders map[string]string
+	translator     translator.Translator
+}
+
+// processRequestHeaders processes the request headers message.
+func (p *processor) processRequestHeaders(_ context.Context, headers *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
+	p.requestHeaders = headersToMap(headers)
+	resp := &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestHeaders{
+		RequestHeaders: &extprocv3.HeadersResponse{},
+	}}
+	return resp, nil
+}
+
+// processRequestBody processes the request body message.
+func (p *processor) processRequestBody(_ context.Context, rawBody *extprocv3.HttpBody) (res *extprocv3.ProcessingResponse, err error) {
+	path := p.requestHeaders[":path"]
+	model, body, err := p.config.bodyParser(path, rawBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	backendName, outputSchema, err := p.config.router.Calculate(p.requestHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate route: %w", err)
+	}
+
+	factory, ok := p.config.factories[outputSchema]
+	if !ok {
+		return nil, fmt.Errorf("failed to find factory for output schema %q", outputSchema)
+	}
+
+	t, err := factory(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create translator: %w", err)
+	}
+	p.translator = t
+
+	headerMutation, bodyMutation, override, err := p.translator.RequestBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform request: %w", err)
+	}
+
+	if headerMutation == nil {
+		headerMutation = &extprocv3.HeaderMutation{}
+	}
+	// Set the model name to the request header with the key `x-ai-gateway-llm-model-name`.
+	headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
+		Header: &corev3.HeaderValue{Key: p.config.ModelNameHeaderKey, RawValue: []byte(model)},
+	}, &corev3.HeaderValueOption{
+		Header: &corev3.HeaderValue{Key: p.config.backendRoutingHeaderKey, RawValue: []byte(backendName)},
+	})
+	resp := &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+		ModeOverride: override,
+	}
+	return resp, nil
+}
+
+// processResponseHeaders processes the response headers message.
+func (p *processor) processResponseHeaders(_ context.Context, headers *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
+	headerMutation, err := p.translator.ResponseHeaders(headersToMap(headers))
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform response: %w", err)
+	}
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+		ResponseHeaders: &extprocv3.HeadersResponse{
+			Response: &extprocv3.CommonResponse{HeaderMutation: headerMutation},
+		},
+	}}, nil
+}
+
+// processResponseBody processes the response body message.
+func (p *processor) processResponseBody(_ context.Context, body *extprocv3.HttpBody) (res *extprocv3.ProcessingResponse, err error) {
+	headerMutation, bodyMutation, usedToken, err := p.translator.ResponseBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform response: %w", err)
+	}
+
+	// TODO: set the used token in metadata.
+	_ = usedToken
+
+	resp := &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseBody{
+			ResponseBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+	}
+	return resp, nil
+}
+
+// headersToMap converts a [corev3.HeaderMap] to a Go map for easier processing.
+func headersToMap(headers *corev3.HeaderMap) map[string]string {
+	// TODO: handle multiple headers with the same key.
+	hdrs := make(map[string]string)
+	for _, h := range headers.GetHeaders() {
+		if len(h.Value) > 0 {
+			hdrs[h.GetKey()] = h.Value
+		} else if utf8.Valid(h.RawValue) {
+			hdrs[h.GetKey()] = string(h.RawValue)
+		}
+	}
+	return hdrs
+}

--- a/internal/extproc/processor_test.go
+++ b/internal/extproc/processor_test.go
@@ -1,0 +1,171 @@
+package extproc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
+)
+
+func TestProcessor_processRequestHeaders(t *testing.T) {
+	p := &processor{}
+	res, err := p.processRequestHeaders(context.Background(), &corev3.HeaderMap{
+		Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}},
+	})
+	require.NoError(t, err)
+	_, ok := res.Response.(*extprocv3.ProcessingResponse_RequestHeaders)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"foo": "bar"}, p.requestHeaders)
+}
+
+func TestProcessor_processResponseHeaders(t *testing.T) {
+	t.Run("error translation", func(t *testing.T) {
+		mt := &mockTranslator{t: t, expHeaders: make(map[string]string)}
+		p := &processor{translator: mt}
+		mt.retErr = errors.New("test error")
+		_, err := p.processResponseHeaders(context.Background(), nil)
+		require.ErrorContains(t, err, "test error")
+	})
+	t.Run("ok", func(t *testing.T) {
+		inHeaders := &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}, {Key: "dog", RawValue: []byte("cat")}},
+		}
+		expHeaders := map[string]string{"foo": "bar", "dog": "cat"}
+		mt := &mockTranslator{t: t, expHeaders: expHeaders}
+		p := &processor{translator: mt}
+		res, err := p.processResponseHeaders(context.Background(), inHeaders)
+		require.NoError(t, err)
+		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseHeaders).ResponseHeaders.Response
+		require.Equal(t, mt.retHeaderMutation, commonRes.HeaderMutation)
+	})
+}
+
+func TestProcessor_processResponseBody(t *testing.T) {
+	t.Run("error translation", func(t *testing.T) {
+		mt := &mockTranslator{t: t}
+		p := &processor{translator: mt}
+		mt.retErr = errors.New("test error")
+		_, err := p.processResponseBody(context.Background(), nil)
+		require.ErrorContains(t, err, "test error")
+	})
+	t.Run("ok", func(t *testing.T) {
+		inBody := &extprocv3.HttpBody{}
+		expBodyMut := &extprocv3.BodyMutation{}
+		expHeadMut := &extprocv3.HeaderMutation{}
+		mt := &mockTranslator{t: t, expResponseBody: inBody, retBodyMutation: expBodyMut, retHeaderMutation: expHeadMut}
+		p := &processor{translator: mt}
+		res, err := p.processResponseBody(context.Background(), inBody)
+		require.NoError(t, err)
+		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseBody).ResponseBody.Response
+		require.Equal(t, expBodyMut, commonRes.BodyMutation)
+		require.Equal(t, expHeadMut, commonRes.HeaderMutation)
+	})
+}
+
+func TestProcessor_processRequestBody(t *testing.T) {
+	t.Run("body parser error", func(t *testing.T) {
+		rbp := mockRequestBodyParser{t: t, retErr: errors.New("test error")}
+		p := &processor{config: &processorConfig{bodyParser: rbp.impl}}
+		_, err := p.processRequestBody(context.Background(), &extprocv3.HttpBody{})
+		require.ErrorContains(t, err, "failed to parse request body: test error")
+	})
+	t.Run("router error", func(t *testing.T) {
+		headers := map[string]string{":path": "/foo"}
+		rbp := mockRequestBodyParser{t: t, retModelName: "some-model", expPath: "/foo"}
+		rt := mockRouter{t: t, expHeaders: headers, retErr: errors.New("test error")}
+		p := &processor{config: &processorConfig{bodyParser: rbp.impl, router: rt}, requestHeaders: headers}
+		_, err := p.processRequestBody(context.Background(), &extprocv3.HttpBody{})
+		require.ErrorContains(t, err, "failed to calculate route: test error")
+	})
+	t.Run("translator not found", func(t *testing.T) {
+		headers := map[string]string{":path": "/foo"}
+		rbp := mockRequestBodyParser{t: t, retModelName: "some-model", expPath: "/foo"}
+		rt := mockRouter{
+			t: t, expHeaders: headers, retBackendName: "some-backend",
+			retVersionedAPISchema: extprocconfig.VersionedAPISchema{Schema: "some-schema", Version: "v10.0"},
+		}
+		p := &processor{config: &processorConfig{
+			bodyParser: rbp.impl, router: rt,
+			factories: make(map[extprocconfig.VersionedAPISchema]translator.Factory),
+		}, requestHeaders: headers}
+		_, err := p.processRequestBody(context.Background(), &extprocv3.HttpBody{})
+		require.ErrorContains(t, err, "failed to find factory for output schema {\"some-schema\" \"v10.0\"}")
+	})
+	t.Run("translator factory error", func(t *testing.T) {
+		headers := map[string]string{":path": "/foo"}
+		rbp := mockRequestBodyParser{t: t, retModelName: "some-model", expPath: "/foo"}
+		rt := mockRouter{
+			t: t, expHeaders: headers, retBackendName: "some-backend",
+			retVersionedAPISchema: extprocconfig.VersionedAPISchema{Schema: "some-schema", Version: "v10.0"},
+		}
+		factory := mockTranslatorFactory{t: t, retErr: errors.New("test error"), expPath: "/foo"}
+		p := &processor{config: &processorConfig{
+			bodyParser: rbp.impl, router: rt,
+			factories: map[extprocconfig.VersionedAPISchema]translator.Factory{
+				{Schema: "some-schema", Version: "v10.0"}: factory.impl,
+			},
+		}, requestHeaders: headers}
+		_, err := p.processRequestBody(context.Background(), &extprocv3.HttpBody{})
+		require.ErrorContains(t, err, "failed to create translator: test error")
+	})
+	t.Run("translator error", func(t *testing.T) {
+		headers := map[string]string{":path": "/foo"}
+		rbp := mockRequestBodyParser{t: t, retModelName: "some-model", expPath: "/foo"}
+		rt := mockRouter{
+			t: t, expHeaders: headers, retBackendName: "some-backend",
+			retVersionedAPISchema: extprocconfig.VersionedAPISchema{Schema: "some-schema", Version: "v10.0"},
+		}
+		factory := mockTranslatorFactory{t: t, retTranslator: mockTranslator{t: t, retErr: errors.New("test error")}, expPath: "/foo"}
+		p := &processor{config: &processorConfig{
+			bodyParser: rbp.impl, router: rt,
+			factories: map[extprocconfig.VersionedAPISchema]translator.Factory{
+				{Schema: "some-schema", Version: "v10.0"}: factory.impl,
+			},
+		}, requestHeaders: headers}
+		_, err := p.processRequestBody(context.Background(), &extprocv3.HttpBody{})
+		require.ErrorContains(t, err, "failed to transform request: test error")
+	})
+	t.Run("ok", func(t *testing.T) {
+		someBody := router.RequestBody("foooooooooooooo")
+		headers := map[string]string{":path": "/foo"}
+		rbp := mockRequestBodyParser{t: t, retModelName: "some-model", expPath: "/foo", retRb: someBody}
+		rt := mockRouter{
+			t: t, expHeaders: headers, retBackendName: "some-backend",
+			retVersionedAPISchema: extprocconfig.VersionedAPISchema{Schema: "some-schema", Version: "v10.0"},
+		}
+		headerMut := &extprocv3.HeaderMutation{}
+		bodyMut := &extprocv3.BodyMutation{}
+		mt := mockTranslator{t: t, expRequestBody: someBody, retHeaderMutation: headerMut, retBodyMutation: bodyMut}
+		factory := mockTranslatorFactory{t: t, retTranslator: mt, expPath: "/foo"}
+		p := &processor{config: &processorConfig{
+			bodyParser: rbp.impl, router: rt,
+			factories: map[extprocconfig.VersionedAPISchema]translator.Factory{
+				{Schema: "some-schema", Version: "v10.0"}: factory.impl,
+			},
+			backendRoutingHeaderKey: "x-ai-gateway-backend-key",
+			ModelNameHeaderKey:      "x-ai-gateway-model-key",
+		}, requestHeaders: headers}
+		resp, err := p.processRequestBody(context.Background(), &extprocv3.HttpBody{})
+		require.NoError(t, err)
+		require.Equal(t, mt, p.translator)
+		require.NotNil(t, resp)
+		commonRes := resp.Response.(*extprocv3.ProcessingResponse_RequestBody).RequestBody.Response
+		require.Equal(t, headerMut, commonRes.HeaderMutation)
+		require.Equal(t, bodyMut, commonRes.BodyMutation)
+
+		// Check the model and backend headers are set in headerMut.
+		hdrs := headerMut.SetHeaders
+		require.Len(t, hdrs, 2)
+		require.Equal(t, "x-ai-gateway-model-key", hdrs[0].Header.Key)
+		require.Equal(t, "some-model", string(hdrs[0].Header.RawValue))
+		require.Equal(t, "x-ai-gateway-backend-key", hdrs[1].Header.Key)
+		require.Equal(t, "some-backend", string(hdrs[1].Header.RawValue))
+	})
+}

--- a/internal/extproc/router/request_body.go
+++ b/internal/extproc/router/request_body.go
@@ -1,0 +1,38 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+// RequestBodyParser is a function that parses the body of the request.
+type RequestBodyParser func(path string, body *extprocv3.HttpBody) (modelName string, rb RequestBody, err error)
+
+// NewRequestBodyParser creates a new RequestBodyParser based on the schema.
+func NewRequestBodyParser(inputSchema extprocconfig.VersionedAPISchema) (RequestBodyParser, error) {
+	if inputSchema.Schema == extprocconfig.APISchemaOpenAI {
+		return openAIParseBody, nil
+	}
+	return nil, fmt.Errorf("unsupported API schema: %s", inputSchema)
+}
+
+// RequestBody is the union of all request body types.
+type RequestBody any
+
+// openAIParseBody parses the body of the request for OpenAI.
+func openAIParseBody(path string, body *extprocv3.HttpBody) (modelName string, rb RequestBody, err error) {
+	if path == "/v1/chat/completions" {
+		var openAIReq openai.ChatCompletionRequest
+		if err := json.Unmarshal(body.Body, &openAIReq); err != nil {
+			return "", nil, fmt.Errorf("failed to unmarshal body: %w", err)
+		}
+		return openAIReq.Model, openAIReq, nil
+	} else {
+		return "", nil, fmt.Errorf("unsupported path: %s", path)
+	}
+}

--- a/internal/extproc/router/request_body_test.go
+++ b/internal/extproc/router/request_body_test.go
@@ -1,0 +1,46 @@
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+func TestNewRequestBodyParser(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		res, err := NewRequestBodyParser(extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI})
+		require.NotNil(t, res)
+		require.NoError(t, err)
+	})
+	t.Run("error", func(t *testing.T) {
+		res, err := NewRequestBodyParser(extprocconfig.VersionedAPISchema{Schema: "foo"})
+		require.Nil(t, res)
+		require.Error(t, err)
+	})
+}
+
+func Test_openAIParseBody(t *testing.T) {
+	t.Run("/v1/chat/completions", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			original := openai.ChatCompletionRequest{Model: "llama3.3"}
+			bytes, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			modelName, rb, err := openAIParseBody("/v1/chat/completions", &extprocv3.HttpBody{Body: bytes})
+			require.NoError(t, err)
+			require.Equal(t, "llama3.3", modelName)
+			require.NotNil(t, rb)
+		})
+		t.Run("error", func(t *testing.T) {
+			modelName, rb, err := openAIParseBody("/v1/chat/completions", &extprocv3.HttpBody{})
+			require.Error(t, err)
+			require.Equal(t, "", modelName)
+			require.Nil(t, rb)
+		})
+	})
+}

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -1,0 +1,21 @@
+package router
+
+import (
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+type Router interface {
+	Calculate(
+		headers map[string]string,
+	) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error)
+}
+
+type router struct{}
+
+func NewRouter(config *extprocconfig.Config) (Router, error) {
+	return &router{}, nil
+}
+
+func (r *router) Calculate(headers map[string]string) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error) {
+	return "", extprocconfig.VersionedAPISchema{}, nil
+}

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -5,9 +5,7 @@ import (
 )
 
 type Router interface {
-	Calculate(
-		headers map[string]string,
-	) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error)
+	Calculate(headers map[string]string) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error)
 }
 
 type router struct{}

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -1,19 +1,69 @@
 package router
 
 import (
+	"errors"
+	"time"
+
+	"golang.org/x/exp/rand"
+
 	"github.com/envoyproxy/ai-gateway/extprocconfig"
 )
 
+// Router is the interface for the router.
 type Router interface {
+	// Calculate determines the backend to route to based on the headers.
+	// Returns the backend name and the output schema.
 	Calculate(headers map[string]string) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error)
 }
 
-type router struct{}
-
-func NewRouter(config *extprocconfig.Config) (Router, error) {
-	return &router{}, nil
+// router implements [Router].
+type router struct {
+	rules []extprocconfig.RouteRule
+	rng   *rand.Rand
 }
 
+// NewRouter creates a new [Router] implementation for the given config.
+func NewRouter(config *extprocconfig.Config) (Router, error) {
+	return &router{rules: config.Rules, rng: rand.New(rand.NewSource(uint64(time.Now().UnixNano())))}, nil
+}
+
+// Calculate implements [Router.Calculate].
 func (r *router) Calculate(headers map[string]string) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error) {
-	return "", extprocconfig.VersionedAPISchema{}, nil
+	var rule *extprocconfig.RouteRule
+	for i := range r.rules {
+		_rule := &r.rules[i]
+		for _, hdr := range _rule.Headers {
+			v, ok := headers[string(hdr.Name)]
+			// Currently, we only do the exact matching.
+			if ok && v == hdr.Value {
+				rule = _rule
+				break
+			}
+		}
+	}
+	if rule == nil {
+		return "", extprocconfig.VersionedAPISchema{}, errors.New("no matching rule found")
+	}
+	backendName, outputSchema = r.selectBackendFromRule(rule)
+	return
+}
+
+func (r *router) selectBackendFromRule(rule *extprocconfig.RouteRule) (backendName string, outputSchema extprocconfig.VersionedAPISchema) {
+	// Each backend has a weight, so we randomly select depending on the weight.
+	// This is a pretty naive implementation and can be buggy, so fix it later.
+	totalWeight := 0
+	for _, b := range rule.Backends {
+		totalWeight += b.Weight
+	}
+	if totalWeight == 0 {
+		return rule.Backends[0].Name, rule.Backends[0].OutputSchema
+	}
+	selected := r.rng.Intn(totalWeight)
+	for _, b := range rule.Backends {
+		if selected < b.Weight {
+			return b.Name, b.OutputSchema
+		}
+		selected -= b.Weight
+	}
+	return rule.Backends[0].Name, rule.Backends[0].OutputSchema
 }

--- a/internal/extproc/router/router_test.go
+++ b/internal/extproc/router/router_test.go
@@ -1,0 +1,89 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+func TestRouter_Calculate(t *testing.T) {
+	outSchema := extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}
+	_r, err := NewRouter(&extprocconfig.Config{
+		Rules: []extprocconfig.RouteRule{
+			{
+				Backends: []extprocconfig.Backend{
+					{Name: "foo", OutputSchema: outSchema, Weight: 1},
+					{Name: "bar", OutputSchema: outSchema, Weight: 3},
+				},
+				Headers: []extprocconfig.HeaderMatch{
+					{Name: "x-model-name", Value: "llama3.3333"},
+				},
+			},
+			{
+				Backends: []extprocconfig.Backend{
+					{Name: "openai", OutputSchema: outSchema},
+				},
+				Headers: []extprocconfig.HeaderMatch{
+					{Name: "x-model-name", Value: "gpt4.4444"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	r, ok := _r.(*router)
+	require.True(t, ok)
+
+	t.Run("no matching rule", func(t *testing.T) {
+		backendName, outputSchema, err := r.Calculate(map[string]string{"x-model-name": "something-quirky"})
+		require.Error(t, err)
+		require.Empty(t, backendName)
+		require.Empty(t, outputSchema)
+	})
+	t.Run("matching rule - single backend choice", func(t *testing.T) {
+		backendName, outputSchema, err := r.Calculate(map[string]string{"x-model-name": "gpt4.4444"})
+		require.NoError(t, err)
+		require.Equal(t, "openai", backendName)
+		require.Equal(t, outSchema, outputSchema)
+	})
+	t.Run("matching rule - multiple backend choices", func(t *testing.T) {
+		chosenNames := make(map[string]int)
+		for i := 0; i < 1000; i++ {
+			backendName, outputSchema, err := r.Calculate(map[string]string{"x-model-name": "llama3.3333"})
+			require.NoError(t, err)
+			chosenNames[backendName]++
+			require.Contains(t, []string{"foo", "bar"}, backendName)
+			require.Equal(t, outSchema, outputSchema)
+		}
+		require.Greater(t, chosenNames["bar"], chosenNames["foo"])
+		require.Greater(t, chosenNames["bar"], 700)
+		require.Greater(t, chosenNames["foo"], 200)
+	})
+}
+
+func TestRouter_selectBackendFromRule(t *testing.T) {
+	_r, err := NewRouter(&extprocconfig.Config{})
+	require.NoError(t, err)
+	r, ok := _r.(*router)
+	require.True(t, ok)
+
+	outSchema := extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}
+
+	rule := &extprocconfig.RouteRule{
+		Backends: []extprocconfig.Backend{
+			{Name: "foo", OutputSchema: outSchema, Weight: 1},
+			{Name: "bar", OutputSchema: outSchema, Weight: 3},
+		},
+	}
+
+	chosenNames := make(map[string]int)
+	for i := 0; i < 1000; i++ {
+		backendName, _ := r.selectBackendFromRule(rule)
+		chosenNames[backendName]++
+	}
+
+	require.Greater(t, chosenNames["bar"], chosenNames["foo"])
+	require.Greater(t, chosenNames["bar"], 700)
+	require.Greater(t, chosenNames["foo"], 200)
+}

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -1,0 +1,143 @@
+package extproc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
+)
+
+// Server implements the external process server.
+type Server struct {
+	logger *slog.Logger
+	config *processorConfig
+}
+
+// NewServer creates a new external processor server.
+func NewServer(logger *slog.Logger) (*Server, error) {
+	srv := &Server{logger: logger}
+	return srv, nil
+}
+
+func (s *Server) SetConfig(config *extprocconfig.Config) error {
+	bodyParser, err := router.NewRequestBodyParser(config.InputSchema)
+	if err != nil {
+		return fmt.Errorf("cannot create request body parser: %w", err)
+	}
+	rt, err := router.NewRouter(config)
+	if err != nil {
+		return fmt.Errorf("cannot create router: %w", err)
+	}
+
+	factories := make(map[extprocconfig.VersionedAPISchema]translator.Factory)
+	for _, r := range config.Rules {
+		for _, b := range r.Backends {
+			if _, ok := factories[b.OutputSchema]; !ok {
+				factories[b.OutputSchema], err = translator.NewFactory(config.InputSchema, b.OutputSchema)
+				if err != nil {
+					return fmt.Errorf("cannot create translator factory: %w", err)
+				}
+			}
+		}
+	}
+
+	s.config = &processorConfig{
+		bodyParser: bodyParser, router: rt,
+		backendRoutingHeaderKey: config.BackendRoutingHeaderKey,
+		factories:               factories,
+	}
+	return nil
+}
+
+// Process implements [extprocv3.ExternalProcessorServer].
+func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error {
+	ctx := stream.Context()
+	p := &processor{config: s.config}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
+			return nil
+		} else if err != nil {
+			s.logger.Error("cannot receive stream request", slog.String("error", err.Error()))
+			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", err)
+		}
+
+		resp, err := s.processMsg(ctx, p, req)
+		if err != nil {
+			s.logger.Error("cannot process request", slog.String("error", err.Error()))
+			return status.Errorf(codes.Unknown, "cannot process request: %v", err)
+		}
+		if err := stream.Send(resp); err != nil {
+			s.logger.Error("cannot send response", slog.String("error", err.Error()))
+			return status.Errorf(codes.Unknown, "cannot send response: %v", err)
+		}
+	}
+}
+
+func (s *Server) processMsg(ctx context.Context, p *processor, req *extprocv3.ProcessingRequest) (*extprocv3.ProcessingResponse, error) {
+	switch value := req.Request.(type) {
+	case *extprocv3.ProcessingRequest_RequestHeaders:
+		requestHdrs := req.GetRequestHeaders().Headers
+		s.logger.Debug("request headers processing", slog.Any("request_headers", requestHdrs))
+		resp, err := p.processRequestHeaders(ctx, requestHdrs)
+		if err != nil {
+			return nil, fmt.Errorf("cannot process request headers: %w", err)
+		}
+		s.logger.Debug("request headers processed", slog.Any("response", resp))
+		return resp, nil
+	case *extprocv3.ProcessingRequest_RequestBody:
+		s.logger.Debug("request body processing", slog.Any("request", req))
+		resp, err := p.processRequestBody(ctx, value.RequestBody)
+		s.logger.Debug("request body processed", slog.Any("response", resp))
+		if err != nil {
+			return nil, fmt.Errorf("cannot process request body: %w", err)
+		}
+		return resp, nil
+	case *extprocv3.ProcessingRequest_ResponseHeaders:
+		responseHdrs := req.GetResponseHeaders().Headers
+		s.logger.Debug("response headers processing", slog.Any("response_headers", responseHdrs))
+		resp, err := p.processResponseHeaders(ctx, responseHdrs)
+		if err != nil {
+			return nil, fmt.Errorf("cannot process response headers: %w", err)
+		}
+		s.logger.Debug("response headers processed", slog.Any("response", resp))
+		return resp, nil
+	case *extprocv3.ProcessingRequest_ResponseBody:
+		s.logger.Debug("response body processing", slog.Any("request", req))
+		resp, err := p.processResponseBody(ctx, value.ResponseBody)
+		s.logger.Debug("response body processed", slog.Any("response", resp))
+		if err != nil {
+			return nil, fmt.Errorf("cannot process response body: %w", err)
+		}
+		return resp, nil
+	default:
+		s.logger.Error("unknown request type", slog.Any("request", value))
+		return nil, fmt.Errorf("unknown request type: %T", value)
+	}
+}
+
+// Check implements [grpc_health_v1.HealthServer].
+func (s *Server) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+// Watch implements [grpc_health_v1.HealthServer].
+func (s *Server) Watch(*grpc_health_v1.HealthCheckRequest, grpc_health_v1.Health_WatchServer) error {
+	return status.Error(codes.Unimplemented, "Watch is not implemented")
+}

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -30,8 +30,8 @@ func NewServer[P ProcessorIface](logger *slog.Logger, newProcessor func(*process
 	return srv, nil
 }
 
-// SetConfig  updates the configuration of the external processor.
-func (s *Server[P]) SetConfig(config *extprocconfig.Config) error {
+// LoadConfig updates the configuration of the external processor.
+func (s *Server[P]) LoadConfig(config *extprocconfig.Config) error {
 	bodyParser, err := router.NewRequestBodyParser(config.InputSchema)
 	if err != nil {
 		return fmt.Errorf("cannot create request body parser: %w", err)

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -18,18 +18,20 @@ import (
 )
 
 // Server implements the external process server.
-type Server struct {
-	logger *slog.Logger
-	config *processorConfig
+type Server[P ProcessorIface] struct {
+	logger       *slog.Logger
+	config       *processorConfig
+	newProcessor func(*processorConfig) P
 }
 
 // NewServer creates a new external processor server.
-func NewServer(logger *slog.Logger) (*Server, error) {
-	srv := &Server{logger: logger}
+func NewServer[P ProcessorIface](logger *slog.Logger, newProcessor func(*processorConfig) P) (*Server[P], error) {
+	srv := &Server[P]{logger: logger, newProcessor: newProcessor}
 	return srv, nil
 }
 
-func (s *Server) SetConfig(config *extprocconfig.Config) error {
+// SetConfig  updates the configuration of the external processor.
+func (s *Server[P]) SetConfig(config *extprocconfig.Config) error {
 	bodyParser, err := router.NewRequestBodyParser(config.InputSchema)
 	if err != nil {
 		return fmt.Errorf("cannot create request body parser: %w", err)
@@ -51,18 +53,24 @@ func (s *Server) SetConfig(config *extprocconfig.Config) error {
 		}
 	}
 
-	s.config = &processorConfig{
+	newConfig := &processorConfig{
 		bodyParser: bodyParser, router: rt,
 		backendRoutingHeaderKey: config.BackendRoutingHeaderKey,
+		ModelNameHeaderKey:      config.ModelNameHeaderKey,
 		factories:               factories,
 	}
+	s.config = newConfig // This is racey, but we don't care.
 	return nil
 }
 
 // Process implements [extprocv3.ExternalProcessorServer].
-func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error {
+func (s *Server[P]) Process(stream extprocv3.ExternalProcessor_ProcessServer) error {
+	p := s.newProcessor(s.config)
+	return s.process(p, stream)
+}
+
+func (s *Server[P]) process(p P, stream extprocv3.ExternalProcessor_ProcessServer) error {
 	ctx := stream.Context()
-	p := &processor{config: s.config}
 	for {
 		select {
 		case <-ctx.Done():
@@ -90,12 +98,12 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 	}
 }
 
-func (s *Server) processMsg(ctx context.Context, p *processor, req *extprocv3.ProcessingRequest) (*extprocv3.ProcessingResponse, error) {
+func (s *Server[P]) processMsg(ctx context.Context, p P, req *extprocv3.ProcessingRequest) (*extprocv3.ProcessingResponse, error) {
 	switch value := req.Request.(type) {
 	case *extprocv3.ProcessingRequest_RequestHeaders:
 		requestHdrs := req.GetRequestHeaders().Headers
 		s.logger.Debug("request headers processing", slog.Any("request_headers", requestHdrs))
-		resp, err := p.processRequestHeaders(ctx, requestHdrs)
+		resp, err := p.ProcessRequestHeaders(ctx, requestHdrs)
 		if err != nil {
 			return nil, fmt.Errorf("cannot process request headers: %w", err)
 		}
@@ -103,7 +111,7 @@ func (s *Server) processMsg(ctx context.Context, p *processor, req *extprocv3.Pr
 		return resp, nil
 	case *extprocv3.ProcessingRequest_RequestBody:
 		s.logger.Debug("request body processing", slog.Any("request", req))
-		resp, err := p.processRequestBody(ctx, value.RequestBody)
+		resp, err := p.ProcessRequestBody(ctx, value.RequestBody)
 		s.logger.Debug("request body processed", slog.Any("response", resp))
 		if err != nil {
 			return nil, fmt.Errorf("cannot process request body: %w", err)
@@ -112,7 +120,7 @@ func (s *Server) processMsg(ctx context.Context, p *processor, req *extprocv3.Pr
 	case *extprocv3.ProcessingRequest_ResponseHeaders:
 		responseHdrs := req.GetResponseHeaders().Headers
 		s.logger.Debug("response headers processing", slog.Any("response_headers", responseHdrs))
-		resp, err := p.processResponseHeaders(ctx, responseHdrs)
+		resp, err := p.ProcessResponseHeaders(ctx, responseHdrs)
 		if err != nil {
 			return nil, fmt.Errorf("cannot process response headers: %w", err)
 		}
@@ -120,7 +128,7 @@ func (s *Server) processMsg(ctx context.Context, p *processor, req *extprocv3.Pr
 		return resp, nil
 	case *extprocv3.ProcessingRequest_ResponseBody:
 		s.logger.Debug("response body processing", slog.Any("request", req))
-		resp, err := p.processResponseBody(ctx, value.ResponseBody)
+		resp, err := p.ProcessResponseBody(ctx, value.ResponseBody)
 		s.logger.Debug("response body processed", slog.Any("response", resp))
 		if err != nil {
 			return nil, fmt.Errorf("cannot process response body: %w", err)
@@ -133,11 +141,11 @@ func (s *Server) processMsg(ctx context.Context, p *processor, req *extprocv3.Pr
 }
 
 // Check implements [grpc_health_v1.HealthServer].
-func (s *Server) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+func (s *Server[P]) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 }
 
 // Watch implements [grpc_health_v1.HealthServer].
-func (s *Server) Watch(*grpc_health_v1.HealthCheckRequest, grpc_health_v1.Health_WatchServer) error {
+func (s *Server[P]) Watch(*grpc_health_v1.HealthCheckRequest, grpc_health_v1.Health_WatchServer) error {
 	return status.Error(codes.Unimplemented, "Watch is not implemented")
 }

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -25,10 +25,10 @@ func requireNewServerWithMockProcessor(t *testing.T) *Server[*mockProcessor] {
 	return s
 }
 
-func TestServer_SetConfig(t *testing.T) {
+func TestServer_LoadConfig(t *testing.T) {
 	t.Run("invalid input schema", func(t *testing.T) {
 		s := requireNewServerWithMockProcessor(t)
-		err := s.SetConfig(&extprocconfig.Config{
+		err := s.LoadConfig(&extprocconfig.Config{
 			InputSchema: extprocconfig.VersionedAPISchema{Schema: "some-invalid-schema"},
 		})
 		require.Error(t, err)
@@ -66,7 +66,7 @@ func TestServer_SetConfig(t *testing.T) {
 			},
 		}
 		s := requireNewServerWithMockProcessor(t)
-		err := s.SetConfig(config)
+		err := s.LoadConfig(config)
 		require.NoError(t, err)
 
 		require.NotNil(t, s.config)

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -1,0 +1,226 @@
+package extproc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+func requireNewServerWithMockProcessor(t *testing.T) *Server[*mockProcessor] {
+	s, err := NewServer[*mockProcessor](slog.Default(), newMockProcessor)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	return s
+}
+
+func TestServer_SetConfig(t *testing.T) {
+	t.Run("invalid input schema", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		err := s.SetConfig(&extprocconfig.Config{
+			InputSchema: extprocconfig.VersionedAPISchema{Schema: "some-invalid-schema"},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "cannot create request body parser")
+	})
+	t.Run("ok", func(t *testing.T) {
+		config := &extprocconfig.Config{
+			InputSchema:             extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+			BackendRoutingHeaderKey: "x-backend-name",
+			ModelNameHeaderKey:      "x-model-name",
+			Rules: []extprocconfig.RouteRule{
+				{
+					Backends: []extprocconfig.Backend{
+						{Name: "kserve", OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}},
+						{Name: "awsbedrock", OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock}},
+					},
+					Headers: []extprocconfig.HeaderMatch{
+						{
+							Name:  "x-model-name",
+							Value: "llama3.3333",
+						},
+					},
+				},
+				{
+					Backends: []extprocconfig.Backend{
+						{Name: "openai", OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}},
+					},
+					Headers: []extprocconfig.HeaderMatch{
+						{
+							Name:  "x-model-name",
+							Value: "gpt4.4444",
+						},
+					},
+				},
+			},
+		}
+		s := requireNewServerWithMockProcessor(t)
+		err := s.SetConfig(config)
+		require.NoError(t, err)
+
+		require.NotNil(t, s.config)
+		require.NotNil(t, s.config.router)
+		require.NotNil(t, s.config.bodyParser)
+		require.Equal(t, "x-backend-name", s.config.backendRoutingHeaderKey)
+		require.Equal(t, "x-model-name", s.config.ModelNameHeaderKey)
+		require.Len(t, s.config.factories, 2)
+		require.NotNil(t, s.config.factories[extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}])
+		require.NotNil(t, s.config.factories[extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock}])
+	})
+}
+
+func TestServer_Check(t *testing.T) {
+	s := requireNewServerWithMockProcessor(t)
+
+	res, err := s.Check(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, res.Status)
+}
+
+func TestServer_Watch(t *testing.T) {
+	s := requireNewServerWithMockProcessor(t)
+
+	err := s.Watch(nil, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Watch is not implemented")
+}
+
+func TestServer_processMsg(t *testing.T) {
+	t.Run("unknown request type", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		p := s.newProcessor(nil)
+		_, err := s.processMsg(context.Background(), p, &extprocv3.ProcessingRequest{})
+		require.ErrorContains(t, err, "unknown request type")
+	})
+	t.Run("request headers", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		p := s.newProcessor(nil)
+
+		hm := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}}}
+		expResponse := &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestHeaders{}}
+		p.t = t
+		p.expHeaderMap = hm
+		p.retProcessingResponse = expResponse
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{RequestHeaders: &extprocv3.HttpHeaders{Headers: hm}},
+		}
+		resp, err := s.processMsg(context.Background(), p, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, expResponse, resp)
+	})
+	t.Run("request body", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		p := s.newProcessor(nil)
+
+		reqBody := &extprocv3.HttpBody{}
+		expResponse := &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestBody{}}
+		p.t = t
+		p.expBody = reqBody
+		p.retProcessingResponse = expResponse
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestBody{RequestBody: reqBody},
+		}
+		resp, err := s.processMsg(context.Background(), p, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, expResponse, resp)
+	})
+	t.Run("response headers", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		p := s.newProcessor(nil)
+
+		hm := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}}}
+		expResponse := &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{}}
+		p.t = t
+		p.expHeaderMap = hm
+		p.retProcessingResponse = expResponse
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_ResponseHeaders{ResponseHeaders: &extprocv3.HttpHeaders{Headers: hm}},
+		}
+		resp, err := s.processMsg(context.Background(), p, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, expResponse, resp)
+	})
+	t.Run("response body", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		p := s.newProcessor(nil)
+
+		reqBody := &extprocv3.HttpBody{}
+		expResponse := &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseBody{}}
+		p.t = t
+		p.expBody = reqBody
+		p.retProcessingResponse = expResponse
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_ResponseBody{ResponseBody: reqBody},
+		}
+		resp, err := s.processMsg(context.Background(), p, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, expResponse, resp)
+	})
+}
+
+func TestServer_Process(t *testing.T) {
+	t.Run("context done", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ms := &mockExternalProcessingStream{t: t, ctx: ctx}
+		err := s.Process(ms)
+		require.ErrorContains(t, err, "context canceled")
+	})
+	t.Run("recv iof", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		ms := &mockExternalProcessingStream{t: t, retErr: io.EOF, ctx: context.Background()}
+		err := s.Process(ms)
+		require.NoError(t, err)
+	})
+	t.Run("recv canceled", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		ms := &mockExternalProcessingStream{t: t, retErr: status.Error(codes.Canceled, "someerror"), ctx: context.Background()}
+		err := s.Process(ms)
+		require.NoError(t, err)
+	})
+	t.Run("recv generic error", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+		ms := &mockExternalProcessingStream{t: t, retErr: errors.New("some error"), ctx: context.Background()}
+		err := s.Process(ms)
+		require.ErrorContains(t, err, "some error")
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		s := requireNewServerWithMockProcessor(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		p := s.newProcessor(nil)
+		hm := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}}}
+		expResponse := &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestHeaders{}}
+		p.t = t
+		p.expHeaderMap = hm
+		p.retProcessingResponse = expResponse
+
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{RequestHeaders: &extprocv3.HttpHeaders{Headers: hm}},
+		}
+		ms := &mockExternalProcessingStream{t: t, ctx: ctx, retRecv: req, expResponseOnSend: expResponse}
+		err := s.process(p, ms)
+		require.Error(t, err, "context canceled")
+	})
+}

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -4,18 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 )
 
 // newOpenAIToOpenAITranslator implements [TranslatorFactory] for OpenAI to OpenAI translation.
-func newOpenAIToOpenAITranslator(path string, l *slog.Logger) (Translator, error) {
+func newOpenAIToOpenAITranslator(path string) (Translator, error) {
 	if path == "/v1/chat/completions" {
-		return &openAIToOpenAITranslatorV1ChatCompletion{l: l}, nil
+		return &openAIToOpenAITranslatorV1ChatCompletion{}, nil
 	} else {
 		return nil, fmt.Errorf("unsupported path: %s", path)
 	}
@@ -24,21 +24,19 @@ func newOpenAIToOpenAITranslator(path string, l *slog.Logger) (Translator, error
 // openAIToOpenAITranslatorV1ChatCompletion implements [Translator] for /v1/chat/completions.
 type openAIToOpenAITranslatorV1ChatCompletion struct {
 	defaultTranslator
-	l             *slog.Logger
 	stream        bool
 	buffered      []byte
 	bufferingDone bool
 }
 
 // RequestBody implements [RequestBody].
-func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(body *extprocv3.HttpBody) (
-	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, override *extprocv3http.ProcessingMode, modelName string, err error,
+func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(body router.RequestBody) (
+	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, override *extprocv3http.ProcessingMode, err error,
 ) {
-	var req openai.ChatCompletionRequest
-	if err := json.Unmarshal(body.Body, &req); err != nil {
-		return nil, nil, nil, "", fmt.Errorf("failed to unmarshal body: %w", err)
+	req, ok := body.(*openai.ChatCompletionRequest)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("unexpected body type: %T", body)
 	}
-
 	if req.Stream {
 		o.stream = true
 		override = &extprocv3http.ProcessingMode{
@@ -46,7 +44,7 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(body *extprocv3.H
 			ResponseBodyMode:   extprocv3http.ProcessingMode_STREAMED,
 		}
 	}
-	return nil, nil, override, req.Model, nil
+	return nil, nil, override, nil
 }
 
 // ResponseBody implements [Translator.ResponseBody].
@@ -85,7 +83,6 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) extractUsageFromBufferEvent()
 		}
 		var event openai.ChatCompletionResponseChunk
 		if err := json.Unmarshal(bytes.TrimPrefix(line, dataPrefix), &event); err != nil {
-			o.l.Warn("failed to unmarshal the event", slog.Any("error", err))
 			continue
 		}
 		if usage := event.Usage; usage != nil {

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -2,29 +2,29 @@ package translator
 
 import (
 	"fmt"
-	"log/slog"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 )
 
 // Factory creates a [Translator] for the given API schema combination and request path.
 //
 //   - `path`: the path of the request.
 //   - `l`: the logger.
-type Factory func(path string, l *slog.Logger) (Translator, error)
+type Factory func(path string) (Translator, error)
 
 // NewFactory returns a callback function that creates a translator for the given API schema combination.
-func NewFactory(in, out aigv1a1.LLMAPISchema) (Factory, error) {
-	if in.Schema == aigv1a1.APISchemaOpenAI {
+func NewFactory(in, out extprocconfig.VersionedAPISchema) (Factory, error) {
+	if in.Schema == extprocconfig.APISchemaOpenAI {
 		// TODO: currently, we ignore the LLMAPISchema."Version" field.
 		switch out.Schema {
-		case aigv1a1.APISchemaOpenAI:
+		case extprocconfig.APISchemaOpenAI:
 			return newOpenAIToOpenAITranslator, nil
-		case aigv1a1.APISchemaAWSBedrock:
+		case extprocconfig.APISchemaAWSBedrock:
 			return newOpenAIToAWSBedrockTranslator, nil
 		}
 	}
@@ -38,24 +38,14 @@ func NewFactory(in, out aigv1a1.LLMAPISchema) (Factory, error) {
 //
 // This is created per request and is not thread-safe.
 type Translator interface {
-	// RequestHeaders translates the request headers.
-	//	- `headers` is the request headers.
-	//	- This returns `headerMutation` that can be nil to indicate no mutation.
-	RequestHeaders(headers map[string]string) (
-		headerMutation *extprocv3.HeaderMutation,
-		err error,
-	)
-
 	// RequestBody translates the request body.
-	// 	- `body` is the request body either chunk or the entire body, depending on the context.
+	// 	- `body` is the request body already parsed by [router.RequestBodyParser]. The concrete type is specific to the schema and the path.
 	//	- This returns `headerMutation` and `bodyMutation` that can be nil to indicate no mutation.
 	//  - This returns `override` that to change the processing mode. This is used to process streaming requests properly.
-	// 	- This returns `modelName` that is extracted from the body.
-	RequestBody(body *extprocv3.HttpBody) (
+	RequestBody(body router.RequestBody) (
 		headerMutation *extprocv3.HeaderMutation,
 		bodyMutation *extprocv3.BodyMutation,
 		override *extprocv3http.ProcessingMode,
-		modelName string,
 		err error,
 	)
 
@@ -81,11 +71,6 @@ type Translator interface {
 
 // defaultTranslator is a no-op translator that implements [Translator].
 type defaultTranslator struct{}
-
-// RequestHeaders implements [Translator.RequestHeaders].
-func (d *defaultTranslator) RequestHeaders(map[string]string) (*extprocv3.HeaderMutation, error) {
-	return nil, nil
-}
 
 // RequestBody implements [Translator.RequestBody].
 func (d *defaultTranslator) RequestBody(*extprocv3.HttpBody) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, *extprocv3http.ProcessingMode, string, error) {

--- a/internal/extproc/translator/translator_test.go
+++ b/internal/extproc/translator/translator_test.go
@@ -1,36 +1,44 @@
 package translator
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
 )
 
 func TestNewFactory(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
-		_, err := NewFactory(aigv1a1.LLMAPISchema{Schema: "Foo", Version: "v100"}, aigv1a1.LLMAPISchema{Schema: "Bar", Version: "v123"})
+		_, err := NewFactory(
+			extprocconfig.VersionedAPISchema{Schema: "Foo", Version: "v100"},
+			extprocconfig.VersionedAPISchema{Schema: "Bar", Version: "v123"},
+		)
 		require.ErrorContains(t, err, "unsupported API schema combination: client={Foo v100}, backend={Bar v123}")
 	})
 	t.Run("openai to openai", func(t *testing.T) {
-		f, err := NewFactory(aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI}, aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI})
+		f, err := NewFactory(
+			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+		)
 		require.NoError(t, err)
 		require.NotNil(t, f)
 
-		tl, err := f("/v1/chat/completions", slog.Default())
+		tl, err := f("/v1/chat/completions")
 		require.NoError(t, err)
 		require.NotNil(t, tl)
 		_, ok := tl.(*openAIToOpenAITranslatorV1ChatCompletion)
 		require.True(t, ok)
 	})
 	t.Run("openai to aws bedrock", func(t *testing.T) {
-		f, err := NewFactory(aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI}, aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaAWSBedrock})
+		f, err := NewFactory(
+			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock},
+		)
 		require.NoError(t, err)
 		require.NotNil(t, f)
 
-		tl, err := f("/v1/chat/completions", slog.Default())
+		tl, err := f("/v1/chat/completions")
 		require.NoError(t, err)
 		require.NotNil(t, tl)
 		_, ok := tl.(*openAIToAWSBedrockTranslatorV1ChatCompletion)

--- a/internal/extproc/watcher.go
+++ b/internal/extproc/watcher.go
@@ -1,0 +1,74 @@
+package extproc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+// ConfigReceiver is an interface that can receive *extprocconfig.Config updates.
+type ConfigReceiver interface {
+	// LoadConfig updates the configuration.
+	LoadConfig(config *extprocconfig.Config) error
+}
+
+type configWatcher struct {
+	lastMod time.Time
+	path    string
+	rcv     ConfigReceiver
+	l       *slog.Logger
+}
+
+// StartConfigWatcher starts a watcher for the given path and Receiver.
+// Periodically checks the file for changes and calls the Receiver's UpdateConfig method.
+func StartConfigWatcher(ctx context.Context, path string, rcv ConfigReceiver, l *slog.Logger, tick time.Duration) error {
+	cw := &configWatcher{rcv: rcv, l: l, path: path}
+
+	if err := cw.loadConfig(); err != nil {
+		return fmt.Errorf("failed to load initial config: %w", err)
+	}
+
+	l.Info("start watching the config file", slog.String("path", path), slog.String("interval", tick.String()))
+	go cw.watch(ctx, tick)
+	return nil
+}
+
+// watch periodically checks the file for changes and calls the update method.
+func (cw *configWatcher) watch(ctx context.Context, tick time.Duration) {
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			cw.l.Info("stop watching the config file", slog.String("path", cw.path))
+			return
+		case <-ticker.C:
+			if err := cw.loadConfig(); err != nil {
+				cw.l.Error("failed to update config", slog.String("error", err.Error()))
+			}
+		}
+	}
+}
+
+// loadConfig loads a new config from the given path and updates the Receiver by
+// calling the [Receiver.Load].
+func (cw *configWatcher) loadConfig() error {
+	stat, err := os.Stat(cw.path)
+	if err != nil {
+		return err
+	}
+	if stat.ModTime().Sub(cw.lastMod) <= 0 {
+		return nil
+	}
+	cw.lastMod = stat.ModTime()
+	cw.l.Info("loading a new config", slog.String("path", cw.path))
+	cfg, err := extprocconfig.UnmarshalConfigYaml(cw.path)
+	if err != nil {
+		return err
+	}
+	return cw.rcv.LoadConfig(cfg)
+}

--- a/internal/extproc/watcher_test.go
+++ b/internal/extproc/watcher_test.go
@@ -1,0 +1,106 @@
+package extproc
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+// mockReceiver is a mock implementation of Receiver.
+type mockReceiver struct {
+	cfg *extprocconfig.Config
+	mux sync.Mutex
+}
+
+// LoadConfig implements ConfigReceiver.
+func (m *mockReceiver) LoadConfig(cfg *extprocconfig.Config) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	m.cfg = cfg
+	return nil
+}
+
+func (m *mockReceiver) getConfig() *extprocconfig.Config {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	return m.cfg
+}
+
+func TestStartConfigWatcher(t *testing.T) {
+	tmpdir := t.TempDir()
+	path := tmpdir + "/config.yaml"
+	rcv := &mockReceiver{}
+
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o600))
+
+	// Create the initial config file.
+	cfg := `
+inputSchema:
+  schema: OpenAI
+backendRoutingHeaderKey: x-backend-name
+modelNameHeaderKey: x-model-name
+rules:
+- backends:
+  - name: kserve
+    weight: 1
+    outputSchema:
+      schema: OpenAI
+  - name: awsbedrock
+    weight: 10
+    outputSchema:
+      schema: AWSBedrock
+  headers:
+  - name: x-model-name
+    value: llama3.3333
+- backends:
+  - name: openai
+    outputSchema:
+      schema: OpenAI
+  headers:
+  - name: x-model-name
+    value: gpt4.4444
+`
+	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := StartConfigWatcher(ctx, path, rcv, slog.Default(), time.Millisecond*100)
+	require.NoError(t, err)
+
+	// Initial loading should have happened.
+	require.Eventually(t, func() bool {
+		return rcv.getConfig() != nil
+	}, 1*time.Second, 100*time.Millisecond)
+	firstCfg := rcv.getConfig()
+	require.NotNil(t, firstCfg)
+
+	// Update the config file.
+	cfg = `
+inputSchema:
+  schema: OpenAI
+backendRoutingHeaderKey: x-backend-name
+modelNameHeaderKey: x-model-name
+rules:
+- backends:
+  - name: openai
+    outputSchema:
+      schema: OpenAI
+  headers:
+  - name: x-model-name
+    value: gpt4.4444
+`
+
+	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+
+	// Log should contain the updated loading.
+	require.Eventually(t, func() bool {
+		return rcv.getConfig() != firstCfg
+	}, 1*time.Second, 100*time.Millisecond)
+	require.NotEqual(t, firstCfg, rcv.getConfig())
+}


### PR DESCRIPTION
This scaffolds and implements the initial logic based on the 
current API. Notably, I intentionally organized the extproc code 
in a way that it is decoupled from EG concepts as well as the 
AI Gateway API level constructs. The rationale is that it not only
allows us to test the extproc without relying on not only EG/AIG
and even without kubernetes at all, but also some users are asking
for the use of outside the ai-gateway projects.

As for the implementation, there's nothing special going on, and 
it is simply mostly migrated from the MVP with the decoupling in mind.


I will follow up with the end-to-end test in subsequent PRs.