### PR TITLE
Scaffolds the initial extproc e2e test 

### DIFF
--- a/.github/workflows/safe_to_test.yaml
+++ b/.github/workflows/safe_to_test.yaml
@@ -1,0 +1,31 @@
+name: Tests using Secrets
+
+on:
+  push:
+    branches:
+      - main
+  # TODO: allows the PR to run this test when a specific label like "safe-to-test" is added by a maintainer.
+
+jobs:
+  extproc_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - name: Run unit tests
+        env:
+          # These credentials and info are managed by Terraform in test/e2e/terraform directory.
+          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
+          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
+          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
+        run: make test-extproc-e2e

--- a/.github/workflows/tests_using_secrets.yaml
+++ b/.github/workflows/tests_using_secrets.yaml
@@ -1,5 +1,7 @@
 name: Tests using Secrets
-
+# This workflow is triggered on pushes to the main branch and pull requests to the main branch.
+# If the PR is coming from a fork, the workflow is triggered only if the PR is labeled with 'safe to test',
+# which can only be added by the maintainers.
 on:
   push:
     branches:
@@ -14,7 +16,7 @@ on:
 
 jobs:
   extproc_tests:
-    name: External Processor Tests
+    name: External Processor
     if: ( github.event.pull_request.head.repo.fork == false ) ||
       ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     runs-on: ubuntu-latest

--- a/.github/workflows/tests_using_secrets.yaml
+++ b/.github/workflows/tests_using_secrets.yaml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Install Envoy
         env:
+          # TODO: use the latest envoy after 1.33 is released.
           ENVOY_VERSION: envoyproxy/envoy-dev:latest
         run: |
           export ENVOY_BIN_DIR=$HOME/envoy/bin

--- a/.github/workflows/tests_using_secrets.yaml
+++ b/.github/workflows/tests_using_secrets.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   extproc_tests:
+    name: External Processor Tests
     if: ( github.event.pull_request.head.repo.fork == false ) ||
       ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     runs-on: ubuntu-latest
@@ -45,6 +46,16 @@ jobs:
             ~/go/pkg/mod
             ~/go/bin
           key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+
+      - name: Install Envoy
+        env:
+          ENVOY_VERSION: envoyproxy/envoy-dev:latest
+        run: |
+          export ENVOY_BIN_DIR=$HOME/envoy/bin
+          mkdir -p $ENVOY_BIN_DIR
+          docker run -v $ENVOY_BIN_DIR:/tmp/coraza -w /tmp/coraza \
+          --entrypoint /bin/cp ${ENVOY_VERSION} /usr/local/bin/envoy .
+          echo $ENVOY_BIN_DIR >> $GITHUB_PATH
 
       - name: Run unit tests
         env:

--- a/.github/workflows/tests_using_secrets.yaml
+++ b/.github/workflows/tests_using_secrets.yaml
@@ -4,17 +4,40 @@ on:
   push:
     branches:
       - main
-  # TODO: allows the PR to run this test when a specific label like "safe-to-test" is added by a maintainer.
+  pull_request:
+    branches:
+      - main
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - main
 
 jobs:
   extproc_tests:
+    if: ( github.event.pull_request.head.repo.fork == false ) ||
+      ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     runs-on: ubuntu-latest
     steps:
+      # The original repo.
       - uses: actions/checkout@v4
+        if: >-
+          ( github.event_name == 'pull_request' ) &&
+          ( github.event.pull_request.head.repo.fork == false )
+
+      # Forked repo.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+        if: >-
+          ( github.event_name == 'pull_request_target' ) &&
+          ( github.event.pull_request.head.repo.fork == true )
+
       - uses: actions/setup-go@v5
         with:
           cache: false
           go-version-file: go.mod
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -22,9 +45,9 @@ jobs:
             ~/go/pkg/mod
             ~/go/bin
           key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+
       - name: Run unit tests
         env:
-          # These credentials and info are managed by Terraform in test/e2e/terraform directory.
           TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
           TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
           TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ check: editorconfig-checker
 .PHONY: test
 test:
 	@echo "test => ./..."
-	@go test -v $(shell go list ./... | grep -v e2e)
+	@go test -v ./...
 
 
 # This runs the integration tests of CEL validation rules in API definitions.
@@ -84,6 +84,12 @@ test-cel: envtest apigen format
         KUBEBUILDER_ASSETS="$$($(ENVTEST) use $$k8sVersion -p path)" \
                  go test ./tests/cel-validation --tags celvalidation -count=1; \
     done
+# This runs the end-to-end tests for extproc without controller or k8s at all.
+# It is useful for the fast iteration of the extproc code.
+.PHONY: test-extproc-e2e # This requires the extproc binary to be built.
+test-extproc-e2e: build.extproc
+	@echo "test ./tests/extproc/..."
+	@go test ./tests/extproc/... -tags extproc_e2e -v -count=1
 
 # This builds a binary for the given command under the internal/cmd directory.
 #

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/envoyproxy/gateway v1.2.4
 	github.com/envoyproxy/go-control-plane/envoy v1.32.2
+	github.com/openai/openai-go v0.1.0-alpha.41
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	google.golang.org/grpc v1.69.2
 	k8s.io/apimachinery v0.32.0
 	sigs.k8s.io/controller-runtime v0.19.3
 	sigs.k8s.io/gateway-api v1.2.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -54,6 +56,10 @@ require (
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
@@ -76,5 +82,4 @@ require (
 	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.3 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/openai/openai-go v0.1.0-alpha.41 h1:OPRT5YfNKlENfipMtolMWnKbCR1iQDc9hCRsUkhMaK8=
+github.com/openai/openai-go v0.1.0-alpha.41/go.mod h1:3SdE6BffOX9HPEQv8IL/fi3LYZ5TUpRYaqGQZbyk11A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
@@ -111,6 +113,16 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -29,7 +29,7 @@ type ChatCompletionRequest struct {
 type ChatCompletionRequestMessage struct {
 	// Role is the role of the message. The role of the message (whether it represents the user or the AI).
 	Role string `json:"role,omitempty"`
-	// Content is the content of the message. Mainly this is a string, but it can be more complex.
+	// Content is the content of the message.
 	Content any `json:"content,omitempty"`
 }
 

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -2,6 +2,7 @@ package extproc
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -83,8 +84,12 @@ func (m mockTranslator) ResponseHeaders(headers map[string]string) (headerMutati
 }
 
 // ResponseBody implements [translator.Translator.ResponseBody].
-func (m mockTranslator) ResponseBody(body *extprocv3.HttpBody) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, usedToken uint32, err error) {
-	require.Equal(m.t, m.expResponseBody, body)
+func (m mockTranslator) ResponseBody(body io.Reader, _ bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, usedToken uint32, err error) {
+	if m.expResponseBody != nil {
+		buf, err := io.ReadAll(body)
+		require.NoError(m.t, err)
+		require.Equal(m.t, m.expResponseBody.Body, buf)
+	}
 	return m.retHeaderMutation, m.retBodyMutation, usedToken, m.retErr
 }
 

--- a/internal/extproc/processor_test.go
+++ b/internal/extproc/processor_test.go
@@ -52,11 +52,11 @@ func TestProcessor_ProcessResponseBody(t *testing.T) {
 		mt := &mockTranslator{t: t}
 		p := &Processor{translator: mt}
 		mt.retErr = errors.New("test error")
-		_, err := p.ProcessResponseBody(context.Background(), nil)
+		_, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{})
 		require.ErrorContains(t, err, "test error")
 	})
 	t.Run("ok", func(t *testing.T) {
-		inBody := &extprocv3.HttpBody{}
+		inBody := &extprocv3.HttpBody{Body: []byte("some-body")}
 		expBodyMut := &extprocv3.BodyMutation{}
 		expHeadMut := &extprocv3.HeaderMutation{}
 		mt := &mockTranslator{t: t, expResponseBody: inBody, retBodyMutation: expBodyMut, retHeaderMutation: expHeadMut}

--- a/internal/extproc/router/request_body.go
+++ b/internal/extproc/router/request_body.go
@@ -31,7 +31,7 @@ func openAIParseBody(path string, body *extprocv3.HttpBody) (modelName string, r
 		if err := json.Unmarshal(body.Body, &openAIReq); err != nil {
 			return "", nil, fmt.Errorf("failed to unmarshal body: %w", err)
 		}
-		return openAIReq.Model, openAIReq, nil
+		return openAIReq.Model, &openAIReq, nil
 	} else {
 		return "", nil, fmt.Errorf("unsupported path: %s", path)
 	}

--- a/internal/extproc/translator/openai_openai_test.go
+++ b/internal/extproc/translator/openai_openai_test.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -96,7 +97,7 @@ data: [DONE]
 		o := &openAIToOpenAITranslatorV1ChatCompletion{stream: true}
 		var usedToken uint32
 		for i := 0; i < len(wholeBody); i++ {
-			hm, bm, _usedToken, err := o.ResponseBody(&extprocv3.HttpBody{Body: wholeBody[i : i+1]})
+			hm, bm, _usedToken, err := o.ResponseBody(bytes.NewReader(wholeBody[i:i+1]), false)
 			require.NoError(t, err)
 			require.Nil(t, hm)
 			require.Nil(t, bm)
@@ -114,7 +115,7 @@ data: [DONE]
 	t.Run("non-streaming", func(t *testing.T) {
 		t.Run("invalid body", func(t *testing.T) {
 			o := &openAIToOpenAITranslatorV1ChatCompletion{}
-			_, _, _, err := o.ResponseBody(&extprocv3.HttpBody{Body: []byte("invalid")})
+			_, _, _, err := o.ResponseBody(bytes.NewBuffer([]byte("invalid")), false)
 			require.Error(t, err)
 		})
 		t.Run("valid body", func(t *testing.T) {
@@ -123,7 +124,7 @@ data: [DONE]
 			body, err := json.Marshal(resp)
 			require.NoError(t, err)
 			o := &openAIToOpenAITranslatorV1ChatCompletion{}
-			_, _, usedToken, err := o.ResponseBody(&extprocv3.HttpBody{Body: body})
+			_, _, usedToken, err := o.ResponseBody(bytes.NewBuffer(body), false)
 			require.NoError(t, err)
 			require.Equal(t, uint32(42), usedToken)
 		})

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"fmt"
+	"io"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
@@ -61,7 +62,7 @@ type Translator interface {
 	// 	- `body` is the response body either chunk or the entire body, depending on the context.
 	//	- This returns `headerMutation` and `bodyMutation` that can be nil to indicate no mutation.
 	//  - This returns `usedToken` that is extracted from the body and will be used to do token rate limiting.
-	ResponseBody(body *extprocv3.HttpBody) (
+	ResponseBody(body io.Reader, endOfStream bool) (
 		headerMutation *extprocv3.HeaderMutation,
 		bodyMutation *extprocv3.BodyMutation,
 		usedToken uint32,
@@ -83,7 +84,7 @@ func (d *defaultTranslator) ResponseHeaders(map[string]string) (*extprocv3.Heade
 }
 
 // ResponseBody implements [Translator.ResponseBody].
-func (d *defaultTranslator) ResponseBody(*extprocv3.HttpBody) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, uint32, error) {
+func (d *defaultTranslator) ResponseBody(io.Reader, bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, uint32, error) {
 	return nil, nil, 0, nil
 }
 

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -1,0 +1,110 @@
+static_resources:
+  listeners:
+    - address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 1062
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  virtual_hosts:
+                    - name: local_route
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-selected-backend-name
+                                string_match:
+                                  exact: aws-bedrock
+                          route:
+                            cluster: aws_bedrock
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-selected-backend-name
+                                string_match:
+                                  exact: openai
+                          route:
+                            host_rewrite_literal: api.openai.com
+                            cluster: openai
+                          request_headers_to_add:
+                            - header:
+                                key: 'Authorization'
+                                value: 'Bearer TEST_OPENAI_API_KEY'
+                http_filters:
+                  - name: envoy.filters.http.ext_proc
+                    typed_config:
+                      # https://github.com/envoyproxy/envoy/pull/27263/files
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                      allow_mode_override: true
+                      mutation_rules:
+                        allow_all_routing: true
+                      processing_mode:
+                        request_header_mode: "SEND"
+                        response_header_mode: "SEND"
+                        request_body_mode: "BUFFERED"
+                        response_body_mode: "BUFFERED"
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: extproc_cluster
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      suppressEnvoyHeaders: true
+
+  clusters:
+    - name: extproc_cluster
+      connect_timeout: 0.25s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: extproc_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 1063
+    - name: aws_bedrock
+      connect_timeout: 30s
+      type: STRICT_DNS
+      load_assignment:
+        cluster_name: aws_bedrock
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: bedrock-runtime.us-east-1.amazonaws.com
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: bedrock-runtime.us-east-1.amazonaws.com
+    - name: openai
+      connect_timeout: 30s
+      type: STRICT_DNS
+      load_assignment:
+        cluster_name: openai
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: api.openai.com
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: api.openai.com

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -1,0 +1,164 @@
+//go:build extproc_e2e
+
+package extproc
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+//go:embed envoy.yaml
+var envoyYamlBase string
+
+var (
+	openAISchema     = extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}
+	awsBedrockSchema = extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock}
+)
+
+// TestE2E tests the end-to-end flow of the external processor with Envoy.
+//
+// This requires the following environment variables to be set:
+//   - TEST_AWS_ACCESS_KEY_ID
+//   - TEST_AWS_SECRET_ACCESS_KEY
+//   - TEST_OPENAI_API_KEY
+//
+// The test will be skipped if any of these are not set.
+func TestE2E(t *testing.T) {
+	requireBinaries(t)
+	requireRunEnvoy(t)
+	configPath := t.TempDir() + "/extproc-config.yaml"
+	requireWriteExtProcConfig(t, configPath, &extprocconfig.Config{
+		InputSchema: openAISchema,
+		// This can be any header key, but it must match the envoy.yaml routing configuration.
+		BackendRoutingHeaderKey: "x-selected-backend-name",
+		ModelNameHeaderKey:      "x-model-name",
+		Rules: []extprocconfig.RouteRule{
+			{
+				Backends: []extprocconfig.Backend{{Name: "openai", OutputSchema: openAISchema}},
+				Headers:  []extprocconfig.HeaderMatch{{Name: "x-model-name", Value: "gpt-4o-mini"}},
+			},
+			{
+				Backends: []extprocconfig.Backend{{Name: "aws-bedrock", OutputSchema: awsBedrockSchema}},
+				Headers:  []extprocconfig.HeaderMatch{{Name: "x-model-name", Value: "us.meta.llama3-2-1b-instruct-v1:0"}},
+			},
+		},
+	})
+	requireExtProc(t, configPath)
+
+	client := openai.NewClient(option.WithBaseURL("http://localhost:1062/v1/"))
+	for _, modelName := range []string{
+		"gpt-4o-mini", // This will go to "openai"
+		// TODO: enable after we migrate to sign requests in extproc.
+		//"us.meta.llama3-2-1b-instruct-v1:0", // This will go to "aws-bedrock".
+	} {
+		t.Run(modelName, func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				chatCompletion, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+					Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage("Say this is a test"),
+					}),
+					Model: openai.F(modelName),
+				})
+				if err != nil {
+					t.Logf("error: %v", err)
+					return false
+				}
+				for _, choice := range chatCompletion.Choices {
+					t.Logf("choice: %s", choice.Message.Content)
+				}
+				return true
+			}, 10*time.Second, 1*time.Second)
+		})
+	}
+}
+
+// requireExtProc starts the external processor with the provided configPath.
+// The config must be in YAML format specified in [extprocconfig.Config] type.
+func requireExtProc(t *testing.T, configPath string) {
+	cmd := exec.Command(extProcBinaryPath()) // #nosec G204
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Args = append(cmd.Args, "-configPath", configPath)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Signal(os.Interrupt) })
+}
+
+// requireRunEnvoy starts the Envoy proxy with the provided configuration.
+func requireRunEnvoy(t *testing.T) {
+	awsAccessKeyID := requireEnvVar(t, "TEST_AWS_ACCESS_KEY_ID")
+	awsSecretAccessKey := requireEnvVar(t, "TEST_AWS_SECRET_ACCESS_KEY")
+	openAIAPIKey := requireEnvVar(t, "TEST_OPENAI_API_KEY")
+
+	tmpDir := t.TempDir()
+	envoyYaml := strings.Replace(envoyYamlBase, "TEST_OPENAI_API_KEY", openAIAPIKey, 1)
+
+	// Write the envoy.yaml file.
+	envoyYamlPath := tmpDir + "/envoy.yaml"
+	require.NoError(t, os.WriteFile(envoyYamlPath, []byte(envoyYaml), 0o600))
+
+	// Starts the Envoy proxy.
+	envoyCmd := exec.Command("envoy",
+		"-c", envoyYamlPath,
+		"--component-log-level", "aws:debug,router:trace,ext_proc:trace",
+		"--concurrency", strconv.Itoa(max(runtime.NumCPU(), 2)),
+	)
+	envoyCmd.Stdout = os.Stdout
+	envoyCmd.Stderr = os.Stderr
+	envoyCmd.Env = append(os.Environ(),
+		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", awsAccessKeyID),
+		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", awsSecretAccessKey),
+	)
+	require.NoError(t, envoyCmd.Start())
+	t.Cleanup(func() { _ = envoyCmd.Process.Signal(os.Interrupt) })
+}
+
+// requireBinaries requires Envoy to be present in the PATH as well as the Extproc binary in the out directory,
+// otherwise skips the test.
+func requireBinaries(t *testing.T) {
+	_, err := exec.LookPath("envoy")
+	if err != nil {
+		// Skip the test if the binary is not found
+		t.Skipf("Envoy not found in PATH")
+	}
+
+	// Check if the Extproc binary is present in the root of the repository
+	_, err = os.Stat(extProcBinaryPath())
+	if err != nil {
+		t.Skipf("%s binary not found in the root of the repository", extProcBinaryPath())
+	}
+}
+
+// requireEnvVar requires an environment variable to be set, otherwise skips the test.
+func requireEnvVar(t *testing.T, envVar string) string {
+	value := os.Getenv(envVar)
+	if value == "" {
+		t.Skipf("Environment variable %s is not set", envVar)
+	}
+	return value
+}
+
+// requireWriteExtProcConfig writes the provided config to the configPath in YAML format.
+func requireWriteExtProcConfig(t *testing.T, configPath string, config *extprocconfig.Config) {
+	configBytes, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, configBytes, 0o600))
+}
+
+func extProcBinaryPath() string {
+	return fmt.Sprintf("../../out/extproc-%s-%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -114,7 +114,7 @@ func requireRunEnvoy(t *testing.T) {
 	// Starts the Envoy proxy.
 	envoyCmd := exec.Command("envoy",
 		"-c", envoyYamlPath,
-		"--component-log-level", "aws:debug,router:trace,ext_proc:trace",
+		"--log-level", "warn",
 		"--concurrency", strconv.Itoa(max(runtime.NumCPU(), 2)),
 	)
 	envoyCmd.Stdout = os.Stdout

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -141,11 +141,11 @@ func requireBinaries(t *testing.T) {
 	}
 }
 
-// requireEnvVar requires an environment variable to be set, otherwise skips the test.
+// requireEnvVar requires an environment variable to be set.
 func requireEnvVar(t *testing.T, envVar string) string {
 	value := os.Getenv(envVar)
 	if value == "" {
-		t.Skipf("Environment variable %s is not set", envVar)
+		t.Fatalf("Environment variable %s is not set", envVar)
 	}
 	return value
 }

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -127,19 +127,17 @@ func requireRunEnvoy(t *testing.T) {
 	t.Cleanup(func() { _ = envoyCmd.Process.Signal(os.Interrupt) })
 }
 
-// requireBinaries requires Envoy to be present in the PATH as well as the Extproc binary in the out directory,
-// otherwise skips the test.
+// requireBinaries requires Envoy to be present in the PATH as well as the Extproc binary in the out directory.
 func requireBinaries(t *testing.T) {
 	_, err := exec.LookPath("envoy")
 	if err != nil {
-		// Skip the test if the binary is not found
-		t.Skipf("Envoy not found in PATH")
+		t.Fatalf("envoy binary not found in PATH")
 	}
 
 	// Check if the Extproc binary is present in the root of the repository
 	_, err = os.Stat(extProcBinaryPath())
 	if err != nil {
-		t.Skipf("%s binary not found in the root of the repository", extProcBinaryPath())
+		t.Fatalf("%s binary not found in the root of the repository", extProcBinaryPath())
 	}
 }
 


### PR DESCRIPTION
This scaffolds the initial extproc e2e tests using the secrets.
The GHA workflow is defined in a separate file so that we can run
the tests for PRs coming from fork repos as well under the condition that
a maintainer verifies the code and adds the label "safe-to-test".

The actual test for AWS bedrock is commented out now as we will do the
request signing inside the extproc. 