### PR TITLE
api: adds missing CEL validation on LLMRouteRuleMatch

### DIFF
--- a/api/v1alpha1/api.go
+++ b/api/v1alpha1/api.go
@@ -112,6 +112,7 @@ type LLMRouteRuleMatch struct {
 	// +listMapKey=name
 	// +optional
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:XValidation:rule="self.all(match, match.type != 'RegularExpression')", message="currently only exact match is supported"
 	Headers []gwapiv1.HTTPHeaderMatch `json:"headers,omitempty"`
 }
 

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_llmroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_llmroutes.yaml
@@ -188,6 +188,9 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
+                            x-kubernetes-validations:
+                            - message: currently only exact match is supported
+                              rule: self.all(match, match.type != 'RegularExpression')
                         type: object
                       maxItems: 128
                       type: array

--- a/tests/cel-validation/main_test.go
+++ b/tests/cel-validation/main_test.go
@@ -83,6 +83,10 @@ func TestLLMRoutes(t *testing.T) {
 			name:   "unknown_schema.yaml",
 			expErr: "spec.inputSchema.schema: Unsupported value: \"SomeRandomVendor\": supported values: \"OpenAI\", \"AWSBedrock\"",
 		},
+		{
+			name:   "unsupported_match.yaml",
+			expErr: "spec.rules[0].matches[0].headers: Invalid value: \"array\": currently only exact match is supported",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			data, err := tests.ReadFile(path.Join("testdata/llmroutes", tc.name))

--- a/tests/cel-validation/testdata/llmroutes/unsupported_match.yaml
+++ b/tests/cel-validation/testdata/llmroutes/unsupported_match.yaml
@@ -1,0 +1,19 @@
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: LLMRoute
+metadata:
+  name: apple
+  namespace: default
+spec:
+  inputSchema:
+    schema: OpenAI
+  rules:
+    - matches:
+      - headers:
+        - type: RegularExpression
+          name: x-envoy-ai-gateway-llm-model
+          value: llama3-70b
+      backendRefs:
+        - name: kserve
+          weight: 20
+        - name: aws-bedrock
+          weight: 80


### PR DESCRIPTION
This was a missing CEL validation in #47.
In the near future, we will support the regular
expression, but for now simply reject the 
configuration as documented in the comment.