### PR TITLE
Adds initial controller implementation 

### DIFF
--- a/api/v1alpha1/api.go
+++ b/api/v1alpha1/api.go
@@ -59,7 +59,7 @@ type LLMRouteSpec struct {
 	// AI Gateway controller will generate a HTTPRoute based on the configuration given here with the additional
 	// modifications to achieve the necessary jobs, notably inserting the AI Gateway external processor filter.
 	//
-	// In the matching conditions in the LLMRouteRule, `x-envoy-ai-gateway-llm-model` header is available
+	// In the matching conditions in the LLMRouteRule, `x-envoy-ai-gateway-model` header is available
 	// if we want to describe the routing behavior based on the model name. The model name is extracted
 	// from the request content before the routing decision.
 	//
@@ -203,5 +203,5 @@ const (
 const (
 	// LLMModelHeaderKey is the header key whose value is extracted from the request by the ai-gateway.
 	// This can be used to describe the routing behavior in HTTPRoute referenced by LLMRoute.
-	LLMModelHeaderKey = "x-envoy-ai-gateway-llm-model"
+	LLMModelHeaderKey = "x-envoy-ai-gateway-model"
 )

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -1,7 +1,54 @@
 package main
 
-import "github.com/envoyproxy/ai-gateway/internal/version"
+import (
+	"context"
+	"flag"
+	"log"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/envoyproxy/ai-gateway/internal/controller"
+)
+
+var (
+	logLevel     = flag.String("logLevel", "info", "log level")
+	extProcImage = flag.String("extprocImage",
+		"ghcr.io/envoyproxy/ai-gateway-extproc:latest", "image for the external processor")
+)
 
 func main() {
-	println(version.Version)
+	flag.Parse()
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(*logLevel)); err != nil {
+		log.Fatalf("failed to unmarshal log level: %v", err)
+	}
+	l := logr.FromSlogHandler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	}))
+	klog.SetLogger(l)
+
+	k8sConfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Fatalf("failed to get k8s config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	signalsChan := make(chan os.Signal, 1)
+	signal.Notify(signalsChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-signalsChan
+		cancel()
+	}()
+
+	// TODO: starts the extension server?
+
+	if err := controller.StartControllers(ctx, k8sConfig, l, *logLevel, *extProcImage); err != nil {
+		log.Fatalf("failed to start controller: %v", err)
+	}
 }

--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -14,6 +14,15 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+// DefaultConfig is the default configuration for the external processor
+// that can be used as a fallback when the configuration is not explicitly provided.
+const DefaultConfig = `
+inputSchema:
+  schema: OpenAI
+selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
+modelNameHeaderKey: x-envoy-ai-gateway-llm-model
+`
+
 // Config is the configuration for the external processor.
 //
 // The configuration is loaded from a file path specified via the command line flag -configPath to the external processor.
@@ -22,8 +31,8 @@ import (
 //
 //	inputSchema:
 //	  schema: OpenAI
-//	backendRoutingHeaderKey: x-backend-name
-//	modelNameHeaderKey: x-model-name
+//	selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
+//	modelNameHeaderKey: x-envoy-ai-gateway-llm-model
 //	tokenUsageMetadata:
 //	  namespace: ai_gateway_llm_ns
 //	  key: token_usage_key
@@ -38,24 +47,24 @@ import (
 //	    outputSchema:
 //	      schema: AWSBedrock
 //	  headers:
-//	  - name: x-model-name
+//	  - name: x-envoy-ai-gateway-llm-model
 //	    value: llama3.3333
 //	- backends:
 //	  - name: openai
 //	    outputSchema:
 //	      schema: OpenAI
 //	  headers:
-//	  - name: x-model-name
+//	  - name: x-envoy-ai-gateway-llm-model
 //	    value: gpt4.4444
 //
-// where the input of the external processor is in the OpenAI schema, the model name is populated in the header x-model-name,
-// The model name header `x-model-name` is used in the header matching to make the routing decision. **After** the routing decision is made,
-// the selected backend name is populated in the header `x-backend-name`. For example, when the model name is `llama3.3333`,
+// where the input of the external processor is in the OpenAI schema, the model name is populated in the header x-envoy-ai-gateway-llm-model,
+// The model name header `x-envoy-ai-gateway-llm-model` is used in the header matching to make the routing decision. **After** the routing decision is made,
+// the selected backend name is populated in the header `x-envoy-ai-gateway-selected-backend`. For example, when the model name is `llama3.3333`,
 // the request is routed to either backends `kserve` or `awsbedrock` with weights 1 and 10 respectively, and the selected
-// backend, say `awsbedrock`, is populated in the header `x-backend-name`.
+// backend, say `awsbedrock`, is populated in the header `x-envoy-ai-gateway-selected-backend`.
 //
-// From Envoy configuration perspective, configuring the header matching based on `x-backend-name` is enough to route the request to the selected backend.
-// That is because the matching decision is made by the external processor and the selected backend is populated in the header `x-backend-name`.
+// From Envoy configuration perspective, configuring the header matching based on `x-envoy-ai-gateway-selected-backend` is enough to route the request to the selected backend.
+// That is because the matching decision is made by the external processor and the selected backend is populated in the header `x-envoy-ai-gateway-selected-backend`.
 type Config struct {
 	// TokenUsageMetadata is the namespace and key to be used in the filter metadata to store the usage token, optional.
 	// If this is provided, the external processor will populate the usage token in the filter metadata at the end of the
@@ -65,9 +74,9 @@ type Config struct {
 	InputSchema VersionedAPISchema `yaml:"inputSchema"`
 	// ModelNameHeaderKey is the header key to be populated with the model name by the external processor.
 	ModelNameHeaderKey string `yaml:"modelNameHeaderKey"`
-	// BackendRoutingHeaderKey is the header key to be populated with the backend name by the external processor
+	// SelectedBackendHeaderKey is the header key to be populated with the backend name by the external processor
 	// **after** the routing decision is made by the external processor using Rules.
-	BackendRoutingHeaderKey string `yaml:"backendRoutingHeaderKey"`
+	SelectedBackendHeaderKey string `yaml:"selectedBackendHeaderKey"`
 	// Rules is the routing rules to be used by the external processor to make the routing decision.
 	// Inside the routing rules, the header ModelNameHeaderKey may be used to make the routing decision.
 	Rules []RouteRule `yaml:"rules"`

--- a/extprocconfig/extprocconfig.go
+++ b/extprocconfig/extprocconfig.go
@@ -20,7 +20,7 @@ const DefaultConfig = `
 inputSchema:
   schema: OpenAI
 selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
-modelNameHeaderKey: x-envoy-ai-gateway-llm-model
+modelNameHeaderKey: x-envoy-ai-gateway-model
 `
 
 // Config is the configuration for the external processor.
@@ -32,7 +32,7 @@ modelNameHeaderKey: x-envoy-ai-gateway-llm-model
 //	inputSchema:
 //	  schema: OpenAI
 //	selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
-//	modelNameHeaderKey: x-envoy-ai-gateway-llm-model
+//	modelNameHeaderKey: x-envoy-ai-gateway-model
 //	tokenUsageMetadata:
 //	  namespace: ai_gateway_llm_ns
 //	  key: token_usage_key
@@ -47,18 +47,18 @@ modelNameHeaderKey: x-envoy-ai-gateway-llm-model
 //	    outputSchema:
 //	      schema: AWSBedrock
 //	  headers:
-//	  - name: x-envoy-ai-gateway-llm-model
+//	  - name: x-envoy-ai-gateway-model
 //	    value: llama3.3333
 //	- backends:
 //	  - name: openai
 //	    outputSchema:
 //	      schema: OpenAI
 //	  headers:
-//	  - name: x-envoy-ai-gateway-llm-model
+//	  - name: x-envoy-ai-gateway-model
 //	    value: gpt4.4444
 //
-// where the input of the external processor is in the OpenAI schema, the model name is populated in the header x-envoy-ai-gateway-llm-model,
-// The model name header `x-envoy-ai-gateway-llm-model` is used in the header matching to make the routing decision. **After** the routing decision is made,
+// where the input of the external processor is in the OpenAI schema, the model name is populated in the header x-envoy-ai-gateway-model,
+// The model name header `x-envoy-ai-gateway-model` is used in the header matching to make the routing decision. **After** the routing decision is made,
 // the selected backend name is populated in the header `x-envoy-ai-gateway-selected-backend`. For example, when the model name is `llama3.3333`,
 // the request is routed to either backends `kserve` or `awsbedrock` with weights 1 and 10 respectively, and the selected
 // backend, say `awsbedrock`, is populated in the header `x-envoy-ai-gateway-selected-backend`.

--- a/extprocconfig/extprocconfig_test.go
+++ b/extprocconfig/extprocconfig_test.go
@@ -32,7 +32,7 @@ func TestUnmarshalConfigYaml(t *testing.T) {
 inputSchema:
   schema: OpenAI
 selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
-modelNameHeaderKey: x-envoy-ai-gateway-llm-model
+modelNameHeaderKey: x-envoy-ai-gateway-model
 tokenUsageMetadata:
   namespace: ai_gateway_llm_ns
   key: token_usage_key
@@ -47,14 +47,14 @@ rules:
     outputSchema:
       schema: AWSBedrock
   headers:
-  - name: x-envoy-ai-gateway-llm-model
+  - name: x-envoy-ai-gateway-model
     value: llama3.3333
 - backends:
   - name: openai
     outputSchema:
       schema: OpenAI
   headers:
-  - name: x-envoy-ai-gateway-llm-model
+  - name: x-envoy-ai-gateway-model
     value: gpt4.4444
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
@@ -64,7 +64,7 @@ rules:
 	require.Equal(t, "token_usage_key", cfg.TokenUsageMetadata.Key)
 	require.Equal(t, "OpenAI", string(cfg.InputSchema.Schema))
 	require.Equal(t, "x-envoy-ai-gateway-selected-backend", cfg.SelectedBackendHeaderKey)
-	require.Equal(t, "x-envoy-ai-gateway-llm-model", cfg.ModelNameHeaderKey)
+	require.Equal(t, "x-envoy-ai-gateway-model", cfg.ModelNameHeaderKey)
 	require.Len(t, cfg.Rules, 2)
 	require.Equal(t, "llama3.3333", cfg.Rules[0].Headers[0].Value)
 	require.Equal(t, "gpt4.4444", cfg.Rules[1].Headers[0].Value)

--- a/extprocconfig/extprocconfig_test.go
+++ b/extprocconfig/extprocconfig_test.go
@@ -1,20 +1,38 @@
-package extprocconfig
+package extprocconfig_test
 
 import (
+	"log/slog"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/internal/extproc"
 )
+
+func TestDefaultConfig(t *testing.T) {
+	server, err := extproc.NewServer(slog.Default(), extproc.NewProcessor)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	var cfg extprocconfig.Config
+	err = yaml.Unmarshal([]byte(extprocconfig.DefaultConfig), &cfg)
+	require.NoError(t, err)
+
+	err = server.LoadConfig(&cfg)
+	require.NoError(t, err)
+}
 
 func TestUnmarshalConfigYaml(t *testing.T) {
 	configPath := path.Join(t.TempDir(), "config.yaml")
 	const config = `
 inputSchema:
   schema: OpenAI
-backendRoutingHeaderKey: x-backend-name
-modelNameHeaderKey: x-model-name
+selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
+modelNameHeaderKey: x-envoy-ai-gateway-llm-model
 tokenUsageMetadata:
   namespace: ai_gateway_llm_ns
   key: token_usage_key
@@ -29,24 +47,24 @@ rules:
     outputSchema:
       schema: AWSBedrock
   headers:
-  - name: x-model-name
+  - name: x-envoy-ai-gateway-llm-model
     value: llama3.3333
 - backends:
   - name: openai
     outputSchema:
       schema: OpenAI
   headers:
-  - name: x-model-name
+  - name: x-envoy-ai-gateway-llm-model
     value: gpt4.4444
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
-	cfg, err := UnmarshalConfigYaml(configPath)
+	cfg, err := extprocconfig.UnmarshalConfigYaml(configPath)
 	require.NoError(t, err)
 	require.Equal(t, "ai_gateway_llm_ns", cfg.TokenUsageMetadata.Namespace)
 	require.Equal(t, "token_usage_key", cfg.TokenUsageMetadata.Key)
 	require.Equal(t, "OpenAI", string(cfg.InputSchema.Schema))
-	require.Equal(t, "x-backend-name", cfg.BackendRoutingHeaderKey)
-	require.Equal(t, "x-model-name", cfg.ModelNameHeaderKey)
+	require.Equal(t, "x-envoy-ai-gateway-selected-backend", cfg.SelectedBackendHeaderKey)
+	require.Equal(t, "x-envoy-ai-gateway-llm-model", cfg.ModelNameHeaderKey)
 	require.Len(t, cfg.Rules, 2)
 	require.Equal(t, "llama3.3333", cfg.Rules[0].Headers[0].Value)
 	require.Equal(t, "gpt4.4444", cfg.Rules[1].Headers[0].Value)

--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,18 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.28.7
 	github.com/envoyproxy/gateway v1.2.4
 	github.com/envoyproxy/go-control-plane/envoy v1.32.2
+	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/openai/openai-go v0.1.0-alpha.43
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	google.golang.org/grpc v1.69.2
 	google.golang.org/protobuf v1.36.1
+	k8s.io/api v0.31.2
+	k8s.io/apiextensions-apiserver v0.31.2
 	k8s.io/apimachinery v0.32.0
+	k8s.io/client-go v0.31.2
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078
 	sigs.k8s.io/controller-runtime v0.19.3
 	sigs.k8s.io/gateway-api v1.2.1
@@ -44,7 +49,6 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
@@ -86,12 +90,9 @@ require (
 	golang.org/x/time v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.31.2 // indirect
-	k8s.io/apiextensions-apiserver v0.31.2 // indirect
-	k8s.io/client-go v0.31.2 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.3 // indirect

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -32,6 +32,7 @@ func init() {
 }
 
 func newClients(config *rest.Config) (kubeClient client.Client, kube kubernetes.Interface, err error) {
+	// TODO: cache options, especially HTTPRoutes managed by the AI Gateway.
 	kubeClient, err = client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create new client: %w", err)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,103 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(aigv1a1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(egv1a1.AddToScheme(scheme))
+	utilruntime.Must(gwapiv1.Install(scheme))
+	utilruntime.Must(gwapiv1b1.Install(scheme))
+}
+
+func newClients(config *rest.Config) (kubeClient client.Client, kube kubernetes.Interface, err error) {
+	kubeClient, err = client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create new client: %w", err)
+	}
+
+	kube, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	return kubeClient, kube, nil
+}
+
+// StartControllers starts the controllers for the AI Gateway.
+// This blocks until the manager is stopped.
+func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logger, logLevel string, extProcImage string) error {
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme:           scheme,
+		LeaderElection:   true,
+		LeaderElectionID: "envoy-ai-gateway-controller",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create new controller manager: %w", err)
+	}
+
+	clientForRouteC, kubeForRouteC, err := newClients(config)
+	if err != nil {
+		return fmt.Errorf("failed to create new clients: %w", err)
+	}
+
+	sinkChan := make(chan configSinkEvent, 100)
+	routeC := newLLMRouteController(clientForRouteC, kubeForRouteC, logger, logLevel, extProcImage, sinkChan)
+	if err = ctrl.NewControllerManagedBy(mgr).
+		For(&aigv1a1.LLMRoute{}).
+		Complete(routeC); err != nil {
+		return fmt.Errorf("failed to create controller for LLMRoute: %w", err)
+	}
+
+	clientForBackendC, kubeForBackendC, err := newClients(config)
+	if err != nil {
+		return fmt.Errorf("failed to create new clients: %w", err)
+	}
+
+	backendC := newLLMBackendController(clientForBackendC, kubeForBackendC, logger, sinkChan)
+	if err = ctrl.NewControllerManagedBy(mgr).
+		For(&aigv1a1.LLMBackend{}).
+		Complete(backendC); err != nil {
+		return fmt.Errorf("failed to create controller for LLMBackend: %w", err)
+	}
+
+	clientForConfigSink, kubeForConfigSink, err := newClients(config)
+	if err != nil {
+		return fmt.Errorf("failed to create new clients: %w", err)
+	}
+
+	sink := newConfigSink(clientForConfigSink, kubeForConfigSink, logger, sinkChan)
+
+	// Wait for the manager to become the leader before starting the controllers.
+	<-mgr.Elected()
+
+	// Before starting the manager, initialize the config sink to sync all LLMBackend and LLMRoute objects in the cluster.
+	if err = sink.init(ctx); err != nil {
+		return fmt.Errorf("failed to initialize config sink: %w", err)
+	}
+
+	if err = mgr.Start(ctx); err != nil { // This blocks until the manager is stopped.
+		return fmt.Errorf("failed to start controller manager: %w", err)
+	}
+	return nil
+}

--- a/internal/controller/llmbackend.go
+++ b/internal/controller/llmbackend.go
@@ -1,0 +1,49 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+)
+
+// llmBackendController implements [reconcile.TypedReconciler] for [aigv1a1.LLMBackend].
+//
+// This handles the LLMBackend resource and sends it to the config sink so that it can modify the configuration together with the state of other resources.
+type llmBackendController struct {
+	client    client.Client
+	kube      kubernetes.Interface
+	logger    logr.Logger
+	eventChan chan configSinkEvent
+}
+
+func newLLMBackendController(client client.Client, kube kubernetes.Interface, logger logr.Logger, ch chan configSinkEvent) *llmBackendController {
+	return &llmBackendController{
+		client:    client,
+		kube:      kube,
+		logger:    logger,
+		eventChan: ch,
+	}
+}
+
+// Reconcile implements the [reconcile.TypedReconciler] for [aigv1a1.LLMBackend].
+func (l *llmBackendController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	var llmBackend aigv1a1.LLMBackend
+	if err := l.client.Get(ctx, req.NamespacedName, &llmBackend); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			l.eventChan <- configSinkEventLLMBackendDeleted{namespace: req.Namespace, name: req.Name}
+			ctrl.Log.Info("Deleting LLMBackend",
+				"namespace", req.Namespace, "name", req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	// Send the LLMBackend to the config sink so that it can modify the configuration together with the state of other resources.
+	l.eventChan <- llmBackend.DeepCopy()
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/llmbackend_test.go
+++ b/internal/controller/llmbackend_test.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fake2 "k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+)
+
+func TestLlmBackendController_Reconcile(t *testing.T) {
+	ch := make(chan configSinkEvent, 100)
+	c := newLLMBackendController(fake.NewClientBuilder().WithScheme(scheme).Build(), fake2.NewClientset(), ctrl.Log, ch)
+
+	// Deleted case.
+	_, err := c.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "mybackend"}})
+	require.NoError(t, err)
+	item, ok := <-ch
+	require.True(t, ok)
+	require.IsType(t, configSinkEventLLMBackendDeleted{}, item)
+	require.Equal(t, "default", item.(configSinkEventLLMBackendDeleted).namespace)
+	require.Equal(t, "mybackend", item.(configSinkEventLLMBackendDeleted).name)
+
+	// Updated case.
+	err = c.client.Create(context.Background(), &aigv1a1.LLMBackend{ObjectMeta: metav1.ObjectMeta{Name: "mybackend", Namespace: "default"}})
+	require.NoError(t, err)
+	_, err = c.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "mybackend"}})
+	require.NoError(t, err)
+	item, ok = <-ch
+	require.True(t, ok)
+	require.IsType(t, &aigv1a1.LLMBackend{}, item)
+	require.Equal(t, "mybackend", item.(*aigv1a1.LLMBackend).Name)
+	require.Equal(t, "default", item.(*aigv1a1.LLMBackend).Namespace)
+}

--- a/internal/controller/llmroute.go
+++ b/internal/controller/llmroute.go
@@ -1,0 +1,252 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+const (
+	managedByLabel        = "app.kubernetes.io/managed-by"
+	expProcConfigFileName = "extproc-config.yaml"
+)
+
+// llmRouteController implements [reconcile.TypedReconciler].
+//
+// This handles the LLMRoute resource and creates the necessary resources for the external process.
+type llmRouteController struct {
+	client       client.Client
+	kube         kubernetes.Interface
+	logger       logr.Logger
+	logLevel     string
+	extProcImage string
+	eventChan    chan configSinkEvent
+}
+
+func newLLMRouteController(
+	client client.Client, kube kubernetes.Interface, logger logr.Logger,
+	logLevel, extProcImage string, ch chan configSinkEvent,
+) *llmRouteController {
+	return &llmRouteController{
+		client:       client,
+		kube:         kube,
+		logger:       logger,
+		logLevel:     logLevel,
+		extProcImage: extProcImage,
+		eventChan:    ch,
+	}
+}
+
+// Reconcile implements [reconcile.TypedReconciler].
+//
+// This only creates the external process deployment and service for the LLMRoute as well as the extension policy.
+// The actual HTTPRoute and the extproc configuration will be created in the config sink since we need
+// not only the LLMRoute but also the LLMBackend and other resources to create the full configuration.
+func (c *llmRouteController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	c.logger.Info("Reconciling LLMRoute")
+
+	var llmRoute aigv1a1.LLMRoute
+	if err := c.client.Get(ctx, req.NamespacedName, &llmRoute); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.eventChan <- configSinkEventLLMRouteDeleted{namespace: req.Namespace, name: req.Name}
+			ctrl.Log.Info("Deleting LLMRoute",
+				"namespace", req.Namespace, "name", req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	ownerRef := ownerReferenceForLLMRoute(&llmRoute)
+	if err := c.ensuresExtProcConfigMapExists(ctx, &llmRoute, ownerRef); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := c.reconcileExtProcDeployment(ctx, &llmRoute, ownerRef); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := c.reconcileExtProcExtensionPolicy(ctx, &llmRoute, ownerRef); err != nil {
+		return ctrl.Result{}, err
+	}
+	// Send a copy to the config sink for a full reconciliation on HTTPRoute as well as the extproc config.
+	c.eventChan <- llmRoute.DeepCopy()
+	return reconcile.Result{}, nil
+}
+
+// reconcileExtProcExtensionPolicy creates or updates the extension policy for the external process.
+// It only changes the target references.
+func (c *llmRouteController) reconcileExtProcExtensionPolicy(ctx context.Context, llmRoute *aigv1a1.LLMRoute, ownerRef []metav1.OwnerReference) error {
+	var existingPolicy egv1a1.EnvoyExtensionPolicy
+	if err := c.client.Get(ctx, client.ObjectKey{Name: extProcName(llmRoute), Namespace: llmRoute.Namespace}, &existingPolicy); err == nil {
+		existingPolicy.Spec.PolicyTargetReferences.TargetRefs = llmRoute.Spec.TargetRefs
+		if err := c.client.Update(ctx, &existingPolicy); err != nil {
+			return fmt.Errorf("failed to update extension policy: %w", err)
+		}
+	} else if client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to get extension policy: %w", err)
+	}
+	pm := egv1a1.BufferedExtProcBodyProcessingMode
+	port := gwapiv1.PortNumber(1063)
+	objNs := gwapiv1.Namespace(llmRoute.Namespace)
+	extPolicy := &egv1a1.EnvoyExtensionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: extProcName(llmRoute), Namespace: llmRoute.Namespace, OwnerReferences: ownerRef},
+		Spec: egv1a1.EnvoyExtensionPolicySpec{
+			PolicyTargetReferences: egv1a1.PolicyTargetReferences{TargetRefs: llmRoute.Spec.TargetRefs},
+			ExtProc: []egv1a1.ExtProc{{
+				ProcessingMode: &egv1a1.ExtProcProcessingMode{
+					Request:  &egv1a1.ProcessingModeOptions{Body: &pm},
+					Response: &egv1a1.ProcessingModeOptions{Body: &pm},
+				},
+				BackendCluster: egv1a1.BackendCluster{BackendRefs: []egv1a1.BackendRef{{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Name:      gwapiv1.ObjectName(extProcName(llmRoute)),
+						Namespace: &objNs,
+						Port:      &port,
+					},
+				}}},
+			}},
+		},
+	}
+	if err := c.client.Create(ctx, extPolicy); client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed to create extension policy: %w", err)
+	}
+	return nil
+}
+
+// ensuresExtProcConfigMapExists ensures that a configmap exists for the external process.
+// This must happen before the external process deployment is created.
+func (c *llmRouteController) ensuresExtProcConfigMapExists(ctx context.Context, llmRoute *aigv1a1.LLMRoute, ownerRef []metav1.OwnerReference) error {
+	name := extProcName(llmRoute)
+	// Check if a configmap exists for extproc exists, and if not, create one with the default config.
+	_, err := c.kube.CoreV1().ConfigMaps(llmRoute.Namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					Namespace:       llmRoute.Namespace,
+					OwnerReferences: ownerRef,
+				},
+				Data: map[string]string{expProcConfigFileName: extprocconfig.DefaultConfig},
+			}
+			_, err = c.kube.CoreV1().ConfigMaps(llmRoute.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// reconcileExtProcDeployment reconciles the external processor's Deployment and Service.
+func (c *llmRouteController) reconcileExtProcDeployment(ctx context.Context, llmRoute *aigv1a1.LLMRoute, ownerRef []metav1.OwnerReference) error {
+	name := extProcName(llmRoute)
+	labels := map[string]string{"app": name, managedByLabel: "envoy-ai-gateway"}
+
+	deployment, err := c.kube.AppsV1().Deployments(llmRoute.Namespace).Get(ctx, extProcName(llmRoute), metav1.GetOptions{})
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			deployment = &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					Namespace:       llmRoute.Namespace,
+					OwnerReferences: ownerRef,
+					Labels:          labels,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: labels},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:            name,
+									Image:           c.extProcImage,
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									Ports:           []corev1.ContainerPort{{Name: "grpc", ContainerPort: 1063}},
+									Args: []string{
+										"-configPath", "/etc/ai-gateway/extproc/" + expProcConfigFileName,
+										"-logLevel", c.logLevel,
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "config", MountPath: "/etc/ai-gateway/extproc"},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: extProcName(llmRoute)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err = c.kube.AppsV1().Deployments(llmRoute.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create deployment: %w", err)
+			}
+			ctrl.Log.Info("Created deployment", "name", name)
+		} else {
+			return fmt.Errorf("failed to get deployment: %w", err)
+		}
+	}
+
+	// TODO: reconcile the deployment spec like replicas etc once we have support for it at the CRD level.
+	_ = deployment
+
+	// This is static, so we don't need to update it.
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       llmRoute.Namespace,
+			OwnerReferences: ownerRef,
+			Labels:          labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "grpc",
+					Protocol:    corev1.ProtocolTCP,
+					Port:        1063,
+					AppProtocol: ptr.To("grpc"),
+				},
+			},
+		},
+	}
+	if _, err = c.kube.CoreV1().Services(llmRoute.Namespace).Create(ctx, service, metav1.CreateOptions{}); client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed to create Service %s.%s: %w", name, llmRoute.Namespace, err)
+	}
+	return nil
+}
+
+func extProcName(route *aigv1a1.LLMRoute) string {
+	return fmt.Sprintf("ai-gateway-llm-route-extproc-%s", route.Name)
+}
+
+func ownerReferenceForLLMRoute(llmRoute *aigv1a1.LLMRoute) []metav1.OwnerReference {
+	return []metav1.OwnerReference{{
+		APIVersion: llmRoute.APIVersion,
+		Kind:       llmRoute.Kind,
+		Name:       llmRoute.Name,
+		UID:        llmRoute.UID,
+	}}
+}

--- a/internal/controller/llmroute_test.go
+++ b/internal/controller/llmroute_test.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake2 "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+func Test_extProcName(t *testing.T) {
+	actual := extProcName(&aigv1a1.LLMRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myroute",
+		},
+	})
+	require.Equal(t, "ai-gateway-llm-route-extproc-myroute", actual)
+}
+
+func TestLLMRouteController_ensuresExtProcConfigMapExists(t *testing.T) {
+	c := &llmRouteController{client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	c.kube = fake2.NewClientset()
+
+	ownerRef := []metav1.OwnerReference{{APIVersion: "v1", Kind: "Kind", Name: "Name"}}
+	llmRoute := &aigv1a1.LLMRoute{ObjectMeta: metav1.ObjectMeta{Name: "myroute", Namespace: "default"}}
+
+	err := c.ensuresExtProcConfigMapExists(context.Background(), llmRoute, ownerRef)
+	require.NoError(t, err)
+
+	configMap, err := c.kube.CoreV1().ConfigMaps("default").Get(context.Background(), extProcName(llmRoute), metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, extProcName(llmRoute), configMap.Name)
+	require.Equal(t, "default", configMap.Namespace)
+	require.Equal(t, ownerRef, configMap.OwnerReferences)
+	require.Equal(t, extprocconfig.DefaultConfig, configMap.Data[expProcConfigFileName])
+
+	// Doing it again should not fail.
+	err = c.ensuresExtProcConfigMapExists(context.Background(), llmRoute, ownerRef)
+	require.NoError(t, err)
+}
+
+func TestLLMRouteController_reconcileExtProcDeployment(t *testing.T) {
+	c := &llmRouteController{client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	c.kube = fake2.NewClientset()
+
+	ownerRef := []metav1.OwnerReference{{APIVersion: "v1", Kind: "Kind", Name: "Name"}}
+	llmRoute := &aigv1a1.LLMRoute{ObjectMeta: metav1.ObjectMeta{Name: "myroute", Namespace: "default"}}
+
+	err := c.reconcileExtProcDeployment(context.Background(), llmRoute, ownerRef)
+	require.NoError(t, err)
+
+	deployment, err := c.kube.AppsV1().Deployments("default").Get(context.Background(), extProcName(llmRoute), metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, extProcName(llmRoute), deployment.Name)
+
+	service, err := c.kube.CoreV1().Services("default").Get(context.Background(), extProcName(llmRoute), metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, extProcName(llmRoute), service.Name)
+
+	// Doing it again should not fail.
+	err = c.reconcileExtProcDeployment(context.Background(), llmRoute, ownerRef)
+	require.NoError(t, err)
+}
+
+func TestLLMRouteController_reconcileExtProcExtensionPolicy(t *testing.T) {
+	c := &llmRouteController{client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	ownerRef := []metav1.OwnerReference{{APIVersion: "v1", Kind: "Kind", Name: "Name"}}
+	llmRoute := &aigv1a1.LLMRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myroute",
+			Namespace: "default",
+		},
+		Spec: aigv1a1.LLMRouteSpec{
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
+				{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "mytarget"}},
+				{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "mytarget2"}},
+			},
+		},
+	}
+	err := c.reconcileExtProcExtensionPolicy(context.Background(), llmRoute, ownerRef)
+	require.NoError(t, err)
+	var extPolicy egv1a1.EnvoyExtensionPolicy
+	err = c.client.Get(context.Background(), client.ObjectKey{Name: extProcName(llmRoute), Namespace: "default"}, &extPolicy)
+	require.NoError(t, err)
+
+	require.Equal(t, len(llmRoute.Spec.TargetRefs), len(extPolicy.Spec.TargetRefs))
+	for i, target := range extPolicy.Spec.TargetRefs {
+		require.Equal(t, llmRoute.Spec.TargetRefs[i].Name, target.Name)
+	}
+
+	// Update the policy.
+	llmRoute.Spec.TargetRefs = []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
+		{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "dog"}},
+		{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "cat"}},
+		{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "bird"}},
+	}
+	err = c.reconcileExtProcExtensionPolicy(context.Background(), llmRoute, ownerRef)
+	require.NoError(t, err)
+
+	err = c.client.Get(context.Background(), client.ObjectKey{Name: extProcName(llmRoute), Namespace: "default"}, &extPolicy)
+	require.NoError(t, err)
+
+	require.Len(t, extPolicy.Spec.TargetRefs, 3)
+	for i, target := range extPolicy.Spec.TargetRefs {
+		require.Equal(t, llmRoute.Spec.TargetRefs[i].Name, target.Name)
+	}
+}

--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -157,11 +157,6 @@ func (c *configSink) syncLLMRoute(llmRoute *aigv1a1.LLMRoute) {
 		return
 	}
 
-	// Print rules.
-	for i, rule := range httpRoute.Spec.Rules {
-		c.logger.Info("rule", "rule", i, "backendRefs", rule.BackendRefs)
-	}
-
 	if existingRoute {
 		if err := c.client.Update(context.Background(), httpRoute); err != nil {
 			c.logger.Error(err, "failed to update HTTPRoute", "httpRoute", httpRoute)
@@ -260,7 +255,6 @@ func (c *configSink) updateExtProcConfigMap(llmRoute *aigv1a1.LLMRoute) error {
 
 // newHTTPRoute updates the HTTPRoute with the new LLMRoute.
 func (c *configSink) newHTTPRoute(dst *gwapiv1.HTTPRoute, llmRoute *aigv1a1.LLMRoute) error {
-	// Update the HTTPRoute with the new LLMRoute.
 	var backends []*aigv1a1.LLMBackend
 	dedup := make(map[string]struct{})
 	for _, rule := range llmRoute.Spec.Rules {

--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -1,0 +1,308 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/yaml"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+const selectedBackendHeaderKey = "x-envoy-ai-gateway-selected-backend"
+
+// configSinkEvent is the interface for the events that the configSink can handle.
+// It can be either an LLMBackend, an LLMRoute, or a deletion event.
+type configSinkEvent any
+
+// configSinkEventLLMBackendDeleted is an event to notify the configSink that an LLMBackend has been deleted.
+type configSinkEventLLMBackendDeleted struct{ namespace, name string }
+
+// configSinkEventLLMRouteDeleted is an event to notify the configSink that an LLMRoute has been deleted.
+type configSinkEventLLMRouteDeleted struct{ namespace, name string }
+
+// configSink centralizes the LLMRoute and LLMBackend objects handling
+// which requires to be done in a single goroutine since we need to
+// consolidate the information from both objects to generate the ExtProcConfig
+// and HTTPRoute objects.
+type configSink struct {
+	client client.Client
+	kube   kubernetes.Interface
+	logger logr.Logger
+
+	eventChan                   chan configSinkEvent
+	httpRoutes                  map[string]*gwapiv1.HTTPRoute
+	llmRoutes                   map[string]*aigv1a1.LLMRoute
+	backends                    map[string]*aigv1a1.LLMBackend
+	backendsToReferencingRoutes map[string]map[*aigv1a1.LLMRoute]struct{}
+}
+
+func newConfigSink(
+	kubeClient client.Client,
+	kube kubernetes.Interface,
+	logger logr.Logger,
+	eventChan chan configSinkEvent,
+) *configSink {
+	c := &configSink{
+		client:                      kubeClient,
+		kube:                        kube,
+		logger:                      logger,
+		httpRoutes:                  make(map[string]*gwapiv1.HTTPRoute),
+		backends:                    make(map[string]*aigv1a1.LLMBackend),
+		llmRoutes:                   make(map[string]*aigv1a1.LLMRoute),
+		backendsToReferencingRoutes: make(map[string]map[*aigv1a1.LLMRoute]struct{}),
+		eventChan:                   eventChan,
+	}
+	return c
+}
+
+// init caches all LLMBackend and LLMRoute objects in the cluster after the controller gets the leader election,
+// and starts a goroutine to handle the events from the controllers.
+func (c *configSink) init(ctx context.Context) error {
+	var llmBackends aigv1a1.LLMBackendList
+	if err := c.client.List(ctx, &llmBackends); err != nil {
+		return fmt.Errorf("failed to list LLMBackends: %w", err)
+	}
+
+	for i := range llmBackends.Items {
+		llmBackend := &llmBackends.Items[i]
+		c.backends[fmt.Sprintf("%s.%s", llmBackend.Name, llmBackend.Namespace)] = llmBackend
+	}
+
+	var llmRoutes aigv1a1.LLMRouteList
+	if err := c.client.List(ctx, &llmRoutes); err != nil {
+		return fmt.Errorf("failed to list LLMRoutes: %w", err)
+	}
+
+	for i := range llmRoutes.Items {
+		llmRoute := &llmRoutes.Items[i]
+		namspacedLLMRouteName := fmt.Sprintf("%s.%s", llmRoute.Name, llmRoute.Namespace)
+		c.llmRoutes[namspacedLLMRouteName] = llmRoute
+
+		for _, rule := range llmRoute.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				namspacedBackendName := fmt.Sprintf("%s.%s", backend.Name, llmRoute.Namespace)
+				if _, ok := c.backendsToReferencingRoutes[namspacedBackendName]; !ok {
+					c.backendsToReferencingRoutes[namspacedBackendName] = make(map[*aigv1a1.LLMRoute]struct{})
+				}
+				c.backendsToReferencingRoutes[namspacedBackendName][llmRoute] = struct{}{}
+			}
+		}
+	}
+
+	var httpRoutes gwapiv1.HTTPRouteList
+	if err := c.client.List(ctx, &httpRoutes, client.MatchingLabels{managedByLabel: "envoy-ai-gateway"}); err != nil {
+		return fmt.Errorf("failed to list HTTPRoutes: %w", err)
+	}
+	for i := range httpRoutes.Items {
+		httpRoute := &httpRoutes.Items[i]
+		c.httpRoutes[fmt.Sprintf("%s.%s", httpRoute.Name, httpRoute.Namespace)] = httpRoute
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(c.eventChan)
+				return
+			case event := <-c.eventChan:
+				c.handleEvent(event)
+			}
+		}
+	}()
+	return nil
+}
+
+// handleEvent handles the event received from the controllers in a single goroutine.
+func (c *configSink) handleEvent(event configSinkEvent) {
+	switch e := event.(type) {
+	case *aigv1a1.LLMBackend:
+		c.syncLLMBackend(e)
+	case configSinkEventLLMBackendDeleted:
+		c.deleteLLMBackend(e)
+	case *aigv1a1.LLMRoute:
+		c.syncLLMRoute(e)
+	case configSinkEventLLMRouteDeleted:
+		c.deleteLLMRoute(e)
+	default:
+		panic(fmt.Sprintf("unexpected event type: %T", e))
+	}
+}
+
+func (c *configSink) syncLLMRoute(llmRoute *aigv1a1.LLMRoute) {
+	// Check if the HTTPRoute exists.
+	key := fmt.Sprintf("%s.%s", llmRoute.Name, llmRoute.Namespace)
+	httpRoute, existingRoute := c.httpRoutes[key]
+	if !existingRoute {
+		// This means that this LLMRoute is a new one.
+		httpRoute = &gwapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            llmRoute.Name,
+				Namespace:       llmRoute.Namespace,
+				OwnerReferences: ownerReferenceForLLMRoute(llmRoute),
+			},
+			Spec: gwapiv1.HTTPRouteSpec{},
+		}
+	}
+
+	// Update the HTTPRoute with the new LLMRoute.
+	if err := c.newHTTPRoute(httpRoute, llmRoute); err != nil {
+		c.logger.Error(err, "failed to update HTTPRoute with LLMRoute", "llmRoute", llmRoute)
+		return
+	}
+
+	// Print rules.
+	for i, rule := range httpRoute.Spec.Rules {
+		c.logger.Info("rule", "rule", i, "backendRefs", rule.BackendRefs)
+	}
+
+	if existingRoute {
+		if err := c.client.Update(context.Background(), httpRoute); err != nil {
+			c.logger.Error(err, "failed to update HTTPRoute", "httpRoute", httpRoute)
+			return
+		}
+	} else {
+		if err := c.client.Create(context.Background(), httpRoute); err != nil {
+			c.logger.Error(err, "failed to create HTTPRoute", "httpRoute", httpRoute)
+			return
+		}
+	}
+
+	// Update the extproc configmap.
+	if err := c.updateExtProcConfigMap(llmRoute); err != nil {
+		c.logger.Error(err, "failed to update extproc configmap", "llmRoute", llmRoute)
+		return
+	}
+
+	// Update the referencing map.
+	for _, rule := range llmRoute.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			key := fmt.Sprintf("%s.%s", backend.Name, llmRoute.Namespace)
+			if _, ok := c.backendsToReferencingRoutes[key]; !ok {
+				c.backendsToReferencingRoutes[key] = make(map[*aigv1a1.LLMRoute]struct{})
+			}
+			c.backendsToReferencingRoutes[key][llmRoute] = struct{}{}
+		}
+	}
+	c.httpRoutes[key] = httpRoute
+	c.llmRoutes[key] = llmRoute
+}
+
+func (c *configSink) syncLLMBackend(llmBackend *aigv1a1.LLMBackend) {
+	key := fmt.Sprintf("%s.%s", llmBackend.Name, llmBackend.Namespace)
+	c.backends[key] = llmBackend
+	for referencedLLMRoute := range c.backendsToReferencingRoutes[key] {
+		c.syncLLMRoute(referencedLLMRoute)
+	}
+}
+
+func (c *configSink) deleteLLMRoute(event configSinkEventLLMRouteDeleted) {
+	key := fmt.Sprintf("%s.%s", event.name, event.namespace)
+	delete(c.llmRoutes, key)
+	delete(c.httpRoutes, key)
+}
+
+func (c *configSink) deleteLLMBackend(event configSinkEventLLMBackendDeleted) {
+	key := fmt.Sprintf("%s.%s", event.name, event.namespace)
+	delete(c.backends, key)
+	delete(c.backendsToReferencingRoutes, key)
+}
+
+// updateExtProcConfigMap updates the external process configmap with the new LLMRoute.
+func (c *configSink) updateExtProcConfigMap(llmRoute *aigv1a1.LLMRoute) error {
+	configMap, err := c.kube.CoreV1().ConfigMaps(llmRoute.Namespace).Get(context.Background(), extProcName(llmRoute), metav1.GetOptions{})
+	if err != nil {
+		// This is a bug since we should have created the configmap before sending the LLMRoute to the configSink.
+		panic(fmt.Errorf("failed to get configmap %s: %w", extProcName(llmRoute), err))
+	}
+
+	ec := &extprocconfig.Config{}
+	spec := &llmRoute.Spec
+
+	ec.InputSchema.Schema = extprocconfig.APISchema(spec.APISchema.Schema)
+	ec.InputSchema.Version = spec.APISchema.Version
+	ec.ModelNameHeaderKey = aigv1a1.LLMModelHeaderKey
+	ec.SelectedBackendHeaderKey = selectedBackendHeaderKey
+	ec.Rules = make([]extprocconfig.RouteRule, len(spec.Rules))
+	for i, rule := range spec.Rules {
+		ec.Rules[i].Backends = make([]extprocconfig.Backend, len(rule.BackendRefs))
+		for j, backend := range rule.BackendRefs {
+			key := fmt.Sprintf("%s.%s", backend.Name, llmRoute.Namespace)
+			ec.Rules[i].Backends[j].Name = key
+			ec.Rules[i].Backends[j].Weight = backend.Weight
+		}
+		ec.Rules[i].Headers = make([]extprocconfig.HeaderMatch, len(rule.Matches))
+		for j, match := range rule.Matches {
+			ec.Rules[i].Headers[j].Name = match.Headers[0].Name
+			ec.Rules[i].Headers[j].Value = match.Headers[0].Value
+		}
+	}
+
+	marshaled, err := yaml.Marshal(ec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal extproc config: %w", err)
+	}
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+	configMap.Data[expProcConfigFileName] = string(marshaled)
+	if _, err := c.kube.CoreV1().ConfigMaps(llmRoute.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update configmap %s: %w", configMap.Name, err)
+	}
+	return nil
+}
+
+// newHTTPRoute updates the HTTPRoute with the new LLMRoute.
+func (c *configSink) newHTTPRoute(dst *gwapiv1.HTTPRoute, llmRoute *aigv1a1.LLMRoute) error {
+	// Update the HTTPRoute with the new LLMRoute.
+	var backends []*aigv1a1.LLMBackend
+	dedup := make(map[string]struct{})
+	for _, rule := range llmRoute.Spec.Rules {
+		for _, br := range rule.BackendRefs {
+			key := fmt.Sprintf("%s.%s", br.Name, llmRoute.Namespace)
+			if _, ok := dedup[key]; ok {
+				continue
+			}
+			dedup[key] = struct{}{}
+			backend, ok := c.backends[key]
+			if !ok {
+				return fmt.Errorf("LLMBackend %s not found", key)
+			}
+			backends = append(backends, backend)
+		}
+	}
+
+	rules := make([]gwapiv1.HTTPRouteRule, len(backends))
+	for i, b := range backends {
+		key := fmt.Sprintf("%s.%s", b.Name, b.Namespace)
+		rule := gwapiv1.HTTPRouteRule{
+			BackendRefs: []gwapiv1.HTTPBackendRef{
+				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: b.Spec.BackendRef.BackendObjectReference}},
+			},
+			Matches: []gwapiv1.HTTPRouteMatch{
+				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: key}}},
+			},
+		}
+		rules[i] = rule
+	}
+	dst.Spec.Rules = rules
+
+	targetRefs := llmRoute.Spec.TargetRefs
+	egNs := gwapiv1.Namespace(llmRoute.Namespace)
+	parentRefs := make([]gwapiv1.ParentReference, len(targetRefs))
+	for i, egRef := range targetRefs {
+		egName := egRef.Name
+		parentRefs[i] = gwapiv1.ParentReference{
+			Name:      egName,
+			Namespace: &egNs,
+		}
+	}
+	dst.Spec.CommonRouteSpec.ParentRefs = parentRefs
+	return nil
+}

--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -80,16 +80,16 @@ func (c *configSink) init(ctx context.Context) error {
 
 	for i := range llmRoutes.Items {
 		llmRoute := &llmRoutes.Items[i]
-		namspacedLLMRouteName := fmt.Sprintf("%s.%s", llmRoute.Name, llmRoute.Namespace)
-		c.llmRoutes[namspacedLLMRouteName] = llmRoute
+		llmRouteKey := fmt.Sprintf("%s.%s", llmRoute.Name, llmRoute.Namespace)
+		c.llmRoutes[llmRouteKey] = llmRoute
 
 		for _, rule := range llmRoute.Spec.Rules {
 			for _, backend := range rule.BackendRefs {
-				namspacedBackendName := fmt.Sprintf("%s.%s", backend.Name, llmRoute.Namespace)
-				if _, ok := c.backendsToReferencingRoutes[namspacedBackendName]; !ok {
-					c.backendsToReferencingRoutes[namspacedBackendName] = make(map[*aigv1a1.LLMRoute]struct{})
+				backendKey := fmt.Sprintf("%s.%s", backend.Name, llmRoute.Namespace)
+				if _, ok := c.backendsToReferencingRoutes[backendKey]; !ok {
+					c.backendsToReferencingRoutes[backendKey] = make(map[*aigv1a1.LLMRoute]struct{})
 				}
-				c.backendsToReferencingRoutes[namspacedBackendName][llmRoute] = struct{}{}
+				c.backendsToReferencingRoutes[backendKey][llmRoute] = struct{}{}
 			}
 		}
 	}

--- a/internal/controller/sink_test.go
+++ b/internal/controller/sink_test.go
@@ -1,0 +1,464 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	fake2 "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
+	"github.com/envoyproxy/ai-gateway/extprocconfig"
+)
+
+func TestConfigSink_init(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kube := fake2.NewClientset()
+
+	eventChan := make(chan configSinkEvent)
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan)
+	require.NotNil(t, s)
+
+	t.Run("setup", func(t *testing.T) {
+		for _, l := range []*aigv1a1.LLMRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"},
+				Spec: aigv1a1.LLMRouteSpec{
+					Rules: []aigv1a1.LLMRouteRule{
+						{
+							BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{
+								{Name: "apple", Weight: 100},
+								{Name: "pineapple", Weight: 100},
+							},
+							Matches: []aigv1a1.LLMRouteRuleMatch{
+								{Headers: []gwapiv1.HTTPHeaderMatch{{Name: "host", Value: "apple.com"}}},
+							},
+						},
+						{
+							BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{
+								{Name: "apple", Weight: 1},
+								{Name: "orange", Weight: 1},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "route2", Namespace: "ns2"},
+				Spec: aigv1a1.LLMRouteSpec{
+					Rules: []aigv1a1.LLMRouteRule{
+						{
+							BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{{Name: "cat", Weight: 100}},
+						},
+					},
+				},
+			},
+		} {
+			err := fakeClient.Create(context.Background(), l, &client.CreateOptions{})
+			require.NoError(t, err)
+		}
+
+		for _, b := range []*aigv1a1.LLMBackend{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pineapple", Namespace: "ns1"},
+				Spec: aigv1a1.LLMBackendSpec{
+					BackendRef: egv1a1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+					},
+					APISchema: aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"},
+				Spec: aigv1a1.LLMBackendSpec{
+					BackendRef: egv1a1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+					},
+					APISchema: aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaAWSBedrock},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: "ns1"},
+				Spec: aigv1a1.LLMBackendSpec{
+					BackendRef: egv1a1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+					},
+					APISchema: aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "cat", Namespace: "ns2"},
+				Spec: aigv1a1.LLMBackendSpec{
+					BackendRef: egv1a1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend4", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+					},
+					APISchema: aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI},
+				},
+			},
+		} {
+			err := fakeClient.Create(context.Background(), b, &client.CreateOptions{})
+			require.NoError(t, err)
+		}
+
+		for _, httpRoute := range []*gwapiv1.HTTPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1", Labels: map[string]string{managedByLabel: "envoy-ai-gateway"}},
+				Spec:       gwapiv1.HTTPRouteSpec{},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "route2", Namespace: "ns2", Labels: map[string]string{managedByLabel: "envoy-ai-gateway"}},
+				Spec:       gwapiv1.HTTPRouteSpec{},
+			},
+			// Not managed by envoy-ai-gateway.
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "route3", Namespace: "ns3"},
+				Spec:       gwapiv1.HTTPRouteSpec{},
+			},
+		} {
+			err := fakeClient.Create(context.Background(), httpRoute, &client.CreateOptions{})
+			require.NoError(t, err)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := s.init(ctx)
+	require.NoError(t, err)
+
+	t.Run("httpRoutes", func(t *testing.T) {
+		require.Len(t, s.httpRoutes, 2)
+		require.NotNil(t, s.httpRoutes["route1.ns1"])
+		require.NotNil(t, s.httpRoutes["route2.ns2"])
+	})
+	t.Run("llmRoutes", func(t *testing.T) {
+		require.Len(t, s.llmRoutes, 2)
+		require.NotNil(t, s.llmRoutes["route1.ns1"])
+		require.NotNil(t, s.llmRoutes["route2.ns2"])
+	})
+	t.Run("backends", func(t *testing.T) {
+		require.Len(t, s.backends, 4)
+		require.NotNil(t, s.backends["orange.ns1"])
+		require.NotNil(t, s.backends["apple.ns1"])
+		require.NotNil(t, s.backends["pineapple.ns1"])
+		require.NotNil(t, s.backends["cat.ns2"])
+	})
+	t.Run("backendsToReferencingRoutes", func(t *testing.T) {
+		require.Len(t, s.backendsToReferencingRoutes, 4)
+
+		takeMapKey := func(m map[*aigv1a1.LLMRoute]struct{}) *aigv1a1.LLMRoute {
+			for k := range m {
+				return k
+			}
+			return nil
+		}
+
+		referenced := s.backendsToReferencingRoutes["orange.ns1"]
+		require.Len(t, referenced, 1)
+		require.Equal(t, s.llmRoutes["route1.ns1"], takeMapKey(referenced))
+
+		referenced = s.backendsToReferencingRoutes["apple.ns1"]
+		require.Len(t, referenced, 1)
+		require.Equal(t, s.llmRoutes["route1.ns1"], takeMapKey(referenced))
+
+		referenced = s.backendsToReferencingRoutes["pineapple.ns1"]
+		require.Len(t, referenced, 1)
+		require.Equal(t, s.llmRoutes["route1.ns1"], takeMapKey(referenced))
+
+		referenced = s.backendsToReferencingRoutes["cat.ns2"]
+		require.Len(t, referenced, 1)
+		require.Equal(t, s.llmRoutes["route2.ns2"], takeMapKey(referenced))
+	})
+
+	// Until the context is cancelled, the event channel should be open, otherwise this should panic.
+	eventChan <- configSinkEventLLMBackendDeleted{namespace: "ns1", name: "apple"}
+	time.Sleep(200 * time.Millisecond)
+	require.NotContains(t, s.backends, "apple.ns1")
+	cancel()
+	// Check if the event channel is closed.
+	_, ok := <-eventChan
+	require.False(t, ok)
+}
+
+func TestConfigSink_syncLLMRoute(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kube := fake2.NewClientset()
+
+	eventChan := make(chan configSinkEvent, 10)
+	s := newConfigSink(fakeClient, kube, logr.FromSlogHandler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{})), eventChan)
+	require.NotNil(t, s)
+
+	s.backends = map[string]*aigv1a1.LLMBackend{
+		"apple.ns1": {ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"}, Spec: aigv1a1.LLMBackendSpec{
+			BackendRef: egv1a1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}},
+		}},
+		"orange.ns1": {ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: "ns1"}, Spec: aigv1a1.LLMBackendSpec{
+			BackendRef: egv1a1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}},
+		}},
+	}
+
+	t.Run("existing", func(t *testing.T) {
+		route := &aigv1a1.LLMRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"},
+			Spec: aigv1a1.LLMRouteSpec{
+				Rules: []aigv1a1.LLMRouteRule{
+					{
+						BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{{Name: "apple", Weight: 1}, {Name: "orange", Weight: 1}},
+					},
+				},
+				APISchema: aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI, Version: "v123"},
+			},
+		}
+		err := fakeClient.Create(context.Background(), route, &client.CreateOptions{})
+		require.NoError(t, err)
+		httpRoute := &gwapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1", Labels: map[string]string{managedByLabel: "envoy-ai-gateway"}},
+			Spec:       gwapiv1.HTTPRouteSpec{},
+		}
+		err = fakeClient.Create(context.Background(), httpRoute, &client.CreateOptions{})
+		require.NoError(t, err)
+		s.httpRoutes = map[string]*gwapiv1.HTTPRoute{"route1.ns1": httpRoute}
+
+		// Create the initial configmap.
+		_, err = kube.CoreV1().ConfigMaps(route.Namespace).Create(context.Background(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: extProcName(route), Namespace: route.Namespace},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Then sync.
+		s.syncLLMRoute(route)
+		require.NotNil(t, s.llmRoutes["route1.ns1"])
+		require.NotNil(t, s.httpRoutes["route1.ns1"])
+		// Referencing backends should be updated.
+		require.Contains(t, s.backendsToReferencingRoutes["apple.ns1"], route)
+		require.Contains(t, s.backendsToReferencingRoutes["orange.ns1"], route)
+		// Also HTTPRoute should be updated.
+		var updatedHTTPRoute gwapiv1.HTTPRoute
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: "route1", Namespace: "ns1"}, &updatedHTTPRoute)
+		require.NoError(t, err)
+		require.Len(t, updatedHTTPRoute.Spec.Rules, 2)
+		require.Len(t, updatedHTTPRoute.Spec.Rules[0].BackendRefs, 1)
+		require.Equal(t, "some-backend1", string(updatedHTTPRoute.Spec.Rules[0].BackendRefs[0].BackendRef.Name))
+		require.Equal(t, "apple.ns1", updatedHTTPRoute.Spec.Rules[0].Matches[0].Headers[0].Value)
+		require.Equal(t, "some-backend2", string(updatedHTTPRoute.Spec.Rules[1].BackendRefs[0].BackendRef.Name))
+		require.Equal(t, "orange.ns1", updatedHTTPRoute.Spec.Rules[1].Matches[0].Headers[0].Value)
+	})
+}
+
+func TestConfigSink_syncLLMBackend(t *testing.T) {
+	eventChan := make(chan configSinkEvent)
+	s := newConfigSink(nil, nil, logr.Discard(), eventChan)
+	s.syncLLMBackend(&aigv1a1.LLMBackend{ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"}})
+	require.Len(t, s.backends, 1)
+	require.NotNil(t, s.backends["apple.ns1"])
+}
+
+func TestConfigSink_deleteLLMRoute(t *testing.T) {
+	eventChan := make(chan configSinkEvent)
+	s := newConfigSink(nil, nil, logr.Discard(), eventChan)
+	s.httpRoutes = map[string]*gwapiv1.HTTPRoute{"route1.ns1": {}}
+	s.llmRoutes = map[string]*aigv1a1.LLMRoute{"route1.ns1": {}}
+
+	s.deleteLLMRoute(configSinkEventLLMRouteDeleted{namespace: "ns1", name: "route1"})
+	require.Empty(t, s.httpRoutes)
+	require.Empty(t, s.llmRoutes)
+}
+
+func TestConfigSink_deleteLLMBackend(t *testing.T) {
+	eventChan := make(chan configSinkEvent)
+	s := newConfigSink(nil, nil, logr.Discard(), eventChan)
+	s.backends = map[string]*aigv1a1.LLMBackend{"apple.ns1": {}}
+	s.backendsToReferencingRoutes = map[string]map[*aigv1a1.LLMRoute]struct{}{
+		"apple.ns1": {&aigv1a1.LLMRoute{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"}}: {}},
+	}
+
+	s.deleteLLMBackend(configSinkEventLLMBackendDeleted{namespace: "ns1", name: "apple"})
+	require.Empty(t, s.backends)
+	require.Empty(t, s.backendsToReferencingRoutes)
+}
+
+func Test_newHTTPRoute(t *testing.T) {
+	eventChan := make(chan configSinkEvent)
+	s := newConfigSink(nil, nil, logr.Discard(), eventChan)
+	httpRoute := &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"},
+		Spec:       gwapiv1.HTTPRouteSpec{},
+	}
+	llmRoute := &aigv1a1.LLMRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"},
+		Spec: aigv1a1.LLMRouteSpec{
+			Rules: []aigv1a1.LLMRouteRule{
+				{
+					BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{{Name: "apple", Weight: 100}},
+				},
+				{
+					BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{
+						{Name: "orange", Weight: 100},
+						{Name: "apple", Weight: 100},
+						{Name: "pineapple", Weight: 100},
+					},
+				},
+				{
+					BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{{Name: "foo", Weight: 1}},
+				},
+			},
+		},
+	}
+	s.backends = map[string]*aigv1a1.LLMBackend{
+		"apple.ns1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"},
+			Spec: aigv1a1.LLMBackendSpec{
+				BackendRef: egv1a1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+				},
+			},
+		},
+		"orange.ns1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: "ns1"},
+			Spec: aigv1a1.LLMBackendSpec{
+				BackendRef: egv1a1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+				},
+			},
+		},
+		"pineapple.ns1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "pineapple", Namespace: "ns1"},
+			Spec: aigv1a1.LLMBackendSpec{
+				BackendRef: egv1a1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+				},
+			},
+		},
+		"foo.ns1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns1"},
+			Spec: aigv1a1.LLMBackendSpec{
+				BackendRef: egv1a1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend4", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
+				},
+			},
+		},
+	}
+	err := s.newHTTPRoute(httpRoute, llmRoute)
+	require.NoError(t, err)
+
+	expRules := []gwapiv1.HTTPRouteRule{
+		{
+			Matches: []gwapiv1.HTTPRouteMatch{
+				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "apple.ns1"}}},
+			},
+			BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}}}},
+		},
+		{
+			Matches: []gwapiv1.HTTPRouteMatch{
+				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "orange.ns1"}}},
+			},
+			BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}}}},
+		},
+		{
+			Matches: []gwapiv1.HTTPRouteMatch{
+				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "pineapple.ns1"}}},
+			},
+			BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}}}},
+		},
+		{
+			Matches: []gwapiv1.HTTPRouteMatch{
+				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "foo.ns1"}}},
+			},
+			BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend4", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}}}},
+		},
+	}
+	require.Len(t, httpRoute.Spec.Rules, 4)
+	for i, r := range httpRoute.Spec.Rules {
+		t.Run(fmt.Sprintf("rule-%d", i), func(t *testing.T) {
+			require.Equal(t, expRules[i].Matches, r.Matches)
+			require.Equal(t, expRules[i].BackendRefs, r.BackendRefs)
+		})
+	}
+}
+
+func Test_updateExtProcConfigMap(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kube := fake2.NewClientset()
+
+	eventChan := make(chan configSinkEvent)
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan)
+	require.NotNil(t, s)
+
+	for _, tc := range []struct {
+		name  string
+		route *aigv1a1.LLMRoute
+		exp   *extprocconfig.Config
+	}{
+		{
+			name: "basic",
+			route: &aigv1a1.LLMRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "myroute", Namespace: "ns"},
+				Spec: aigv1a1.LLMRouteSpec{
+					APISchema: aigv1a1.LLMAPISchema{Schema: aigv1a1.APISchemaOpenAI, Version: "v123"},
+					Rules: []aigv1a1.LLMRouteRule{
+						{
+							BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{
+								{Name: "apple", Weight: 1},
+								{Name: "pineapple", Weight: 2},
+							},
+							Matches: []aigv1a1.LLMRouteRuleMatch{
+								{Headers: []gwapiv1.HTTPHeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "some-ai"}}},
+							},
+						},
+						{
+							BackendRefs: []aigv1a1.LLMRouteRuleBackendRef{{Name: "cat", Weight: 1}},
+							Matches: []aigv1a1.LLMRouteRuleMatch{
+								{Headers: []gwapiv1.HTTPHeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "another-ai"}}},
+							},
+						},
+					},
+				},
+			},
+			exp: &extprocconfig.Config{
+				InputSchema:              extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI, Version: "v123"},
+				ModelNameHeaderKey:       aigv1a1.LLMModelHeaderKey,
+				SelectedBackendHeaderKey: selectedBackendHeaderKey,
+				Rules: []extprocconfig.RouteRule{
+					{
+						Backends: []extprocconfig.Backend{{Name: "apple.ns", Weight: 1}, {Name: "pineapple.ns", Weight: 2}},
+						Headers:  []extprocconfig.HeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "some-ai"}},
+					},
+					{
+						Backends: []extprocconfig.Backend{{Name: "cat.ns", Weight: 1}},
+						Headers:  []extprocconfig.HeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "another-ai"}},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.kube.CoreV1().ConfigMaps(tc.route.Namespace).Create(context.Background(), &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: extProcName(tc.route), Namespace: tc.route.Namespace},
+			}, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			err = s.updateExtProcConfigMap(tc.route)
+			require.NoError(t, err)
+
+			cm, err := s.kube.CoreV1().ConfigMaps(tc.route.Namespace).Get(context.Background(), extProcName(tc.route), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, cm)
+
+			data := cm.Data[expProcConfigFileName]
+			var actual extprocconfig.Config
+			require.NoError(t, yaml.Unmarshal([]byte(data), &actual))
+			require.Equal(t, tc.exp, &actual)
+		})
+	}
+}

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -21,12 +21,12 @@ import (
 // processorConfig is the configuration for the processor.
 // This will be created by the server and passed to the processor when it detects a new configuration.
 type processorConfig struct {
-	bodyParser                                  router.RequestBodyParser
-	router                                      router.Router
-	ModelNameHeaderKey, backendRoutingHeaderKey string
-	factories                                   map[extprocconfig.VersionedAPISchema]translator.Factory
-	backendAuthHandlers                         map[string]backendauth.Handler
-	tokenUsageMetadata                          *extprocconfig.TokenUsageMetadata
+	bodyParser                                   router.RequestBodyParser
+	router                                       router.Router
+	ModelNameHeaderKey, selectedBackendHeaderKey string
+	factories                                    map[extprocconfig.VersionedAPISchema]translator.Factory
+	backendAuthHandlers                          map[string]backendauth.Handler
+	tokenUsageMetadata                           *extprocconfig.TokenUsageMetadata
 }
 
 // ProcessorIface is the interface for the processor.
@@ -101,7 +101,7 @@ func (p *Processor) ProcessRequestBody(_ context.Context, rawBody *extprocv3.Htt
 	headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
 		Header: &corev3.HeaderValue{Key: p.config.ModelNameHeaderKey, RawValue: []byte(model)},
 	}, &corev3.HeaderValueOption{
-		Header: &corev3.HeaderValue{Key: p.config.backendRoutingHeaderKey, RawValue: []byte(backendName)},
+		Header: &corev3.HeaderValue{Key: p.config.selectedBackendHeaderKey, RawValue: []byte(backendName)},
 	})
 
 	if authHandler, ok := p.config.backendAuthHandlers[backendName]; ok {

--- a/internal/extproc/processor_test.go
+++ b/internal/extproc/processor_test.go
@@ -155,8 +155,8 @@ func TestProcessor_ProcessRequestBody(t *testing.T) {
 			factories: map[extprocconfig.VersionedAPISchema]translator.Factory{
 				{Schema: "some-schema", Version: "v10.0"}: factory.impl,
 			},
-			backendRoutingHeaderKey: "x-ai-gateway-backend-key",
-			ModelNameHeaderKey:      "x-ai-gateway-model-key",
+			selectedBackendHeaderKey: "x-ai-gateway-backend-key",
+			ModelNameHeaderKey:       "x-ai-gateway-model-key",
 		}, requestHeaders: headers}
 		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{})
 		require.NoError(t, err)

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -65,11 +65,11 @@ func (s *Server[P]) LoadConfig(config *extprocconfig.Config) error {
 
 	newConfig := &processorConfig{
 		bodyParser: bodyParser, router: rt,
-		backendRoutingHeaderKey: config.BackendRoutingHeaderKey,
-		ModelNameHeaderKey:      config.ModelNameHeaderKey,
-		factories:               factories,
-		backendAuthHandlers:     backendAuthHandlers,
-		tokenUsageMetadata:      config.TokenUsageMetadata,
+		selectedBackendHeaderKey: config.SelectedBackendHeaderKey,
+		ModelNameHeaderKey:       config.ModelNameHeaderKey,
+		factories:                factories,
+		backendAuthHandlers:      backendAuthHandlers,
+		tokenUsageMetadata:       config.TokenUsageMetadata,
 	}
 	s.config = newConfig // This is racey, but we don't care.
 	return nil

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -36,10 +36,10 @@ func TestServer_LoadConfig(t *testing.T) {
 	})
 	t.Run("ok", func(t *testing.T) {
 		config := &extprocconfig.Config{
-			TokenUsageMetadata:      &extprocconfig.TokenUsageMetadata{Namespace: "ns", Key: "key"},
-			InputSchema:             extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
-			BackendRoutingHeaderKey: "x-backend-name",
-			ModelNameHeaderKey:      "x-model-name",
+			TokenUsageMetadata:       &extprocconfig.TokenUsageMetadata{Namespace: "ns", Key: "key"},
+			InputSchema:              extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+			SelectedBackendHeaderKey: "x-envoy-ai-gateway-selected-backend",
+			ModelNameHeaderKey:       "x-model-name",
 			Rules: []extprocconfig.RouteRule{
 				{
 					Backends: []extprocconfig.Backend{
@@ -76,7 +76,7 @@ func TestServer_LoadConfig(t *testing.T) {
 		require.Equal(t, "key", s.config.tokenUsageMetadata.Key)
 		require.NotNil(t, s.config.router)
 		require.NotNil(t, s.config.bodyParser)
-		require.Equal(t, "x-backend-name", s.config.backendRoutingHeaderKey)
+		require.Equal(t, "x-envoy-ai-gateway-selected-backend", s.config.selectedBackendHeaderKey)
 		require.Equal(t, "x-model-name", s.config.ModelNameHeaderKey)
 		require.Len(t, s.config.factories, 2)
 		require.NotNil(t, s.config.factories[extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}])

--- a/internal/extproc/watcher_test.go
+++ b/internal/extproc/watcher_test.go
@@ -44,7 +44,7 @@ func TestStartConfigWatcher(t *testing.T) {
 	cfg := `
 inputSchema:
   schema: OpenAI
-backendRoutingHeaderKey: x-backend-name
+selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
 modelNameHeaderKey: x-model-name
 rules:
 - backends:
@@ -84,7 +84,7 @@ rules:
 	cfg = `
 inputSchema:
   schema: OpenAI
-backendRoutingHeaderKey: x-backend-name
+selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
 modelNameHeaderKey: x-model-name
 rules:
 - backends:

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_llmroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_llmroutes.yaml
@@ -81,7 +81,7 @@ spec:
                   AI Gateway controller will generate a HTTPRoute based on the configuration given here with the additional
                   modifications to achieve the necessary jobs, notably inserting the AI Gateway external processor filter.
 
-                  In the matching conditions in the LLMRouteRule, `x-envoy-ai-gateway-llm-model` header is available
+                  In the matching conditions in the LLMRouteRule, `x-envoy-ai-gateway-model` header is available
                   if we want to describe the routing behavior based on the model name. The model name is extracted
                   from the request content before the routing decision.
 

--- a/tests/cel-validation/testdata/llmroutes/basic.yaml
+++ b/tests/cel-validation/testdata/llmroutes/basic.yaml
@@ -10,7 +10,7 @@ spec:
     - matches:
       - headers:
         - type: Exact
-          name: x-envoy-ai-gateway-llm-model
+          name: x-envoy-ai-gateway-model
           value: llama3-70b
       backendRefs:
         - name: kserve

--- a/tests/cel-validation/testdata/llmroutes/non_openai_schema.yaml
+++ b/tests/cel-validation/testdata/llmroutes/non_openai_schema.yaml
@@ -11,7 +11,7 @@ spec:
     - matches:
       - headers:
         - type: Exact
-          name: x-envoy-ai-gateway-llm-model
+          name: x-envoy-ai-gateway-model
           value: llama3-70b
       backendRefs:
         - name: kserve

--- a/tests/cel-validation/testdata/llmroutes/unknown_schema.yaml
+++ b/tests/cel-validation/testdata/llmroutes/unknown_schema.yaml
@@ -11,7 +11,7 @@ spec:
     - matches:
       - headers:
         - type: Exact
-          name: x-envoy-ai-gateway-llm-model
+          name: x-envoy-ai-gateway-model
           value: llama3-70b
       backendRefs:
         - name: kserve

--- a/tests/cel-validation/testdata/llmroutes/unsupported_match.yaml
+++ b/tests/cel-validation/testdata/llmroutes/unsupported_match.yaml
@@ -10,7 +10,7 @@ spec:
     - matches:
       - headers:
         - type: RegularExpression
-          name: x-envoy-ai-gateway-llm-model
+          name: x-envoy-ai-gateway-model
           value: llama3-70b
       backendRefs:
         - name: kserve

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -53,8 +53,8 @@ func TestE2E(t *testing.T) {
 		},
 		InputSchema: openAISchema,
 		// This can be any header key, but it must match the envoy.yaml routing configuration.
-		BackendRoutingHeaderKey: "x-selected-backend-name",
-		ModelNameHeaderKey:      "x-model-name",
+		SelectedBackendHeaderKey: "x-selected-backend-name",
+		ModelNameHeaderKey:       "x-model-name",
 		Rules: []extprocconfig.RouteRule{
 			{
 				Backends: []extprocconfig.Backend{{Name: "openai", OutputSchema: openAISchema}},


### PR DESCRIPTION
This commit adds the initial implementation of the resource 
management controllers. As per the official recommendation of
controller-runtime, the controller interface is implemented per
CRD. Therefore, this adds two typical "controller" one for LLMRoute
and another for LLMBackend.

In addition, this implements "configuration sink" which is the sync
mechanism across multiple resource events via Go channel. It has
the global view over all AI Gateway resources and hence have the 
full context required to create a final extproc configuration as well
as HTTPRoute. The following is the (very) simple diagram for the
relationship among k8s events, controllers and configSink.

k8s events --async--> {llmRouteCtrl, llmBackendCtrl, ...} --sinkEvent (sync)--> configSink


The followup PR will add the end to end tests.
