### PR TITLE
Add trivy image scan workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Build Controller Docker image
         run: |
@@ -37,7 +37,7 @@ jobs:
           vuln-type: 'os,library'
           exit-code: '1'  # Fail workflow on detected vulnerabilities
           ignore-unfixed: true  # Ignore unfixed vulnerabilities
-      
+
       - name: Run Trivy vulnerability scanner for Ext-Proc
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,34 +14,25 @@ jobs:
   image-scan:
     permissions:
       contents: read  # Required for actions/checkout to fetch code
-    name: Image Scan
+    name: Scan ${{ matrix.target.command_name }} Image
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        target:
+          - command_name: "controller"
+          - command_name: "extproc"
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
 
-      - name: Build Controller Docker image
+      - name: Build ${{ matrix.target.command_name }} Docker image
         run: |
-          make docker-build.controller TAG=${{ github.sha }}
+          make docker-build.${{ matrix.target.command_name }} TAG=${{ github.sha }}
 
-      - name: Build Ext-Proc Docker image
-        run: |
-          make docker-build.extproc TAG=${{ github.sha }}
-
-      - name: Run Trivy vulnerability scanner for Controller
+      - name: Run Trivy vulnerability scanner for ${{ matrix.target.command_name }}
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/envoyproxy/ai-gateway/controller:${{ github.sha }}
-          format: 'table'
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
-          vuln-type: 'os,library'
-          exit-code: '1'  # Fail workflow on detected vulnerabilities
-          ignore-unfixed: true  # Ignore unfixed vulnerabilities
-
-      - name: Run Trivy vulnerability scanner for Ext-Proc
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/envoyproxy/ai-gateway/extproc:${{ github.sha }}
+          image-ref: ghcr.io/envoyproxy/ai-gateway/${{ matrix.target.command_name }}:${{ github.sha }}
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
           vuln-type: 'os,library'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,49 @@
+name: Trivy
+
+on:
+  push:
+    branches:
+      - "main"
+  schedule:
+    - cron: '0 20 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  image-scan:
+    permissions:
+      contents: read  # Required for actions/checkout to fetch code
+    name: Image Scan
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  
+
+      - name: Build Controller Docker image
+        run: |
+          make docker-build.controller TAG=${{ github.sha }}
+
+      - name: Build Ext-Proc Docker image
+        run: |
+          make docker-build.extproc TAG=${{ github.sha }}
+
+      - name: Run Trivy vulnerability scanner for Controller
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/envoyproxy/ai-gateway/controller:${{ github.sha }}
+          format: 'table'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          vuln-type: 'os,library'
+          exit-code: '1'  # Fail workflow on detected vulnerabilities
+          ignore-unfixed: true  # Ignore unfixed vulnerabilities
+      
+      - name: Run Trivy vulnerability scanner for Ext-Proc
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/envoyproxy/ai-gateway/extproc:${{ github.sha }}
+          format: 'table'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          vuln-type: 'os,library'
+          exit-code: '1'  # Fail workflow on detected vulnerabilities
+          ignore-unfixed: true  # Ignore unfixed vulnerabilities


### PR DESCRIPTION
Introduced Trivy image vulnerabilities scan workflow

- This workflow is triggered on merges to the main branch and runs once daily (schedule can be adjusted if needed).

- It currently scans both the controller and extproc images.