### PR TITLE
Refactor controller args and logs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -14,7 +14,6 @@ var setupLog = ctrl.Log.WithName("setup")
 // DefaultOptions returns the default values for the program options.
 func DefaultOptions() controller.Options {
 	return controller.Options{
-		LogLevel:             "info",
 		ExtProcImage:         "ghcr.io/envoyproxy/ai-gateway-extproc:latest",
 		EnableLeaderElection: false,
 	}
@@ -23,7 +22,6 @@ func DefaultOptions() controller.Options {
 // GetOptions parses the program flags and returns them as Options.
 func GetOptions() controller.Options {
 	opts := DefaultOptions()
-	flag.StringVar(&opts.LogLevel, "logLevel", opts.LogLevel, "The log level")
 	flag.StringVar(&opts.ExtProcImage, "extprocImage", opts.ExtProcImage, "The image for the external processor")
 	flag.BoolVar(&opts.EnableLeaderElection, "leader-elect", opts.EnableLeaderElection,
 		"Enable leader election for controller manager. "+

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -11,17 +11,17 @@ import (
 
 var setupLog = ctrl.Log.WithName("setup")
 
-// DefaultOptions returns the default values for the program options.
-func DefaultOptions() controller.Options {
+// defaultOptions returns the default values for the program options.
+func defaultOptions() controller.Options {
 	return controller.Options{
 		ExtProcImage:         "ghcr.io/envoyproxy/ai-gateway-extproc:latest",
 		EnableLeaderElection: false,
 	}
 }
 
-// GetOptions parses the program flags and returns them as Options.
+// getOptions parses the program flags and returns them as Options.
 func getOptions() controller.Options {
-	opts := DefaultOptions()
+	opts := defaultOptions()
 	flag.StringVar(&opts.ExtProcImage, "extprocImage", opts.ExtProcImage, "The image for the external processor")
 	flag.BoolVar(&opts.EnableLeaderElection, "leader-elect", opts.EnableLeaderElection,
 		"Enable leader election for controller manager. "+

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,7 +20,7 @@ func DefaultOptions() controller.Options {
 }
 
 // GetOptions parses the program flags and returns them as Options.
-func GetOptions() controller.Options {
+func getOptions() controller.Options {
 	opts := DefaultOptions()
 	flag.StringVar(&opts.ExtProcImage, "extprocImage", opts.ExtProcImage, "The image for the external processor")
 	flag.BoolVar(&opts.EnableLeaderElection, "leader-elect", opts.EnableLeaderElection,
@@ -36,7 +36,7 @@ func GetOptions() controller.Options {
 }
 
 func main() {
-	options := GetOptions()
+	options := getOptions()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options.ZapOptions)))
 	k8sConfig, err := ctrl.GetConfig()
 	if err != nil {
@@ -45,7 +45,7 @@ func main() {
 
 	// TODO: starts the extension server?
 
-	if err := controller.StartControllers(k8sConfig, setupLog, options); err != nil {
+	if err := controller.StartControllers(ctrl.SetupSignalHandler(), k8sConfig, setupLog, options); err != nil {
 		setupLog.Error(err, "failed to start controller")
 	}
 }

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -30,13 +30,14 @@ func GetOptions() controller.Options {
 		Development: true,
 	}
 	zapOpts.BindFlags(flag.CommandLine)
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
+	opts.ZapOptions = zapOpts
 	flag.Parse()
 	return opts
 }
 
 func main() {
 	options := GetOptions()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options.ZapOptions)))
 	k8sConfig, err := ctrl.GetConfig()
 	if err != nil {
 		setupLog.Error(err, "failed to get k8s config")

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -40,6 +41,7 @@ func MustInitializeScheme(scheme *runtime.Scheme) {
 type Options struct {
 	ExtProcImage         string
 	EnableLeaderElection bool
+	ZapOptions           zap.Options
 }
 
 func newClients(config *rest.Config) (kubeClient client.Client, kube kubernetes.Interface, err error) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -38,7 +38,6 @@ func MustInitializeScheme(scheme *runtime.Scheme) {
 
 // Options defines the program configurable options that may be passed on the command line.
 type Options struct {
-	LogLevel             string
 	ExtProcImage         string
 	EnableLeaderElection bool
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -36,6 +36,13 @@ func MustInitializeScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(gwapiv1b1.Install(scheme))
 }
 
+// Options defines the program configurable options that may be passed on the command line.
+type Options struct {
+	LogLevel             string
+	ExtProcImage         string
+	EnableLeaderElection bool
+}
+
 func newClients(config *rest.Config) (kubeClient client.Client, kube kubernetes.Interface, err error) {
 	// TODO: cache options, especially HTTPRoutes managed by the AI Gateway.
 	kubeClient, err = client.New(config, client.Options{Scheme: scheme})
@@ -54,10 +61,10 @@ func newClients(config *rest.Config) (kubeClient client.Client, kube kubernetes.
 // This blocks until the manager is stopped.
 //
 // Note: this is tested with envtest, hence the test exists outside of this package. See /tests/controller_test.go.
-func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logger, logLevel string, extProcImage string, leaderElection bool) error {
+func StartControllers(config *rest.Config, logger logr.Logger, options Options) error {
 	opt := ctrl.Options{
 		Scheme:           scheme,
-		LeaderElection:   leaderElection,
+		LeaderElection:   options.EnableLeaderElection,
 		LeaderElectionID: "envoy-ai-gateway-controller",
 	}
 
@@ -72,7 +79,7 @@ func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logg
 	}
 
 	sinkChan := make(chan ConfigSinkEvent, 100)
-	routeC := NewLLMRouteController(clientForRouteC, kubeForRouteC, logger, logLevel, extProcImage, sinkChan)
+	routeC := NewLLMRouteController(clientForRouteC, kubeForRouteC, logger, options, sinkChan)
 	if err = ctrl.NewControllerManagedBy(mgr).
 		For(&aigv1a1.LLMRoute{}).
 		Complete(routeC); err != nil {
@@ -98,20 +105,15 @@ func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logg
 
 	sink := newConfigSink(clientForConfigSink, kubeForConfigSink, logger, sinkChan)
 
-	if leaderElection {
-		logger.Info("Waiting to become the leader")
-		<-mgr.Elected()
-		logger.Info("Became the leader")
-	}
-
 	// Before starting the manager, initialize the config sink to sync all LLMBackend and LLMRoute objects in the cluster.
 	logger.Info("Initializing config sink")
+	ctx := context.Background()
 	if err = sink.init(ctx); err != nil {
 		return fmt.Errorf("failed to initialize config sink: %w", err)
 	}
 
 	logger.Info("Starting controller manager")
-	if err = mgr.Start(ctx); err != nil { // This blocks until the manager is stopped.
+	if err = mgr.Start(ctrl.SetupSignalHandler()); err != nil { // This blocks until the manager is stopped.
 		return fmt.Errorf("failed to start controller manager: %w", err)
 	}
 	return nil

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -62,7 +62,7 @@ func newClients(config *rest.Config) (kubeClient client.Client, kube kubernetes.
 // This blocks until the manager is stopped.
 //
 // Note: this is tested with envtest, hence the test exists outside of this package. See /tests/controller_test.go.
-func StartControllers(config *rest.Config, logger logr.Logger, options Options) error {
+func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logger, options Options) error {
 	opt := ctrl.Options{
 		Scheme:           scheme,
 		LeaderElection:   options.EnableLeaderElection,
@@ -108,13 +108,12 @@ func StartControllers(config *rest.Config, logger logr.Logger, options Options) 
 
 	// Before starting the manager, initialize the config sink to sync all LLMBackend and LLMRoute objects in the cluster.
 	logger.Info("Initializing config sink")
-	ctx := context.Background()
 	if err = sink.init(ctx); err != nil {
 		return fmt.Errorf("failed to initialize config sink: %w", err)
 	}
 
 	logger.Info("Starting controller manager")
-	if err = mgr.Start(ctrl.SetupSignalHandler()); err != nil { // This blocks until the manager is stopped.
+	if err = mgr.Start(ctx); err != nil { // This blocks until the manager is stopped.
 		return fmt.Errorf("failed to start controller manager: %w", err)
 	}
 	return nil

--- a/internal/controller/llmroute.go
+++ b/internal/controller/llmroute.go
@@ -47,7 +47,6 @@ func NewLLMRouteController(
 		client:       client,
 		kube:         kube,
 		logger:       logger,
-		logLevel:     options.LogLevel,
 		extProcImage: options.ExtProcImage,
 		eventChan:    ch,
 	}

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -48,7 +48,7 @@ func TestStartControllers(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Minute))
 	defer cancel()
 	go func() {
-		err := controller.StartControllers(cfg, l, opts)
+		err := controller.StartControllers(ctx, cfg, l, opts)
 		require.NoError(t, err)
 	}()
 

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -39,14 +39,16 @@ func extProcName(llmRouteName string) string {
 // TestStartControllers tests the [controller.StartControllers] function.
 func TestStartControllers(t *testing.T) {
 	c, cfg, k := tests.NewEnvTest(t)
-
+	opts := controller.Options{
+		ExtProcImage:         "envoyproxy/ai-gateway-extproc:foo",
+		EnableLeaderElection: false,
+	}
 	l := logr.FromSlogHandler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{}))
 	klog.SetLogger(l)
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Minute))
 	defer cancel()
 	go func() {
-		err := controller.StartControllers(ctx, cfg, l, "debug",
-			"envoyproxy/ai-gateway-extproc:foo", false)
+		err := controller.StartControllers(cfg, l, opts)
 		require.NoError(t, err)
 	}()
 
@@ -197,9 +199,12 @@ func TestStartControllers(t *testing.T) {
 
 func TestLLMRouteController(t *testing.T) {
 	c, cfg, k := tests.NewEnvTest(t)
-
+	opts := controller.Options{
+		ExtProcImage:         "envoyproxy/ai-gateway-extproc:foo",
+		EnableLeaderElection: false,
+	}
 	ch := make(chan controller.ConfigSinkEvent)
-	rc := controller.NewLLMRouteController(c, k, logr.Discard(), "info", "foo", ch)
+	rc := controller.NewLLMRouteController(c, k, logr.Discard(), opts, ch)
 
 	opt := ctrl.Options{Scheme: c.Scheme(), LeaderElection: false, Controller: config.Controller{SkipNameValidation: ptr.To(true)}}
 	mgr, err := ctrl.NewManager(cfg, opt)


### PR DESCRIPTION
- Fixing the issue that logr is not initialized 
- Better debugging reconciliation issue

2025-01-13T00:06:18Z    ERROR   Reconciler error        {"controller": "llmroute", "controllerGroup": 
"aigateway.envoyproxy.io", "controllerKind": "LLMRoute", "LLMRoute": {"name":"llmroute","namespace":"gateway"}, 
"namespace": "gateway", "name": "llmroute", "reconcileID": "7c2497ba-9252-44cc-b06e-dc4854b454f4", "error": 
"failed to update extension policy: EnvoyExtensionPolicy.gateway.envoyproxy.io \"ai-gateway-llm-route-extproc-
llmroute\" is invalid: spec: Invalid value: \"object\": either targetRef or targetRefs must be used"}
```