### PR TITLE
Fix backend output schema in extproc configmap

### DIFF
--- a/cmd/extproc/main.go
+++ b/cmd/extproc/main.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	configPath = flag.String("configPath", "", "path to the configuration file. "+
-		"The file must be in YAML format speified in extprocconfig.Config type. The configuration file is watched for changes.")
+		"The file must be in YAML format specified in extprocconfig.Config type. The configuration file is watched for changes.")
 	// TODO: unix domain socket support.
 	extProcPort = flag.String("extProcPort", ":1063", "gRPC port for the external processor")
 	logLevel    = flag.String("logLevel", "info", "log level")


### PR DESCRIPTION
Fix following error with backend output schema is missing in the extproc config map 

time=2025-01-13T02:47:27.826Z level=INFO msg="starting external processor" version=bcf33a98b8df4293493e5f213f9fd7a753b36073
time=2025-01-13T02:47:27.828Z level=INFO msg="loading a new config" path=/etc/ai-gateway/extproc/extproc-config.yaml
2025/01/13 02:47:27 failed to start config watcher: failed to load initial config: cannot create translator factory: unsupported API schema combination: client={OpenAI }, backend={ }