### PR TITLE
Renames extprocconfig to filterconfig

### DIFF
--- a/filterconfig/filterconfig.go
+++ b/filterconfig/filterconfig.go
@@ -1,11 +1,13 @@
-// Package extprocconfig provides the configuration for the external processor.
-// This is a public package so that the external processor can be testable without
+// Package filterconfig provides the configuration for the AI Gateway-implemented filter
+// which is currently an external processor (See https://github.com/envoyproxy/ai-gateway/issues/90).
+//
+// This is a public package so that the filter can be testable without
 // depending on the Envoy Gateway as well as it can be used outside the Envoy AI Gateway.
 //
 // This configuration must be decoupled from the Envoy Gateway types as well as its implementation
 // details. Also, the configuration must not be tied with k8s so it can be tested and iterated
 // without the need for the k8s cluster.
-package extprocconfig
+package filterconfig
 
 import (
 	"os"
@@ -14,8 +16,8 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-// DefaultConfig is the default configuration for the external processor
-// that can be used as a fallback when the configuration is not explicitly provided.
+// DefaultConfig is the default configuration that can be used as a
+// fallback when the configuration is not explicitly provided.
 const DefaultConfig = `
 inputSchema:
   schema: OpenAI
@@ -23,9 +25,7 @@ selectedBackendHeaderKey: x-envoy-ai-gateway-selected-backend
 modelNameHeaderKey: x-envoy-ai-gateway-model
 `
 
-// Config is the configuration for the external processor.
-//
-// The configuration is loaded from a file path specified via the command line flag -configPath to the external processor.
+// Config is the configuration schema for the filter.
 //
 // # Example configuration:
 //
@@ -57,27 +57,27 @@ modelNameHeaderKey: x-envoy-ai-gateway-model
 //	  - name: x-envoy-ai-gateway-model
 //	    value: gpt4.4444
 //
-// where the input of the external processor is in the OpenAI schema, the model name is populated in the header x-envoy-ai-gateway-model,
+// where the input of the Gateway is in the OpenAI schema, the model name is populated in the header x-envoy-ai-gateway-model,
 // The model name header `x-envoy-ai-gateway-model` is used in the header matching to make the routing decision. **After** the routing decision is made,
 // the selected backend name is populated in the header `x-envoy-ai-gateway-selected-backend`. For example, when the model name is `llama3.3333`,
 // the request is routed to either backends `kserve` or `awsbedrock` with weights 1 and 10 respectively, and the selected
 // backend, say `awsbedrock`, is populated in the header `x-envoy-ai-gateway-selected-backend`.
 //
 // From Envoy configuration perspective, configuring the header matching based on `x-envoy-ai-gateway-selected-backend` is enough to route the request to the selected backend.
-// That is because the matching decision is made by the external processor and the selected backend is populated in the header `x-envoy-ai-gateway-selected-backend`.
+// That is because the matching decision is made by the filter and the selected backend is populated in the header `x-envoy-ai-gateway-selected-backend`.
 type Config struct {
 	// TokenUsageMetadata is the namespace and key to be used in the filter metadata to store the usage token, optional.
-	// If this is provided, the external processor will populate the usage token in the filter metadata at the end of the
+	// If this is provided, the filter will populate the usage token in the filter metadata at the end of the
 	// response body processing.
 	TokenUsageMetadata *TokenUsageMetadata `yaml:"tokenUsageMetadata,omitempty"`
-	// InputSchema specifies the API schema of the input format of requests to the external processor.
+	// InputSchema specifies the API schema of the input format of requests to the filter.
 	InputSchema VersionedAPISchema `yaml:"inputSchema"`
-	// ModelNameHeaderKey is the header key to be populated with the model name by the external processor.
+	// ModelNameHeaderKey is the header key to be populated with the model name by the filter.
 	ModelNameHeaderKey string `yaml:"modelNameHeaderKey"`
-	// SelectedBackendHeaderKey is the header key to be populated with the backend name by the external processor
-	// **after** the routing decision is made by the external processor using Rules.
+	// SelectedBackendHeaderKey is the header key to be populated with the backend name by the filter
+	// **after** the routing decision is made by the filter using Rules.
 	SelectedBackendHeaderKey string `yaml:"selectedBackendHeaderKey"`
-	// Rules is the routing rules to be used by the external processor to make the routing decision.
+	// Rules is the routing rules to be used by the filter to make the routing decision.
 	// Inside the routing rules, the header ModelNameHeaderKey may be used to make the routing decision.
 	Rules []RouteRule `yaml:"rules"`
 }

--- a/filterconfig/filterconfig_test.go
+++ b/filterconfig/filterconfig_test.go
@@ -1,4 +1,4 @@
-package extprocconfig_test
+package filterconfig_test
 
 import (
 	"log/slog"
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/extproc"
 )
 
@@ -18,8 +18,8 @@ func TestDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, server)
 
-	var cfg extprocconfig.Config
-	err = yaml.Unmarshal([]byte(extprocconfig.DefaultConfig), &cfg)
+	var cfg filterconfig.Config
+	err = yaml.Unmarshal([]byte(filterconfig.DefaultConfig), &cfg)
 	require.NoError(t, err)
 
 	err = server.LoadConfig(&cfg)
@@ -58,7 +58,7 @@ rules:
     value: gpt4.4444
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
-	cfg, err := extprocconfig.UnmarshalConfigYaml(configPath)
+	cfg, err := filterconfig.UnmarshalConfigYaml(configPath)
 	require.NoError(t, err)
 	require.Equal(t, "ai_gateway_llm_ns", cfg.TokenUsageMetadata.Namespace)
 	require.Equal(t, "token_usage_key", cfg.TokenUsageMetadata.Key)

--- a/internal/controller/llmroute.go
+++ b/internal/controller/llmroute.go
@@ -18,7 +18,7 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 const (
@@ -153,7 +153,7 @@ func (c *llmRouteController) ensuresExtProcConfigMapExists(ctx context.Context, 
 					Namespace:       llmRoute.Namespace,
 					OwnerReferences: ownerRef,
 				},
-				Data: map[string]string{expProcConfigFileName: extprocconfig.DefaultConfig},
+				Data: map[string]string{expProcConfigFileName: filterconfig.DefaultConfig},
 			}
 			_, err = c.kube.CoreV1().ConfigMaps(llmRoute.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
 			if err != nil {

--- a/internal/controller/llmroute_test.go
+++ b/internal/controller/llmroute_test.go
@@ -13,7 +13,7 @@ import (
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 func Test_extProcName(t *testing.T) {
@@ -40,7 +40,7 @@ func TestLLMRouteController_ensuresExtProcConfigMapExists(t *testing.T) {
 	require.Equal(t, extProcName(llmRoute), configMap.Name)
 	require.Equal(t, "default", configMap.Namespace)
 	require.Equal(t, ownerRef, configMap.OwnerReferences)
-	require.Equal(t, extprocconfig.DefaultConfig, configMap.Data[expProcConfigFileName])
+	require.Equal(t, filterconfig.DefaultConfig, configMap.Data[expProcConfigFileName])
 
 	// Doing it again should not fail.
 	err = c.ensuresExtProcConfigMapExists(context.Background(), llmRoute, ownerRef)

--- a/internal/controller/sink_test.go
+++ b/internal/controller/sink_test.go
@@ -21,7 +21,7 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 func TestConfigSink_init(t *testing.T) {
@@ -418,7 +418,7 @@ func Test_updateExtProcConfigMap(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		route *aigv1a1.LLMRoute
-		exp   *extprocconfig.Config
+		exp   *filterconfig.Config
 	}{
 		{
 			name: "basic",
@@ -445,20 +445,20 @@ func Test_updateExtProcConfigMap(t *testing.T) {
 					},
 				},
 			},
-			exp: &extprocconfig.Config{
-				InputSchema:              extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI, Version: "v123"},
+			exp: &filterconfig.Config{
+				InputSchema:              filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI, Version: "v123"},
 				ModelNameHeaderKey:       aigv1a1.LLMModelHeaderKey,
 				SelectedBackendHeaderKey: selectedBackendHeaderKey,
-				Rules: []extprocconfig.RouteRule{
+				Rules: []filterconfig.RouteRule{
 					{
-						Backends: []extprocconfig.Backend{
-							{Name: "apple.ns", Weight: 1, OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock}}, {Name: "pineapple.ns", Weight: 2},
+						Backends: []filterconfig.Backend{
+							{Name: "apple.ns", Weight: 1, OutputSchema: filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaAWSBedrock}}, {Name: "pineapple.ns", Weight: 2},
 						},
-						Headers: []extprocconfig.HeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "some-ai"}},
+						Headers: []filterconfig.HeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "some-ai"}},
 					},
 					{
-						Backends: []extprocconfig.Backend{{Name: "cat.ns", Weight: 1}},
-						Headers:  []extprocconfig.HeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "another-ai"}},
+						Backends: []filterconfig.Backend{{Name: "cat.ns", Weight: 1}},
+						Headers:  []filterconfig.HeaderMatch{{Name: aigv1a1.LLMModelHeaderKey, Value: "another-ai"}},
 					},
 				},
 			},
@@ -478,7 +478,7 @@ func Test_updateExtProcConfigMap(t *testing.T) {
 			require.NotNil(t, cm)
 
 			data := cm.Data[expProcConfigFileName]
-			var actual extprocconfig.Config
+			var actual filterconfig.Config
 			require.NoError(t, yaml.Unmarshal([]byte(data), &actual))
 			require.Equal(t, tc.exp, &actual)
 		})

--- a/internal/extproc/backendauth/auth.go
+++ b/internal/extproc/backendauth/auth.go
@@ -5,7 +5,7 @@ import (
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 // Handler is the interface that deals with the backend auth for a specific backend.
@@ -17,7 +17,7 @@ type Handler interface {
 }
 
 // NewHandler returns a new implementation of [Handler] based on the configuration.
-func NewHandler(config *extprocconfig.BackendAuth) (Handler, error) {
+func NewHandler(config *filterconfig.BackendAuth) (Handler, error) {
 	if config.AWSAuth != nil {
 		return newAWSHandler(config.AWSAuth)
 	}

--- a/internal/extproc/backendauth/aws.go
+++ b/internal/extproc/backendauth/aws.go
@@ -16,7 +16,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 // awsHandler implements [Handler] for AWS Bedrock authz.
@@ -26,7 +26,7 @@ type awsHandler struct {
 	region string
 }
 
-func newAWSHandler(_ *extprocconfig.AWSAuth) (*awsHandler, error) {
+func newAWSHandler(_ *filterconfig.AWSAuth) (*awsHandler, error) {
 	cfg, err := config.NewEnvConfig()
 	if err != nil {
 		return nil, fmt.Errorf("cannot create AWS config: %w", err)

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 )
@@ -99,12 +99,12 @@ type mockRouter struct {
 	t                     *testing.T
 	expHeaders            map[string]string
 	retBackendName        string
-	retVersionedAPISchema extprocconfig.VersionedAPISchema
+	retVersionedAPISchema filterconfig.VersionedAPISchema
 	retErr                error
 }
 
 // Calculate implements [router.Router.Calculate].
-func (m mockRouter) Calculate(headers map[string]string) (string, extprocconfig.VersionedAPISchema, error) {
+func (m mockRouter) Calculate(headers map[string]string) (string, filterconfig.VersionedAPISchema, error) {
 	require.Equal(m.t, m.expHeaders, headers)
 	return m.retBackendName, m.retVersionedAPISchema, m.retErr
 }

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -12,7 +12,7 @@ import (
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
@@ -24,9 +24,9 @@ type processorConfig struct {
 	bodyParser                                   router.RequestBodyParser
 	router                                       router.Router
 	ModelNameHeaderKey, selectedBackendHeaderKey string
-	factories                                    map[extprocconfig.VersionedAPISchema]translator.Factory
+	factories                                    map[filterconfig.VersionedAPISchema]translator.Factory
 	backendAuthHandlers                          map[string]backendauth.Handler
-	tokenUsageMetadata                           *extprocconfig.TokenUsageMetadata
+	tokenUsageMetadata                           *filterconfig.TokenUsageMetadata
 }
 
 // ProcessorIface is the interface for the processor.
@@ -185,7 +185,7 @@ func (p *Processor) ProcessResponseBody(_ context.Context, body *extprocv3.HttpB
 	return resp, nil
 }
 
-func buildTokenUsageDynamicMetadata(md *extprocconfig.TokenUsageMetadata, usage uint32) *structpb.Struct {
+func buildTokenUsageDynamicMetadata(md *filterconfig.TokenUsageMetadata, usage uint32) *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			md.Namespace: {

--- a/internal/extproc/router/request_body.go
+++ b/internal/extproc/router/request_body.go
@@ -6,7 +6,7 @@ import (
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 )
 
@@ -14,8 +14,8 @@ import (
 type RequestBodyParser func(path string, body *extprocv3.HttpBody) (modelName string, rb RequestBody, err error)
 
 // NewRequestBodyParser creates a new RequestBodyParser based on the schema.
-func NewRequestBodyParser(inputSchema extprocconfig.VersionedAPISchema) (RequestBodyParser, error) {
-	if inputSchema.Schema == extprocconfig.APISchemaOpenAI {
+func NewRequestBodyParser(inputSchema filterconfig.VersionedAPISchema) (RequestBodyParser, error) {
+	if inputSchema.Schema == filterconfig.APISchemaOpenAI {
 		return openAIParseBody, nil
 	}
 	return nil, fmt.Errorf("unsupported API schema: %s", inputSchema)

--- a/internal/extproc/router/request_body_test.go
+++ b/internal/extproc/router/request_body_test.go
@@ -7,18 +7,18 @@ import (
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 )
 
 func TestNewRequestBodyParser(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		res, err := NewRequestBodyParser(extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI})
+		res, err := NewRequestBodyParser(filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI})
 		require.NotNil(t, res)
 		require.NoError(t, err)
 	})
 	t.Run("error", func(t *testing.T) {
-		res, err := NewRequestBodyParser(extprocconfig.VersionedAPISchema{Schema: "foo"})
+		res, err := NewRequestBodyParser(filterconfig.VersionedAPISchema{Schema: "foo"})
 		require.Nil(t, res)
 		require.Error(t, err)
 	})

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -6,30 +6,30 @@ import (
 
 	"golang.org/x/exp/rand"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 // Router is the interface for the router.
 type Router interface {
 	// Calculate determines the backend to route to based on the headers.
 	// Returns the backend name and the output schema.
-	Calculate(headers map[string]string) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error)
+	Calculate(headers map[string]string) (backendName string, outputSchema filterconfig.VersionedAPISchema, err error)
 }
 
 // router implements [Router].
 type router struct {
-	rules []extprocconfig.RouteRule
+	rules []filterconfig.RouteRule
 	rng   *rand.Rand
 }
 
 // NewRouter creates a new [Router] implementation for the given config.
-func NewRouter(config *extprocconfig.Config) (Router, error) {
+func NewRouter(config *filterconfig.Config) (Router, error) {
 	return &router{rules: config.Rules, rng: rand.New(rand.NewSource(uint64(time.Now().UnixNano())))}, nil
 }
 
 // Calculate implements [Router.Calculate].
-func (r *router) Calculate(headers map[string]string) (backendName string, outputSchema extprocconfig.VersionedAPISchema, err error) {
-	var rule *extprocconfig.RouteRule
+func (r *router) Calculate(headers map[string]string) (backendName string, outputSchema filterconfig.VersionedAPISchema, err error) {
+	var rule *filterconfig.RouteRule
 	for i := range r.rules {
 		_rule := &r.rules[i]
 		for _, hdr := range _rule.Headers {
@@ -42,13 +42,13 @@ func (r *router) Calculate(headers map[string]string) (backendName string, outpu
 		}
 	}
 	if rule == nil {
-		return "", extprocconfig.VersionedAPISchema{}, errors.New("no matching rule found")
+		return "", filterconfig.VersionedAPISchema{}, errors.New("no matching rule found")
 	}
 	backendName, outputSchema = r.selectBackendFromRule(rule)
 	return
 }
 
-func (r *router) selectBackendFromRule(rule *extprocconfig.RouteRule) (backendName string, outputSchema extprocconfig.VersionedAPISchema) {
+func (r *router) selectBackendFromRule(rule *filterconfig.RouteRule) (backendName string, outputSchema filterconfig.VersionedAPISchema) {
 	// Each backend has a weight, so we randomly select depending on the weight.
 	// This is a pretty naive implementation and can be buggy, so fix it later.
 	totalWeight := 0

--- a/internal/extproc/router/router_test.go
+++ b/internal/extproc/router/router_test.go
@@ -5,27 +5,27 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 func TestRouter_Calculate(t *testing.T) {
-	outSchema := extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}
-	_r, err := NewRouter(&extprocconfig.Config{
-		Rules: []extprocconfig.RouteRule{
+	outSchema := filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI}
+	_r, err := NewRouter(&filterconfig.Config{
+		Rules: []filterconfig.RouteRule{
 			{
-				Backends: []extprocconfig.Backend{
+				Backends: []filterconfig.Backend{
 					{Name: "foo", OutputSchema: outSchema, Weight: 1},
 					{Name: "bar", OutputSchema: outSchema, Weight: 3},
 				},
-				Headers: []extprocconfig.HeaderMatch{
+				Headers: []filterconfig.HeaderMatch{
 					{Name: "x-model-name", Value: "llama3.3333"},
 				},
 			},
 			{
-				Backends: []extprocconfig.Backend{
+				Backends: []filterconfig.Backend{
 					{Name: "openai", OutputSchema: outSchema},
 				},
-				Headers: []extprocconfig.HeaderMatch{
+				Headers: []filterconfig.HeaderMatch{
 					{Name: "x-model-name", Value: "gpt4.4444"},
 				},
 			},
@@ -63,15 +63,15 @@ func TestRouter_Calculate(t *testing.T) {
 }
 
 func TestRouter_selectBackendFromRule(t *testing.T) {
-	_r, err := NewRouter(&extprocconfig.Config{})
+	_r, err := NewRouter(&filterconfig.Config{})
 	require.NoError(t, err)
 	r, ok := _r.(*router)
 	require.True(t, ok)
 
-	outSchema := extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}
+	outSchema := filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI}
 
-	rule := &extprocconfig.RouteRule{
-		Backends: []extprocconfig.Backend{
+	rule := &filterconfig.RouteRule{
+		Backends: []filterconfig.Backend{
 			{Name: "foo", OutputSchema: outSchema, Weight: 1},
 			{Name: "bar", OutputSchema: outSchema, Weight: 3},
 		},

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
@@ -32,7 +32,7 @@ func NewServer[P ProcessorIface](logger *slog.Logger, newProcessor func(*process
 }
 
 // LoadConfig updates the configuration of the external processor.
-func (s *Server[P]) LoadConfig(config *extprocconfig.Config) error {
+func (s *Server[P]) LoadConfig(config *filterconfig.Config) error {
 	bodyParser, err := router.NewRequestBodyParser(config.InputSchema)
 	if err != nil {
 		return fmt.Errorf("cannot create request body parser: %w", err)
@@ -42,7 +42,7 @@ func (s *Server[P]) LoadConfig(config *extprocconfig.Config) error {
 		return fmt.Errorf("cannot create router: %w", err)
 	}
 
-	factories := make(map[extprocconfig.VersionedAPISchema]translator.Factory)
+	factories := make(map[filterconfig.VersionedAPISchema]translator.Factory)
 	backendAuthHandlers := make(map[string]backendauth.Handler)
 	for _, r := range config.Rules {
 		for _, b := range r.Backends {

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 func requireNewServerWithMockProcessor(t *testing.T) *Server[*mockProcessor] {
@@ -28,25 +28,25 @@ func requireNewServerWithMockProcessor(t *testing.T) *Server[*mockProcessor] {
 func TestServer_LoadConfig(t *testing.T) {
 	t.Run("invalid input schema", func(t *testing.T) {
 		s := requireNewServerWithMockProcessor(t)
-		err := s.LoadConfig(&extprocconfig.Config{
-			InputSchema: extprocconfig.VersionedAPISchema{Schema: "some-invalid-schema"},
+		err := s.LoadConfig(&filterconfig.Config{
+			InputSchema: filterconfig.VersionedAPISchema{Schema: "some-invalid-schema"},
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "cannot create request body parser")
 	})
 	t.Run("ok", func(t *testing.T) {
-		config := &extprocconfig.Config{
-			TokenUsageMetadata:       &extprocconfig.TokenUsageMetadata{Namespace: "ns", Key: "key"},
-			InputSchema:              extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+		config := &filterconfig.Config{
+			TokenUsageMetadata:       &filterconfig.TokenUsageMetadata{Namespace: "ns", Key: "key"},
+			InputSchema:              filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI},
 			SelectedBackendHeaderKey: "x-envoy-ai-gateway-selected-backend",
 			ModelNameHeaderKey:       "x-model-name",
-			Rules: []extprocconfig.RouteRule{
+			Rules: []filterconfig.RouteRule{
 				{
-					Backends: []extprocconfig.Backend{
-						{Name: "kserve", OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}},
-						{Name: "awsbedrock", OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock}},
+					Backends: []filterconfig.Backend{
+						{Name: "kserve", OutputSchema: filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI}},
+						{Name: "awsbedrock", OutputSchema: filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaAWSBedrock}},
 					},
-					Headers: []extprocconfig.HeaderMatch{
+					Headers: []filterconfig.HeaderMatch{
 						{
 							Name:  "x-model-name",
 							Value: "llama3.3333",
@@ -54,10 +54,10 @@ func TestServer_LoadConfig(t *testing.T) {
 					},
 				},
 				{
-					Backends: []extprocconfig.Backend{
-						{Name: "openai", OutputSchema: extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}},
+					Backends: []filterconfig.Backend{
+						{Name: "openai", OutputSchema: filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI}},
 					},
-					Headers: []extprocconfig.HeaderMatch{
+					Headers: []filterconfig.HeaderMatch{
 						{
 							Name:  "x-model-name",
 							Value: "gpt4.4444",
@@ -79,8 +79,8 @@ func TestServer_LoadConfig(t *testing.T) {
 		require.Equal(t, "x-envoy-ai-gateway-selected-backend", s.config.selectedBackendHeaderKey)
 		require.Equal(t, "x-model-name", s.config.ModelNameHeaderKey)
 		require.Len(t, s.config.factories, 2)
-		require.NotNil(t, s.config.factories[extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI}])
-		require.NotNil(t, s.config.factories[extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock}])
+		require.NotNil(t, s.config.factories[filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI}])
+		require.NotNil(t, s.config.factories[filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaAWSBedrock}])
 	})
 }
 

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -8,7 +8,7 @@ import (
 	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 )
 
@@ -19,13 +19,13 @@ import (
 type Factory func(path string) (Translator, error)
 
 // NewFactory returns a callback function that creates a translator for the given API schema combination.
-func NewFactory(in, out extprocconfig.VersionedAPISchema) (Factory, error) {
-	if in.Schema == extprocconfig.APISchemaOpenAI {
+func NewFactory(in, out filterconfig.VersionedAPISchema) (Factory, error) {
+	if in.Schema == filterconfig.APISchemaOpenAI {
 		// TODO: currently, we ignore the LLMAPISchema."Version" field.
 		switch out.Schema {
-		case extprocconfig.APISchemaOpenAI:
+		case filterconfig.APISchemaOpenAI:
 			return newOpenAIToOpenAITranslator, nil
-		case extprocconfig.APISchemaAWSBedrock:
+		case filterconfig.APISchemaAWSBedrock:
 			return newOpenAIToAWSBedrockTranslator, nil
 		}
 	}

--- a/internal/extproc/translator/translator_test.go
+++ b/internal/extproc/translator/translator_test.go
@@ -5,21 +5,21 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 func TestNewFactory(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		_, err := NewFactory(
-			extprocconfig.VersionedAPISchema{Schema: "Foo", Version: "v100"},
-			extprocconfig.VersionedAPISchema{Schema: "Bar", Version: "v123"},
+			filterconfig.VersionedAPISchema{Schema: "Foo", Version: "v100"},
+			filterconfig.VersionedAPISchema{Schema: "Bar", Version: "v123"},
 		)
 		require.ErrorContains(t, err, "unsupported API schema combination: client={Foo v100}, backend={Bar v123}")
 	})
 	t.Run("openai to openai", func(t *testing.T) {
 		f, err := NewFactory(
-			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
-			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
+			filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI},
+			filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI},
 		)
 		require.NoError(t, err)
 		require.NotNil(t, f)
@@ -32,8 +32,8 @@ func TestNewFactory(t *testing.T) {
 	})
 	t.Run("openai to aws bedrock", func(t *testing.T) {
 		f, err := NewFactory(
-			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaOpenAI},
-			extprocconfig.VersionedAPISchema{Schema: extprocconfig.APISchemaAWSBedrock},
+			filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaOpenAI},
+			filterconfig.VersionedAPISchema{Schema: filterconfig.APISchemaAWSBedrock},
 		)
 		require.NoError(t, err)
 		require.NotNil(t, f)

--- a/internal/extproc/watcher.go
+++ b/internal/extproc/watcher.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
-// ConfigReceiver is an interface that can receive *extprocconfig.Config updates.
+// ConfigReceiver is an interface that can receive *filterconfig.Config updates.
 type ConfigReceiver interface {
 	// LoadConfig updates the configuration.
-	LoadConfig(config *extprocconfig.Config) error
+	LoadConfig(config *filterconfig.Config) error
 }
 
 type configWatcher struct {
@@ -66,7 +66,7 @@ func (cw *configWatcher) loadConfig() error {
 	}
 	cw.lastMod = stat.ModTime()
 	cw.l.Info("loading a new config", slog.String("path", cw.path))
-	cfg, err := extprocconfig.UnmarshalConfigYaml(cw.path)
+	cfg, err := filterconfig.UnmarshalConfigYaml(cw.path)
 	if err != nil {
 		return err
 	}

--- a/internal/extproc/watcher_test.go
+++ b/internal/extproc/watcher_test.go
@@ -10,24 +10,24 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/envoyproxy/ai-gateway/extprocconfig"
+	"github.com/envoyproxy/ai-gateway/filterconfig"
 )
 
 // mockReceiver is a mock implementation of Receiver.
 type mockReceiver struct {
-	cfg *extprocconfig.Config
+	cfg *filterconfig.Config
 	mux sync.Mutex
 }
 
 // LoadConfig implements ConfigReceiver.
-func (m *mockReceiver) LoadConfig(cfg *extprocconfig.Config) error {
+func (m *mockReceiver) LoadConfig(cfg *filterconfig.Config) error {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 	m.cfg = cfg
 	return nil
 }
 
-func (m *mockReceiver) getConfig() *extprocconfig.Config {
+func (m *mockReceiver) getConfig() *filterconfig.Config {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 	return m.cfg


### PR DESCRIPTION
Per #90, we will migrate to dynamic modules in the second or third version of
AI Gateway, the public configuration package must not be coupled with
extproc (see the description in the issue). This renames `extprocconfig`
to more generic (and accurate) name as `filterconfig`.
