### PR TITLE
feat: support option for continuous monitoring token usage in streaming response

### DIFF
--- a/filterconfig/filterconfig.go
+++ b/filterconfig/filterconfig.go
@@ -71,6 +71,13 @@ type Config struct {
 	// LLMRequestCost configures the cost of each LLM-related request. Optional. If this is provided, the filter will populate
 	// the "calculated" cost in the filter metadata at the end of the response body processing.
 	LLMRequestCosts []LLMRequestCost `json:"llmRequestCosts,omitempty"`
+	// MonitorContinuousUsageStats flag controls if external process monitors every response-body chunk for usage stats
+	// when true, it will monitor for token metadata usage in every response-body chunk received during request in streaming mode
+	// compatible with vllm's 'continuous_usage_stats' flag
+	// when false, it will stop monitoring after detecting token metadata usage after finding it for the first time.
+	// compatible with OpenAI's streaming response (https://platform.openai.com/docs/api-reference/chat/streaming#chat/streaming-usage)
+	// Only affects request in streaming mode
+	MonitorContinuousUsageStats bool `yaml:"monitorContinuousUsageStats,omitempty"`
 	// InputSchema specifies the API schema of the input format of requests to the filter.
 	Schema VersionedAPISchema `json:"schema"`
 	// ModelNameHeaderKey is the header key to be populated with the model name by the filter.

--- a/filterconfig/filterconfig_test.go
+++ b/filterconfig/filterconfig_test.go
@@ -74,6 +74,7 @@ rules:
 	require.Equal(t, "OpenAI", string(cfg.Schema.Name))
 	require.Equal(t, "x-ai-eg-selected-backend", cfg.SelectedBackendHeaderKey)
 	require.Equal(t, "x-ai-eg-model", cfg.ModelNameHeaderKey)
+
 	require.Len(t, cfg.Rules, 2)
 	require.Equal(t, "llama3.3333", cfg.Rules[0].Headers[0].Value)
 	require.Equal(t, "gpt4.4444", cfg.Rules[1].Headers[0].Value)

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -246,6 +246,7 @@ func (p *Processor) maybeBuildDynamicMetadata() (*structpb.Struct, error) {
 	if len(metadata) == 0 {
 		return nil, nil
 	}
+
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			p.config.metadataNamespace: {

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -50,7 +50,7 @@ func (s *Server[P]) LoadConfig(config *filterconfig.Config) error {
 	for _, r := range config.Rules {
 		for _, b := range r.Backends {
 			if _, ok := factories[b.Schema]; !ok {
-				factories[b.Schema], err = translator.NewFactory(config.Schema, b.Schema)
+				factories[b.Schema], err = translator.NewFactory(config.Schema, b.Schema, config.MonitorContinuousUsageStats)
 				if err != nil {
 					return fmt.Errorf("cannot create translator factory: %w", err)
 				}

--- a/internal/extproc/translator/openai_awsbedrock.go
+++ b/internal/extproc/translator/openai_awsbedrock.go
@@ -555,7 +555,6 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(respHeaders 
 	if err := json.NewDecoder(body).Decode(&bedrockResp); err != nil {
 		return nil, nil, tokenUsage, fmt.Errorf("failed to unmarshal body: %w", err)
 	}
-
 	openAIResp := openai.ChatCompletionResponse{
 		Object:  "chat.completion",
 		Choices: make([]openai.ChatCompletionResponseChoice, 0, len(bedrockResp.Output.Message.Content)),

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -35,12 +35,12 @@ func isGoodStatusCode(code int) bool {
 type Factory func(path string) (Translator, error)
 
 // NewFactory returns a callback function that creates a translator for the given API schema combination.
-func NewFactory(in, out filterconfig.VersionedAPISchema) (Factory, error) {
+func NewFactory(in, out filterconfig.VersionedAPISchema, monitorContinuousUsageStats bool) (Factory, error) {
 	if in.Name == filterconfig.APISchemaOpenAI {
 		// TODO: currently, we ignore the LLMAPISchema."Version" field.
 		switch out.Name {
 		case filterconfig.APISchemaOpenAI:
-			return newOpenAIToOpenAITranslator, nil
+			return newOpenAIToOpenAITranslatorFactory(monitorContinuousUsageStats), nil
 		case filterconfig.APISchemaAWSBedrock:
 			return newOpenAIToAWSBedrockTranslator, nil
 		}

--- a/internal/extproc/translator/translator_test.go
+++ b/internal/extproc/translator/translator_test.go
@@ -13,6 +13,7 @@ func TestNewFactory(t *testing.T) {
 		_, err := NewFactory(
 			filterconfig.VersionedAPISchema{Name: "Foo", Version: "v100"},
 			filterconfig.VersionedAPISchema{Name: "Bar", Version: "v123"},
+			false,
 		)
 		require.ErrorContains(t, err, "unsupported API schema combination: client={Foo v100}, backend={Bar v123}")
 	})
@@ -20,6 +21,7 @@ func TestNewFactory(t *testing.T) {
 		f, err := NewFactory(
 			filterconfig.VersionedAPISchema{Name: filterconfig.APISchemaOpenAI},
 			filterconfig.VersionedAPISchema{Name: filterconfig.APISchemaOpenAI},
+			false,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, f)
@@ -34,6 +36,7 @@ func TestNewFactory(t *testing.T) {
 		f, err := NewFactory(
 			filterconfig.VersionedAPISchema{Name: filterconfig.APISchemaOpenAI},
 			filterconfig.VersionedAPISchema{Name: filterconfig.APISchemaAWSBedrock},
+			false,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, f)


### PR DESCRIPTION
Currently only total_tokens usage from response body are pushed to dynamicMetadata. This PR updates that logic to include input and output token usage as well.

This PR also introduces `monitorContinuousUsageStats` flag in config for external process
The flag controls if external process monitors every response-body chunk for usage stats
when true, it will monitor for token metadata usage in every response-body chunk received during request in streaming mode (compatible with vllm's 'continuous_usage_stats' flag)
when false, it will stop monitoring after detecting token metadata usage after finding it for the first time.
(compatible with OpenAI's streaming response (https://platform.openai.com/docs/api-reference/chat/streaming#chat/streaming-usage))
Only affects request in streaming mode