### PR TITLE
api: Use gwapiv1.BackendObjectReference instread of unstable EG one

### DIFF
--- a/api/v1alpha1/api.go
+++ b/api/v1alpha1/api.go
@@ -223,7 +223,7 @@ type AIServiceBackendSpec struct {
 	// This is required to be set.
 	//
 	// +kubebuilder:validation:Required
-	BackendRef egv1a1.BackendRef `json:"backendRef"`
+	BackendRef gwapiv1.BackendObjectReference `json:"backendRef"`
 
 	// BackendSecurityPolicyRef is the name of the BackendSecurityPolicy resources this backend
 	// is being attached to.

--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -229,7 +229,7 @@ func (c *configSink) newHTTPRoute(dst *gwapiv1.HTTPRoute, aiGatewayRoute *aigv1a
 		key := fmt.Sprintf("%s.%s", b.Name, b.Namespace)
 		rule := gwapiv1.HTTPRouteRule{
 			BackendRefs: []gwapiv1.HTTPBackendRef{
-				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: b.Spec.BackendRef.BackendObjectReference}},
+				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: b.Spec.BackendRef}},
 			},
 			Matches: []gwapiv1.HTTPRouteMatch{
 				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: key}}},
@@ -244,7 +244,7 @@ func (c *configSink) newHTTPRoute(dst *gwapiv1.HTTPRoute, aiGatewayRoute *aigv1a
 			{Path: &gwapiv1.HTTPPathMatch{Value: ptr.To("/")}},
 		},
 		BackendRefs: []gwapiv1.HTTPBackendRef{
-			{BackendRef: gwapiv1.BackendRef{BackendObjectReference: backends[0].Spec.BackendRef.BackendObjectReference}},
+			{BackendRef: gwapiv1.BackendRef{BackendObjectReference: backends[0].Spec.BackendRef}},
 		},
 	})
 

--- a/internal/controller/sink_test.go
+++ b/internal/controller/sink_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -42,10 +41,10 @@ func TestConfigSink_syncAIGatewayRoute(t *testing.T) {
 
 	for _, backend := range []*aigv1a1.AIServiceBackend{
 		{ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"}, Spec: aigv1a1.AIServiceBackendSpec{
-			BackendRef: egv1a1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}},
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 		}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: "ns1"}, Spec: aigv1a1.AIServiceBackendSpec{
-			BackendRef: egv1a1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")}},
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 		}},
 	} {
 		err := fakeClient.Create(context.Background(), backend, &client.CreateOptions{})
@@ -137,33 +136,25 @@ func Test_newHTTPRoute(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"},
 			Spec: aigv1a1.AIServiceBackendSpec{
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: "ns1"},
 			Spec: aigv1a1.AIServiceBackendSpec{
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "pineapple", Namespace: "ns1"},
 			Spec: aigv1a1.AIServiceBackendSpec{
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns1"},
 			Spec: aigv1a1.AIServiceBackendSpec{
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend4", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend4", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 			},
 		},
 	} {
@@ -227,25 +218,19 @@ func Test_updateExtProcConfigMap(t *testing.T) {
 				APISchema: aigv1a1.VersionedAPISchema{
 					Schema: aigv1a1.APISchemaAWSBedrock,
 				},
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns")},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "cat", Namespace: "ns"},
 			Spec: aigv1a1.AIServiceBackendSpec{
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns")},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "pineapple", Namespace: "ns"},
 			Spec: aigv1a1.AIServiceBackendSpec{
-				BackendRef: egv1a1.BackendRef{
-					BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns")},
-				},
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: ptr.To[gwapiv1.Namespace]("ns")},
 			},
 		},
 	} {

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aiservicebackends.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aiservicebackends.yaml
@@ -55,15 +55,6 @@ spec:
 
                   This is required to be set.
                 properties:
-                  fallback:
-                    description: |-
-                      Fallback indicates whether the backend is designated as a fallback.
-                      Multiple fallback backends can be configured.
-                      It is highly recommended to configure active or passive health checks to ensure that failover can be detected
-                      when the active backends become unhealthy and to automatically readjust once the primary backends are healthy again.
-                      The overprovisioning factor is set to 1.4, meaning the fallback backends will only start receiving traffic when
-                      the health of the active backends falls below 72%.
-                    type: boolean
                   group:
                     default: ""
                     description: |-

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -60,10 +60,10 @@ func TestStartControllers(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: backend, Namespace: "default"},
 				Spec: aigv1a1.AIServiceBackendSpec{
 					APISchema: defaultSchema,
-					BackendRef: egv1a1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+					BackendRef: gwapiv1.BackendObjectReference{
 						Name: gwapiv1.ObjectName(backend),
 						Port: ptr.To[gwapiv1.PortNumber](8080),
-					}},
+					},
 				},
 			})
 			require.NoError(t, err)
@@ -372,10 +372,10 @@ func TestAIServiceBackendController(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "mybackend", Namespace: "default"},
 			Spec: aigv1a1.AIServiceBackendSpec{
 				APISchema: defaultSchema,
-				BackendRef: egv1a1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+				BackendRef: gwapiv1.BackendObjectReference{
 					Name: gwapiv1.ObjectName("mybackend"),
 					Port: ptr.To[gwapiv1.PortNumber](8080),
-				}},
+				},
 			},
 		}
 		err := c.Create(ctx, origin)


### PR DESCRIPTION
Previously, ` egv1a1.BackendRef` was used for referencing 
backends from AIServiceBacked. However, that's unnecessary
indirection from `gwapiv1.BackendObjectReference` because
the former is basically a wrapper of the latter with unused field.

Basically this removes the unnecessary field from the CRD and 
therefore simplifies the implementation.