### PR TITLE
api: adds cel validation on requiring at least one targetRefs

### DIFF
--- a/api/v1alpha1/api.go
+++ b/api/v1alpha1/api.go
@@ -42,9 +42,9 @@ type AIGatewayRouteList struct {
 type AIGatewayRouteSpec struct {
 	// TargetRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
 	//
-	// +optional
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=128
-	TargetRefs []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName `json:"targetRefs,omitempty"`
+	TargetRefs []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName `json:"targetRefs"`
 	// APISchema specifies the API schema of the input that the target Gateway(s) will receive.
 	// Based on this schema, the ai-gateway will perform the necessary transformation to the
 	// output schema specified in the selected AIServiceBackend during the routing process.

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -355,10 +355,12 @@ spec:
                   - name
                   type: object
                 maxItems: 128
+                minItems: 1
                 type: array
             required:
             - inputSchema
             - rules
+            - targetRefs
             type: object
         type: object
     served: true

--- a/tests/cel-validation/main_test.go
+++ b/tests/cel-validation/main_test.go
@@ -41,6 +41,10 @@ func TestAIGatewayRoutes(t *testing.T) {
 			name:   "unsupported_match.yaml",
 			expErr: "spec.rules[0].matches[0].headers: Invalid value: \"array\": currently only exact match is supported",
 		},
+		{
+			name:   "no_target_refs.yaml",
+			expErr: `spec.targetRefs: Invalid value: 0: spec.targetRefs in body should have at least 1 items`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			data, err := testdata.ReadFile(path.Join("testdata/aigatewayroutes", tc.name))

--- a/tests/cel-validation/testdata/aigatewayroutes/basic.yaml
+++ b/tests/cel-validation/testdata/aigatewayroutes/basic.yaml
@@ -4,6 +4,10 @@ metadata:
   name: apple
   namespace: default
 spec:
+  targetRefs:
+    - name: some-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
   inputSchema:
     schema: OpenAI
   rules:

--- a/tests/cel-validation/testdata/aigatewayroutes/no_target_refs.yaml
+++ b/tests/cel-validation/testdata/aigatewayroutes/no_target_refs.yaml
@@ -4,13 +4,9 @@ metadata:
   name: apple
   namespace: default
 spec:
-  targetRefs:
-    - name: some-gateway
-      kind: Gateway
-      group: gateway.networking.k8s.io
+  targetRefs: []
   inputSchema:
-    # Input must be OpenAI schema at the moment, so this is invalid.
-    schema: AWSBedrock
+    schema: OpenAI
   rules:
     - matches:
       - headers:

--- a/tests/cel-validation/testdata/aigatewayroutes/unknown_schema.yaml
+++ b/tests/cel-validation/testdata/aigatewayroutes/unknown_schema.yaml
@@ -4,6 +4,10 @@ metadata:
   name: apple
   namespace: default
 spec:
+  targetRefs:
+    - name: some-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
   inputSchema:
     # Schema must be OpenAI schema at the moment, so this is invalid.
     schema: SomeRandomVendor

--- a/tests/cel-validation/testdata/aigatewayroutes/unsupported_match.yaml
+++ b/tests/cel-validation/testdata/aigatewayroutes/unsupported_match.yaml
@@ -4,6 +4,10 @@ metadata:
   name: apple
   namespace: default
 spec:
+  targetRefs:
+    - name: some-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
   inputSchema:
     schema: OpenAI
   rules:


### PR DESCRIPTION
Previously targetRefs can be empty. However, in reality,
such AIGatewayRoute is useless while making it necessary
for controller to handle the edge case. This sets the CEL
validation rule to require at least one TargeRefs to exist.
