### PR TITLE
build: fixes multi-platform docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,14 +199,13 @@ build.%:
 # - `make docker-build.extproc_custom_router CMD_PATH_PREFIX=examples`
 # - `make docker-build.testupstream CMD_PATH_PREFIX=tests`
 .PHONY: docker-build.%
+ifeq ($(ENABLE_MULTI_PLATFORMS),true)
+docker-build.%: GOARCH_LIST = amd64 arm64
+docker-build.%: PLATFORMS = --platform linux/amd64,linux/arm64
+endif
 docker-build.%:
 	$(eval COMMAND_NAME := $(subst docker-build.,,$@))
-	@if [ "$(ENABLE_MULTI_PLATFORMS)" = "true" ]; then \
-		GOARCH_LIST="amd64 arm64"; PLATFORMS="--platform linux/amd64,linux/arm64"; \
-	else \
-		GOARCH_LIST="$(shell go env GOARCH)"; PLATFORMS=""; \
-	fi
-	@$(MAKE) build.$(COMMAND_NAME) GOOS_LIST="linux"
+	@$(MAKE) build.$(COMMAND_NAME) GOOS_LIST="linux" GOARCH_LIST="$(GOARCH_LIST)"
 	docker buildx build . -t $(OCI_REGISTRY)/$(COMMAND_NAME):$(TAG) --build-arg COMMAND_NAME=$(COMMAND_NAME) $(PLATFORMS) $(DOCKER_BUILD_ARGS)
 
 # This builds docker images for all commands under cmd/ directory. All options for `docker-build.%` apply.


### PR DESCRIPTION
Fixes the multi-platform Docker build (see as an example [this build](https://github.com/envoyproxy/ai-gateway/actions/runs/12820298883/job/35749679784) only building for the current arch/platform). The main issue was that inside the docker target, the `PLATFORMS` and `GOARCH_LIST` variables were set as shell variables (at target execution time), but they were expected to be Makefile variables (target definition time) by the docker target.

This PR fixes it by properly defining the values as target-scoped variables, to avoid them interfering in other targets).

Before:
```
$  make docker-build.extproc ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"
-> Building extproc for linux/amd64
<- Built out/extproc-linux-amd64
make[1]: Leaving directory '/home/runner/work/ai-gateway/ai-gateway'
docker buildx build . -t ghcr.io/envoyproxy/ai-gateway/extproc:latest --build-arg COMMAND_NAME=extproc  --push
```
After:
```
$ make docker-build.extproc ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"
-> Building extproc for linux/amd64
<- Built out/extproc-linux-amd64
-> Building extproc for linux/arm64
<- Built out/extproc-linux-arm64
make[1]: Leaving directory '/home/runner/work/ai-gateway/ai-gateway'
docker buildx build . -t ghcr.io/envoyproxy/ai-gateway/extproc:latest --build-arg COMMAND_NAME=extproc --platform linux/amd64,linux/arm64 --push
 ```
