### PR TITLE
translator: support the developer role in Bedrock translator

### DIFF
--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -58,6 +58,13 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 						}, Type: openai.ChatMessageRoleSystem,
 					},
 					{
+						Value: openai.ChatCompletionDeveloperMessageParam{
+							Content: openai.StringOrArray{
+								Value: "from-developer",
+							},
+						}, Type: openai.ChatMessageRoleDeveloper,
+					},
+					{
 						Value: openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
@@ -85,6 +92,9 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				System: []*awsbedrock.SystemContentBlock{
 					{
 						Text: "from-system",
+					},
+					{
+						Text: "from-developer",
 					},
 				},
 				Messages: []*awsbedrock.Message{
@@ -131,6 +141,15 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 						}, Type: openai.ChatMessageRoleSystem,
 					},
 					{
+						Value: openai.ChatCompletionDeveloperMessageParam{
+							Content: openai.StringOrArray{
+								Value: []openai.ChatCompletionContentPartTextParam{
+									{Text: "from-developer"},
+								},
+							},
+						}, Type: openai.ChatMessageRoleDeveloper,
+					},
+					{
 						Value: openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: []openai.ChatCompletionContentPartUserUnionParam{
@@ -164,6 +183,9 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				System: []*awsbedrock.SystemContentBlock{
 					{
 						Text: "from-system",
+					},
+					{
+						Text: "from-developer",
 					},
 				},
 				Messages: []*awsbedrock.Message{


### PR DESCRIPTION
This is a follow-up PR for: https://github.com/envoyproxy/ai-gateway/pull/117#issuecomment-2598396168

I think it makes sense to do the same conversions and set it as "system"? The "developer" role is a replacement for "system" in OpenAI, so it should be fine?