### PR TITLE
extproc: allow configuring an UDS listen address

### DIFF
--- a/cmd/extproc/mainlib/main_test.go
+++ b/cmd/extproc/mainlib/main_test.go
@@ -1,0 +1,27 @@
+package mainlib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenAddress(t *testing.T) {
+	tests := []struct {
+		addr        string
+		wantNetwork string
+		wantAddress string
+	}{
+		{"", "tcp", defaultAddress},
+		{":8080", "tcp", ":8080"},
+		{"unix:///var/run/ai-gateway/extproc.sock", "unix", "/var/run/ai-gateway/extproc.sock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			network, address := listenAddress(tt.addr)
+			assert.Equal(t, tt.wantNetwork, network)
+			assert.Equal(t, tt.wantAddress, address)
+		})
+	}
+}


### PR DESCRIPTION
Allows configuring extproc to listen on an Unix domain socket. Note that this PR just enables it in the extproc filter. Follow-up PRs will be needed to accommodate that in the controller as well, but that would require further changes to how the Gateway itself (not only the filter) is deployed, to mount a common volume for the UDS.