### PR TITLE
extproc: load APIKey on load time

### DIFF
--- a/internal/extproc/backendauth/api_key.go
+++ b/internal/extproc/backendauth/api_key.go
@@ -12,26 +12,23 @@ import (
 
 // apiKeyHandler implements [Handler] for api key authz.
 type apiKeyHandler struct {
-	fileName string
+	apiKey string
 }
 
-func NewAPIKeyHandler(auth *filterconfig.APIKeyAuth) (Handler, error) {
-	return &apiKeyHandler{
-		fileName: auth.Filename,
-	}, nil
+func newAPIKeyHandler(auth *filterconfig.APIKeyAuth) (Handler, error) {
+	secret, err := os.ReadFile(auth.Filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read api key file: %w", err)
+	}
+	return &apiKeyHandler{apiKey: string(secret)}, nil
 }
 
 // Do implements [Handler.Do].
 //
 // Extracts the api key from the local file and set it as an authorization header.
 func (a *apiKeyHandler) Do(requestHeaders map[string]string, headerMut *extprocv3.HeaderMutation, _ *extprocv3.BodyMutation) error {
-	// TODO: Stop reading a file on request path.
-	secret, err := os.ReadFile(a.fileName)
-	if err != nil {
-		return err
-	}
 
-	requestHeaders["Authorization"] = fmt.Sprintf("Bearer %s", string(secret))
+	requestHeaders["Authorization"] = fmt.Sprintf("Bearer %s", a.apiKey)
 	headerMut.SetHeaders = append(headerMut.SetHeaders, &corev3.HeaderValueOption{
 		Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte(requestHeaders["Authorization"])},
 	})

--- a/internal/extproc/backendauth/api_key.go
+++ b/internal/extproc/backendauth/api_key.go
@@ -27,7 +27,6 @@ func newAPIKeyHandler(auth *filterconfig.APIKeyAuth) (Handler, error) {
 //
 // Extracts the api key from the local file and set it as an authorization header.
 func (a *apiKeyHandler) Do(requestHeaders map[string]string, headerMut *extprocv3.HeaderMutation, _ *extprocv3.BodyMutation) error {
-
 	requestHeaders["Authorization"] = fmt.Sprintf("Bearer %s", a.apiKey)
 	headerMut.SetHeaders = append(headerMut.SetHeaders, &corev3.HeaderValueOption{
 		Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte(requestHeaders["Authorization"])},

--- a/internal/extproc/backendauth/api_key_test.go
+++ b/internal/extproc/backendauth/api_key_test.go
@@ -12,8 +12,17 @@ import (
 )
 
 func TestNewAPIKeyHandler(t *testing.T) {
-	auth := filterconfig.APIKeyAuth{Filename: "test"}
-	handler, err := NewAPIKeyHandler(&auth)
+	apiKeyFile := t.TempDir() + "/test"
+
+	f, err := os.Create(apiKeyFile)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+	_, err = f.WriteString("test")
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+
+	auth := filterconfig.APIKeyAuth{Filename: apiKeyFile}
+	handler, err := newAPIKeyHandler(&auth)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 }
@@ -23,16 +32,13 @@ func TestApiKeyHandler_Do(t *testing.T) {
 
 	f, err := os.Create(apiKeyFile)
 	require.NoError(t, err)
-
+	defer func() { require.NoError(t, f.Close()) }()
 	_, err = f.WriteString("test")
 	require.NoError(t, err)
-	err = f.Sync()
-	require.NoError(t, err)
-	err = f.Close()
-	require.NoError(t, err)
+	require.NoError(t, f.Sync())
 
 	auth := filterconfig.APIKeyAuth{Filename: apiKeyFile}
-	handler, err := NewAPIKeyHandler(&auth)
+	handler, err := newAPIKeyHandler(&auth)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 

--- a/internal/extproc/backendauth/auth.go
+++ b/internal/extproc/backendauth/auth.go
@@ -21,7 +21,7 @@ func NewHandler(config *filterconfig.BackendAuth) (Handler, error) {
 	if config.AWSAuth != nil {
 		return newAWSHandler(config.AWSAuth)
 	} else if config.APIKey != nil {
-		return NewAPIKeyHandler(config.APIKey)
+		return newAPIKeyHandler(config.APIKey)
 	}
 	return nil, errors.New("no backend auth handler found")
 }


### PR DESCRIPTION
**Commit Message**:

Previously, the API was read on the request path,
which is left to be fixed and left as TODO in #125.
This fixes it and makes extproc load the APIKey
at the config load time.

**Related Issues/PRs (if applicable)**:

Follow up on #125 

<!--
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
Please make sure that at least `make precommit test` passes before submitting the PR as ready for review.
If there's anything you're unsure about, please ensure the PR is marked as a draft. For example,
draft PRs would be ideal for discussing the approach to a problem or the design of a feature.

Also, please make sure that you can check off all the items on the checklist below.

Otherwise, you might unnecessarily consume the time of the maintainers unless there's
a specific reason for not doing so.

**Checklist**:
- [ ] The PR title follows the same format as the merged PRs.
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) (for first-time contributors).
- [ ] I have made sure that `make precommit test` passes locally.
- [ ] I have written tests for any new line of code unless there's existing tests that cover the changes.
- [ ] I have updated the documentation accordingly.
- [ ] I am sure the coding style is consistent with the rest of the codebase.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
-->
