### PR TITLE
examples: adds token rate limit

### DIFF
--- a/examples/token_ratelimit/README.md
+++ b/examples/token_ratelimit/README.md
@@ -1,0 +1,4 @@
+This example demonstrates how to use the token rate limit feature of the AI Gateway.
+This utilizes the Global Rate Limit API of Envoy Gateway combined with the
+AI Gateway's `llmRequestCosts` configuration to capture the consumed tokens
+of each request.

--- a/examples/token_ratelimit/token_ratelimit.yaml
+++ b/examples/token_ratelimit/token_ratelimit.yaml
@@ -1,0 +1,141 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-ai-gateway-token-ratelimit
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-ai-gateway-token-ratelimit
+  namespace: default
+spec:
+  gatewayClassName: envoy-ai-gateway-token-ratelimit
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: envoy-ai-gateway-token-ratelimit
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  targetRefs:
+    - name: envoy-ai-gateway-token-ratelimit
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: gpt-4o-mini
+      backendRefs:
+        - name: envoy-ai-gateway-token-ratelimit-testupstream
+          weight: 100
+  # The following metadata keys are used to store the costs from the LLM request.
+  llmRequestCosts:
+  - metadataKey: llm_input_token
+    type: InputToken
+  - metadataKey: llm_output_token
+    type: OutputToken
+  - metadataKey: llm_total_token
+    type: TotalToken
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIServiceBackend
+metadata:
+  name: envoy-ai-gateway-token-ratelimit-testupstream
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    name: testupstream
+    kind: Service
+    port: 80
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: envoy-ai-gateway-token-ratelimit-policy
+  namespace: default
+spec:
+  # Applies the rate limit policy to the gateway.
+  targetRefs:
+    - name: envoy-ai-gateway-token-ratelimit
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rateLimit:
+    type: Global
+    global:
+      rules:
+        # This configures the input token limit, and it has a different budget than others,
+        # so it will be rate limited separately.
+        - clientSelectors:
+            - headers:
+                # Have the rate limit budget be per unique "x-user-id" header value.
+                - name: x-user-id
+                  type: Distinct
+          limit:
+            # Configures the number of "tokens" allowed per hour, per user.
+            requests: 10
+            unit: Hour
+          cost:
+            request:
+              from: Number
+              # Setting the request cost to zero allows to only check the rate limit budget,
+              # and not consume the budget on the request path.
+              number: 0
+            response:
+              from: Metadata
+              metadata:
+                # This is the fixed namespace for the metadata used by AI Gateway.
+                namespace: io.envoy.ai_gateway
+                # Limit on the input token.
+                key: llm_input_token
+
+        # Repeat the same configuration for a different token type.
+        # This configures the output token limit, and it has a different budget than others,
+        # so it will be rate limited separately.
+        - clientSelectors:
+            - headers:
+                - name: x-user-id
+                  type: Distinct
+          limit:
+            requests: 100
+            unit: Hour
+          cost:
+            request:
+              from: Number
+              number: 0
+            response:
+              from: Metadata
+              metadata:
+                namespace: io.envoy.ai_gateway
+                key: llm_output_token
+
+        # Repeat the same configuration for a different token type.
+        # This configures the total token limit, and it has a different budget than others,
+        # so it will be rate limited separately.
+        - clientSelectors:
+            - headers:
+                - name: x-user-id
+                  type: Distinct
+          limit:
+            requests: 1000
+            unit: Hour
+          cost:
+            request:
+              from: Number
+              number: 0
+            response:
+              from: Metadata
+              metadata:
+                namespace: io.envoy.ai_gateway
+                key: llm_total_token

--- a/examples/token_ratelimit/token_ratelimit.yaml
+++ b/examples/token_ratelimit/token_ratelimit.yaml
@@ -40,12 +40,12 @@ spec:
           weight: 100
   # The following metadata keys are used to store the costs from the LLM request.
   llmRequestCosts:
-  - metadataKey: llm_input_token
-    type: InputToken
-  - metadataKey: llm_output_token
-    type: OutputToken
-  - metadataKey: llm_total_token
-    type: TotalToken
+    - metadataKey: llm_input_token
+      type: InputToken
+    - metadataKey: llm_output_token
+      type: OutputToken
+    - metadataKey: llm_total_token
+      type: TotalToken
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIServiceBackend

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -219,6 +219,7 @@ func (p *Processor) maybeBuildDynamicMetadata() (*structpb.Struct, error) {
 		default:
 			return nil, fmt.Errorf("unknown request cost kind: %s", c.Type)
 		}
+		p.logger.Info("Setting request cost metadata", "type", c.Type, "cost", cost, "metadataKey", c.MetadataKey)
 		metadata[c.MetadataKey] = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(cost)}}
 	}
 	if len(metadata) == 0 {

--- a/internal/extproc/processor_test.go
+++ b/internal/extproc/processor_test.go
@@ -65,7 +65,7 @@ func TestProcessor_ProcessResponseBody(t *testing.T) {
 			retBodyMutation: expBodyMut, retHeaderMutation: expHeadMut,
 			retUsedToken: translator.LLMTokenUsage{OutputTokens: 123, InputTokens: 1},
 		}
-		p := &Processor{translator: mt, config: &processorConfig{
+		p := &Processor{translator: mt, logger: slog.Default(), config: &processorConfig{
 			metadataNamespace: "ai_gateway_llm_ns",
 			requestCosts: []filterconfig.LLMRequestCost{
 				{Type: filterconfig.LLMRequestCostTypeOutputToken, MetadataKey: "output_token_usage"},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -60,6 +60,11 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	if err := initRateLimitServer(ctx); err != nil {
+		cancel()
+		panic(err)
+	}
+
 	code := m.Run()
 	cancel()
 	os.Exit(code)
@@ -178,6 +183,24 @@ func initTestupstream(ctx context.Context) (err error) {
 	}
 	initLog("\twaiting for deployment")
 	return kubectlWaitForDeploymentReady("default", "testupstream")
+}
+
+func initRateLimitServer(ctx context.Context) (err error) {
+	initLog("Installing Redis for Rate limits")
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		initLog(fmt.Sprintf("\tdone (took %.2fs in total)\n", elapsed.Seconds()))
+	}()
+	initLog("\tapplying manifests")
+	if err = kubectlApplyManifest(ctx, "./init/ratelimit/"); err != nil {
+		return
+	}
+	initLog("\twaiting for deployment")
+	if err := kubectlWaitForDeploymentReady("redis-system", "redis"); err != nil {
+		return err
+	}
+	return kubectlWaitForDeploymentReady("envoy-gateway-system", "envoy-ratelimit")
 }
 
 func kubectl(ctx context.Context, args ...string) *exec.Cmd {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	egLatest      = "v0.0.0-latest" // This defaults to the latest dev version.
 	egNamespace   = "envoy-gateway-system"
 	egDefaultPort = 10080
 )
@@ -25,7 +26,7 @@ var egVersion = func() string {
 	if v, ok := os.LookupEnv("EG_VERSION"); ok {
 		return v
 	} else {
-		return "v0.0.0-latest" // This defaults to the latest dev version.
+		return egLatest
 	}
 }()
 

--- a/tests/e2e/init/envoygateway/config.yaml
+++ b/tests/e2e/init/envoygateway/config.yaml
@@ -21,8 +21,6 @@ data:
     provider:
       kubernetes:
         rateLimitDeployment:
-          container:
-            image: docker.io/envoyproxy/ratelimit:master
           patch:
             type: StrategicMerge
             value:
@@ -32,8 +30,14 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+                      image: docker.io/envoyproxy/ratelimit:60d8e81b
       type: Kubernetes
     extensionApis:
       enableEnvoyPatchPolicy: true
       enableBackend: true
+    rateLimit:
+      backend:
+        type: Redis
+        redis:
+          url: redis.redis-system.svc.cluster.local:6379
 ---

--- a/tests/e2e/init/ratelimit/radis.yaml
+++ b/tests/e2e/init/ratelimit/radis.yaml
@@ -1,0 +1,43 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: redis-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: redis-system 
+  labels:
+    app: redis
+spec:
+  ports:
+    - name: redis
+      port: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: redis-system 
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - image: redis:alpine
+          imagePullPolicy: IfNotPresent
+          name: redis
+          ports:
+            - name: redis
+              containerPort: 6379
+      restartPolicy: Always

--- a/tests/e2e/init/ratelimit/redis.yaml
+++ b/tests/e2e/init/ratelimit/redis.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: redis-system 
+  namespace: redis-system
   labels:
     app: redis
 spec:
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
-  namespace: redis-system 
+  namespace: redis-system
 spec:
   replicas: 1
   selector:

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func Test_Examples_TokenRateLimit(t *testing.T) {
+	if egVersion != egLatest {
+		t.Skip("TODO: enable this by default after v1.3.0rc1 is released")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -7,14 +7,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/openai/openai-go"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Examples_TokenRateLimit(t *testing.T) {

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -1,0 +1,85 @@
+//go:build test_e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_Examples_TokenRateLimit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	const manifest = "../../examples/token_ratelimit/token_ratelimit.yaml"
+	require.NoError(t, kubectlApplyManifest(ctx, manifest))
+
+	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-token-ratelimit"
+	requireWaitForPodReady(t, egNamespace, egSelector)
+
+	fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+	defer fwd.kill()
+
+	makeRequest := func(usedID string, input, output, total int, expStatus int) {
+		requestBody := fmt.Sprintf(`{"messages":[{"role":"user","content":"Say this is a test"}],"model":"gpt-4o-mini"}`)
+
+		const fakeResponseBodyTemplate = `{"choices":[{"message":{"content":"This is a test.","role":"assistant"}}],"stopReason":null,"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`
+		fakeResponseBody := fmt.Sprintf(fakeResponseBodyTemplate, input, output, total)
+
+		req, err := http.NewRequest(http.MethodPut, fwd.address()+"/v1/chat/completions", strings.NewReader(requestBody))
+		require.NoError(t, err)
+		req.Header.Set("x-response-body", base64.StdEncoding.EncodeToString([]byte(fakeResponseBody)))
+		req.Header.Set("x-expected-path", base64.StdEncoding.EncodeToString([]byte("/v1/chat/completions")))
+		req.Header.Set("x-user-id", usedID)
+		req.Header.Set("Host", "openai.com")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		for key, values := range resp.Header {
+			t.Logf("key: %s, values: %v\n", key, values)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusOK {
+			var oaiBody openai.ChatCompletion
+			require.NoError(t, json.Unmarshal(body, &oaiBody))
+			// Sanity check the fake response is correctly parsed.
+			require.Equal(t, "This is a test.", oaiBody.Choices[0].Message.Content)
+			require.Equal(t, int64(input), oaiBody.Usage.PromptTokens)
+			require.Equal(t, int64(output), oaiBody.Usage.CompletionTokens)
+			require.Equal(t, int64(total), oaiBody.Usage.TotalTokens)
+		}
+		require.Equal(t, expStatus, resp.StatusCode)
+	}
+
+	// Test the input token limit.
+	baseID := int(time.Now().UnixNano()) // To avoid collision with previous runs.
+	usedID := strconv.Itoa(baseID)
+	makeRequest(usedID, 10000, 0, 0, 200)
+	makeRequest(usedID, 1, 0, 0, 429)
+
+	// Test the output token limit.
+	usedID = strconv.Itoa(baseID + 1)
+	makeRequest(usedID, 0, 20, 0, 200) // This output number exceeds the input limit, but should still be allowed.
+	makeRequest(usedID, 0, 10000, 0, 200)
+	makeRequest(usedID, 0, 1, 0, 429)
+
+	// Test the total token limit.
+	usedID = strconv.Itoa(baseID + 2)
+	makeRequest(usedID, 0, 0, 20, 200)  // This total number exceeds the input limit, but should still be allowed.
+	makeRequest(usedID, 0, 0, 200, 200) // This total number exceeds the output limit, but should still be allowed.
+	makeRequest(usedID, 0, 0, 1000000, 200)
+	makeRequest(usedID, 0, 0, 1, 429)
+}

--- a/tests/e2e/translation_testupstream_test.go
+++ b/tests/e2e/translation_testupstream_test.go
@@ -20,9 +20,6 @@ func TestTranslationWithTestUpstream(t *testing.T) {
 
 	const manifest = "testdata/translation_testupstream.yaml"
 	require.NoError(t, kubectlApplyManifest(ctx, manifest))
-	defer func() {
-		// require.NoError(t, kubectlDeleteManifest(context.Background(), manifest))
-	}()
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=translation-testupstream"
 	requireWaitForPodReady(t, egNamespace, egSelector)


### PR DESCRIPTION
**Commit Message**:

This adds the example that demonstrates how to use
token based rate limit per unique user-id. Basically,
this utilizes the latest Envoy Gateway's request
cost features.

