### PR TITLE
test: fixes flake during waiting for ratelimit server

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -234,6 +234,12 @@ func kubectlRestartDeployment(ctx context.Context, namespace, deployment string)
 
 func kubectlWaitForDeploymentReady(namespace, deployment string) (err error) {
 	cmd := kubectl(context.Background(), "wait", "--timeout=2m", "-n", namespace,
+		"deployment/"+deployment, "--for=create")
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("error waiting for deployment %s in namespace %s: %w", deployment, namespace, err)
+	}
+
+	cmd = kubectl(context.Background(), "wait", "--timeout=2m", "-n", namespace,
 		"deployment/"+deployment, "--for=condition=Available")
 	if err = cmd.Run(); err != nil {
 		return fmt.Errorf("error waiting for deployment %s in namespace %s: %w", deployment, namespace, err)


### PR DESCRIPTION
**Commit Message**:

This fixes the flake during waiting for ratelimit server
is up in the end-to-end test.

**Related Issues/PRs (if applicable)**:

This is a follow up on #171 