### PR TITLE
test: fixes flake of examples/basic e2e

### DIFF
--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -42,9 +42,6 @@ func Test_Examples_Basic(t *testing.T) {
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-basic"
 	requireWaitForPodReady(t, egNamespace, egSelector)
 
-	fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
-	defer fwd.kill()
-
 	t.Run("/chat/completions", func(t *testing.T) {
 		for _, tc := range []struct {
 			name      string
@@ -61,6 +58,9 @@ func Test_Examples_Basic(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				require.Eventually(t, func() bool {
+					fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+					defer fwd.kill()
+
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					defer cancel()
 

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -32,10 +32,10 @@ func Test_Examples_TokenRateLimit(t *testing.T) {
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-token-ratelimit"
 	requireWaitForPodReady(t, egNamespace, egSelector)
 
-	fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
-	defer fwd.kill()
-
 	makeRequest := func(usedID string, input, output, total int, expStatus int) {
+		fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+		defer fwd.kill()
+
 		requestBody := fmt.Sprintf(`{"messages":[{"role":"user","content":"Say this is a test"}],"model":"gpt-4o-mini"}`)
 
 		const fakeResponseBodyTemplate = `{"choices":[{"message":{"content":"This is a test.","role":"assistant"}}],"stopReason":null,"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`

--- a/tests/e2e/translation_testupstream_test.go
+++ b/tests/e2e/translation_testupstream_test.go
@@ -24,9 +24,6 @@ func TestTranslationWithTestUpstream(t *testing.T) {
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=translation-testupstream"
 	requireWaitForPodReady(t, egNamespace, egSelector)
 
-	fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
-	defer fwd.kill()
-
 	t.Run("/chat/completions", func(t *testing.T) {
 		for _, tc := range []struct {
 			name              string
@@ -55,6 +52,9 @@ func TestTranslationWithTestUpstream(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				require.Eventually(t, func() bool {
+					fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+					defer fwd.kill()
+
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					defer cancel()
 


### PR DESCRIPTION
**Commit Message**:

This fixes or mitigates a flake of examples/basic
end to end test by re-creating the connection inside
the require-eventually-loop.
