### PR TITLE
ci: fixes dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,5 @@ updates:
       golang.org:
         patterns:
           - "golang.org/*"
-ignore:
-  - dependency-name: "github.com/envoyproxy/gateway"
+    ignore:
+      - dependency-name: "github.com/envoyproxy/gateway"


### PR DESCRIPTION
**Commit Message**:

This fixes the placement of `ignore` section
in dependabot.yml.

**Related Issues/PRs (if applicable)**:

Follow up on #174 
