### PR TITLE
chore: updates the old package names

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	configPath = flag.String("configPath", "", "path to the configuration file. "+
-		"The file must be in YAML format specified in extprocconfig.Config type. The configuration file is watched for changes.")
+		"The file must be in YAML format specified in filterconfig.Config type. The configuration file is watched for changes.")
 	extProcAddr = flag.String("extProcAddr", defaultAddress, "gRPC address for the external processor")
 	logLevel    = flag.String("logLevel", defaultLogLevel, "log level")
 )

--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -39,7 +39,7 @@ type ConfigSinkEvent any
 
 // configSink centralizes the AIGatewayRoute and AIServiceBackend objects handling
 // which requires to be done in a single goroutine since we need to
-// consolidate the information from both objects to generate the ExtProcConfig
+// consolidate the information from both objects to generate the ExtProc ConfigMap
 // and HTTPRoute objects.
 type configSink struct {
 	client                        client.Client

--- a/tests/extproc/custom_extproc_test.go
+++ b/tests/extproc/custom_extproc_test.go
@@ -24,7 +24,7 @@ func TestExtProcCustomRouter(t *testing.T) {
 	requireRunEnvoy(t, "/dev/null")
 	requireTestUpstream(t)
 	configPath := t.TempDir() + "/extproc-config.yaml"
-	requireWriteExtProcConfig(t, configPath, &filterconfig.Config{
+	requireWriteFilterConfig(t, configPath, &filterconfig.Config{
 		Schema: openAISchema,
 		// This can be any header key, but it must match the envoy.yaml routing configuration.
 		SelectedBackendHeaderKey: "x-selected-backend-name",

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -93,8 +93,8 @@ func getEnvVarOrSkip(t *testing.T, envVar string) string {
 	return value
 }
 
-// requireWriteExtProcConfig writes the provided config to the configPath in YAML format.
-func requireWriteExtProcConfig(t *testing.T, configPath string, config *filterconfig.Config) {
+// requireWriteFilterConfig writes the provided [filterconfig.Config] to the configPath in YAML format.
+func requireWriteFilterConfig(t *testing.T, configPath string, config *filterconfig.Config) {
 	configBytes, err := yaml.Marshal(config)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(configPath, configBytes, 0o600))

--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -58,7 +58,7 @@ func TestWithRealProviders(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, awsFile.Sync())
 
-	requireWriteExtProcConfig(t, configPath, &filterconfig.Config{
+	requireWriteFilterConfig(t, configPath, &filterconfig.Config{
 		MetadataNamespace: "ai_gateway_llm_ns",
 		LLMRequestCosts: []filterconfig.LLMRequestCost{
 			{MetadataKey: "used_token", Type: filterconfig.LLMRequestCostTypeInputToken},

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -28,7 +28,7 @@ func TestWithTestUpstream(t *testing.T) {
 	configPath := t.TempDir() + "/extproc-config.yaml"
 	requireTestUpstream(t)
 
-	requireWriteExtProcConfig(t, configPath, &filterconfig.Config{
+	requireWriteFilterConfig(t, configPath, &filterconfig.Config{
 		MetadataNamespace: "ai_gateway_llm_ns",
 		LLMRequestCosts: []filterconfig.LLMRequestCost{
 			{MetadataKey: "used_token", Type: filterconfig.LLMRequestCostTypeInputToken},


### PR DESCRIPTION
**Commit Message**:

Previously, filterconfig package was named extprocconfig
and renamed to it in #92. This fixes a few places still 
mentioning the old name.

**Related Issues/PRs (if applicable)**:

follow up on #92 
