### PR TITLE
test: testupstream returns openai fake responses

### DIFF
--- a/.github/workflows/docker_builds_template.yaml
+++ b/.github/workflows/docker_builds_template.yaml
@@ -9,9 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target:
+        include:
           - command_name: "controller"
+            cmd_path_prefix: cmd
           - command_name: "extproc"
+            cmd_path_prefix: cmd
+          - command_name: "testupstream"
+            cmd_path_prefix: tests/internal/testupstreamlib
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -53,4 +57,4 @@ jobs:
           else
             TAG="latest"
           fi
-          make docker-build.${{ matrix.target.command_name }} ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"
+          make docker-build.${{ matrix.include.command_name }} CMD_PATH_PREFIX=${{ matrix.include.cmd_path_prefix }}  ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"

--- a/.github/workflows/docker_builds_template.yaml
+++ b/.github/workflows/docker_builds_template.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docker_builds:
-    name: ${{ matrix.target.command_name }}
+    name: ${{ matrix.include.command_name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/examples/basic/basic.yaml
+++ b/examples/basic/basic.yaml
@@ -37,7 +37,6 @@ spec:
               value: gpt-4o-mini
       backendRefs:
         - name: envoy-ai-gateway-basic-openai
-          weight: 100
     - matches:
         - headers:
             - type: Exact
@@ -45,7 +44,13 @@ spec:
               value: us.meta.llama3-2-1b-instruct-v1:0
       backendRefs:
         - name: envoy-ai-gateway-basic-aws
-          weight: 100
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: some-cool-self-hosted-model
+      backendRefs:
+        - name: envoy-ai-gateway-basic-testupstream
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIServiceBackend
@@ -177,3 +182,61 @@ stringData:
     [default]
     aws_access_key_id = AWS_ACCESS_KEY_ID
     aws_secret_access_key = AWS_SECRET_ACCESS_KEY
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIServiceBackend
+metadata:
+  name: envoy-ai-gateway-basic-testupstream
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    name: envoy-ai-gateway-basic-testupstream
+    kind: Service
+    port: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-ai-gateway-basic-testupstream
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: envoy-ai-gateway-basic-testupstream
+  template:
+    metadata:
+      labels:
+        app: envoy-ai-gateway-basic-testupstream
+    spec:
+      containers:
+        - name: testupstream
+          image: ghcr.io/envoyproxy/ai-gateway/testupstream:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TESTUPSTREAM_ID
+              value: test
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-ai-gateway-basic-testupstream
+  namespace: default
+spec:
+  selector:
+    app: envoy-ai-gateway-basic-testupstream
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -55,6 +55,10 @@ func Test_Examples_Basic(t *testing.T) {
 				name:      "aws",
 				modelName: "us.meta.llama3-2-1b-instruct-v1:0",
 			},
+			{
+				name:      "testupsream",
+				modelName: "some-cool-self-hosted-model",
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				require.Eventually(t, func() bool {


### PR DESCRIPTION
**Commit Message**:

As a part of documentation, we need a fake upstream server
that returns openai responses but without credentials.
This modifies the testupstream so that it can return the 
fake openai response when the response body is not given
by the client and the path is known.

To make the testupstream usable in the doctest, this will
start pushing the testupstream to GHCR.


