### PR TITLE
api: allows extproc log level

### DIFF
--- a/api/v1alpha1/api.go
+++ b/api/v1alpha1/api.go
@@ -255,6 +255,12 @@ const (
 )
 
 type AIGatewayFilterConfigExternalProcess struct {
+	// LogLevel is the log level of the external process filter.
+	//
+	// +kubebuilder:default=info
+	// +kubebuilder:validation:Enum=debug;info;warn;error
+	LogLevel string `json:"logLevel,omitempty"`
+
 	// Replicas is the number of desired pods of the external process deployment.
 	//
 	// +optional

--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -187,11 +187,21 @@ func applyExtProcDeploymentConfigUpdate(d *appsv1.DeploymentSpec, filterConfig *
 	if filterConfig == nil || filterConfig.ExternalProcess == nil {
 		return
 	}
+
 	extProc := filterConfig.ExternalProcess
+	c := &d.Template.Spec.Containers[0]
 	if resource := extProc.Resources; resource != nil {
-		d.Template.Spec.Containers[0].Resources = *resource
+		c.Resources = *resource
 	}
 	if replica := extProc.Replicas; replica != nil {
 		d.Replicas = replica
+	}
+	if logLevel := extProc.LogLevel; logLevel != "" {
+		for i, arg := range c.Args {
+			if arg == "-logLevel" {
+				c.Args[i+1] = logLevel
+				return
+			}
+		}
 	}
 }

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -137,11 +137,17 @@ func Test_applyExtProcDeploymentConfigUpdate(t *testing.T) {
 			ExternalProcess: &aigv1a1.AIGatewayFilterConfigExternalProcess{
 				Resources: &req,
 				Replicas:  ptr.To[int32](123),
+				LogLevel:  "debug",
 			},
 		},
 		)
 		require.Equal(t, req, dep.Template.Spec.Containers[0].Resources)
 		require.Equal(t, int32(123), *dep.Replicas)
+		for _, arg := range dep.Template.Spec.Containers[0].Args {
+			if arg == "-logLevel" {
+				require.Equal(t, "debug", dep.Template.Spec.Containers[0].Args[1])
+			}
+		}
 	})
 }
 

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -66,6 +66,16 @@ spec:
                       ExternalProcess is the configuration for the external process filter.
                       This is optional, and if not set, the default values of Deployment spec will be used.
                     properties:
+                      logLevel:
+                        default: info
+                        description: LogLevel is the log level of the external process
+                          filter.
+                        enum:
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
                       replicas:
                         description: Replicas is the number of desired pods of the
                           external process deployment.

--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -49,6 +49,7 @@ _Appears in:_
 
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
+| `logLevel` | _string_ |  true  | LogLevel is the log level of the external process filter. |
 | `replicas` | _integer_ |  false  | Replicas is the number of desired pods of the external process deployment. |
 | `resources` | _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ |  false  | Resources required by the external process container.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 

--- a/tests/cel-validation/main_test.go
+++ b/tests/cel-validation/main_test.go
@@ -46,6 +46,10 @@ func TestAIGatewayRoutes(t *testing.T) {
 			name:   "no_target_refs.yaml",
 			expErr: `spec.targetRefs: Invalid value: 0: spec.targetRefs in body should have at least 1 items`,
 		},
+		{
+			name:   "unknownloglevel.yaml",
+			expErr: "AIGatewayRoute.aigateway.envoyproxy.io \"apple\" is invalid: [spec.filterConfig.externalProcess.logLevel: Unsupported value: \"someLogLevel\": supported values: \"debug\", \"info\", \"warn\", \"error\"",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			data, err := testdata.ReadFile(path.Join("testdata/aigatewayroutes", tc.name))

--- a/tests/cel-validation/testdata/aigatewayroutes/unknownloglevel.yaml
+++ b/tests/cel-validation/testdata/aigatewayroutes/unknownloglevel.yaml
@@ -9,15 +9,7 @@ spec:
   filterConfig:
     type: ExternalProcess
     externalProcess:
-      logLevel: info
-      replicas: 2
-      resources:
-        requests:
-          cpu: 100m
-          memory: 128Mi
-        limits:
-          cpu: 200m
-          memory: 256Mi
+      logLevel: someLogLevel
   targetRefs:
     - name: some-gateway
       kind: Gateway
@@ -29,7 +21,4 @@ spec:
               name: x-ai-eg-model
               value: llama3-70b
       backendRefs:
-        - name: kserve
-          weight: 20
         - name: aws-bedrock
-          weight: 80


### PR DESCRIPTION
**Commit Message**:

This adds `logLevel` field nob to `AIGatewayFilterConfigExternalProcess`
to allows fine-tune the log level of external processing.
