### PR TITLE
docs: Moved docs link, and changed Overview to Home of Docs site

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,6 +1,7 @@
 ---
-id: overview
-title: Overview
+id: home
+title: Home
+sidebar_position: 1
 ---
 
 # Envoy AI Gateway Overview
@@ -23,8 +24,7 @@ The **Envoy AI Gateway** was created to address the complexity of connecting app
 
 The initial release focuses on key foundational features to provide LLM/AI traffic management:
 
-- **Request Routing and Failover**: Directs API requests to appropriate GenAI services and switches providers based on availability and performance.
-- **Load Balancing**: Distributes incoming requests to maintain optimal system performance.
+- **Request Routing**: Directs API requests to appropriate GenAI services
 - **Authentication and Authorization**: Implement API key validation to secure communication.
 - **Backend Security Policy**: Introduces fine-grained access control for backend services.
 This also controls LLM/AI backend usage using token-per-second (TPS) policies to prevent overuse.
@@ -53,6 +53,3 @@ Refer to the contribution guide in the GitHub repository for detailed instructio
 ---
 
 The **Envoy AI Gateway** addresses the growing demand for secure, scalable, and efficient AI/LLM traffic management. Your contributions and feedback are key to its success and to advancing the future of AI service integration.
-
-
-

--- a/site/docs/intro.md
+++ b/site/docs/intro.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 1
----
-
-# Envoy AI Gateway Docs
-
-Version 0.1.0 is expected end of January 2025.
-
-

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -74,11 +74,6 @@ const config: Config = {
         //   position: 'left',
         //   label: 'Tutorial',
         // },
-          {
-         label: 'Overview',
-          to: '/docs/overview', // Path to your Overview page
-          position: 'left',
-        },
         {
           label: 'Community',
           position: 'left',
@@ -102,6 +97,11 @@ const config: Config = {
           to: '/blog',
           position: 'left',
         },
+        {
+          label: 'Docs',
+           to: '/docs', // Path to your Overview page
+           position: 'right',
+         },
         {
           href: 'https://github.com/envoyproxy/ai-gateway',
           label: 'GitHub',


### PR DESCRIPTION
**Commit Message**:

I changed the overview.md to be the home/index of the docs site.
I moved the Docs link to the right side of the navigation bar.

Please add the related issues or PRs here.

Related: #29

