### PR TITLE
controller: annotate extproc pods with uuid for faster refresh

### DIFF
--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -432,6 +432,10 @@ func (c *configSink) newHTTPRoute(dst *gwapiv1.HTTPRoute, aiGatewayRoute *aigv1a
 	return nil
 }
 
+// annotateExtProcPods annotates the external processor pods with the new config uuid.
+// This is necessary to make the config update faster.
+//
+// See https://neonmirrors.net/post/2022-12/reducing-pod-volume-update-times/ for explanation.
 func (c *configSink) annotateExtProcPods(ctx context.Context, aiGatewayRoute *aigv1a1.AIGatewayRoute, uuid string) error {
 	pods, err := c.kube.CoreV1().Pods(aiGatewayRoute.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", extProcName(aiGatewayRoute)),

--- a/internal/controller/sink_test.go
+++ b/internal/controller/sink_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -782,4 +783,40 @@ func TestConfigSink_MountBackendSecurityPolicySecrets(t *testing.T) {
 func Test_backendSecurityPolicyVolumeName(t *testing.T) {
 	mountPath := backendSecurityPolicyVolumeName(1, 2, "name")
 	require.Equal(t, "rule1-backref2-name", mountPath)
+}
+
+func Test_annotateExtProcPods(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kube := fake2.NewClientset()
+
+	eventChan := make(chan ConfigSinkEvent)
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage")
+
+	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "myroute", Namespace: "foons"},
+	}
+
+	for i := range 5 {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "somepod" + strconv.Itoa(i),
+				Namespace: "foons",
+				Labels:    map[string]string{"app": extProcName(aiGatewayRoute)},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "someapp"}}},
+		}
+		_, err := kube.CoreV1().Pods("foons").Create(context.Background(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	uuid := string(uuid2.NewUUID())
+	err := s.annotateExtProcPods(context.Background(), aiGatewayRoute, uuid)
+	require.NoError(t, err)
+
+	// Check that all pods have been annotated.
+	for i := range 5 {
+		pod, err := kube.CoreV1().Pods("foons").Get(context.Background(), "somepod"+strconv.Itoa(i), metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, uuid, pod.Annotations[extProcConfigAnnotationKey])
+	}
 }

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -25,6 +25,7 @@ import (
 // processorConfig is the configuration for the processor.
 // This will be created by the server and passed to the processor when it detects a new configuration.
 type processorConfig struct {
+	uuid                                         string
 	bodyParser                                   router.RequestBodyParser
 	router                                       extprocapi.Router
 	modelNameHeaderKey, selectedBackendHeaderKey string

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -80,6 +80,7 @@ func (s *Server[P]) LoadConfig(config *filterconfig.Config) error {
 	}
 
 	newConfig := &processorConfig{
+		uuid:       config.UUID,
 		bodyParser: bodyParser, router: rt,
 		selectedBackendHeaderKey: config.SelectedBackendHeaderKey,
 		modelNameHeaderKey:       config.ModelNameHeaderKey,
@@ -95,6 +96,7 @@ func (s *Server[P]) LoadConfig(config *filterconfig.Config) error {
 // Process implements [extprocv3.ExternalProcessorServer].
 func (s *Server[P]) Process(stream extprocv3.ExternalProcessor_ProcessServer) error {
 	p := s.newProcessor(s.config, s.logger)
+	s.logger.Debug("handling a new stream", slog.Any("config_uuid", s.config.uuid))
 	return s.process(p, stream)
 }
 

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -23,6 +23,7 @@ func requireNewServerWithMockProcessor(t *testing.T) *Server[*mockProcessor] {
 	s, err := NewServer[*mockProcessor](slog.Default(), newMockProcessor)
 	require.NoError(t, err)
 	require.NotNil(t, s)
+	s.config = &processorConfig{}
 	return s
 }
 

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -46,7 +46,7 @@ func Test_Examples_Basic(t *testing.T) {
 		replaced = strings.ReplaceAll(replaced, "AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
 		require.NoError(t, kubectlApplyManifestStdin(ctx, replaced))
 
-		time.Sleep(5 * time.Second) // At least 10 seconds for the updated secret to be propagated.
+		time.Sleep(5 * time.Second) // At least 5 seconds for the updated secret to be propagated.
 
 		for _, tc := range []examplesBasicTestCase{
 			{

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -15,38 +15,40 @@ import (
 )
 
 // TestExamplesBasic tests the basic example in examples/basic directory.
-//
-// This requires the following environment variables to be set:
-//   - TEST_AWS_ACCESS_KEY_ID
-//   - TEST_AWS_SECRET_ACCESS_KEY
-//   - TEST_OPENAI_API_KEY
-//
-// The test will be skipped if any of these are not set.
 func Test_Examples_Basic(t *testing.T) {
-	openAiApiKey := getEnvVarOrSkip(t, "TEST_OPENAI_API_KEY")
-	awsAccessKeyID := getEnvVarOrSkip(t, "TEST_AWS_ACCESS_KEY_ID")
-	awsSecretAccessKey := getEnvVarOrSkip(t, "TEST_AWS_SECRET_ACCESS_KEY")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
 	const manifest = "../../examples/basic/basic.yaml"
-	read, err := os.ReadFile(manifest)
-	require.NoError(t, err)
-	// Replace the placeholder with the actual API key.
-	replaced := strings.ReplaceAll(string(read), "OPENAI_API_KEY", openAiApiKey)
-	replaced = strings.ReplaceAll(replaced, "AWS_ACCESS_KEY_ID", awsAccessKeyID)
-	replaced = strings.ReplaceAll(replaced, "AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
-	require.NoError(t, kubectlApplyManifestStdin(ctx, replaced))
+	require.NoError(t, kubectlApplyManifest(ctx, manifest))
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-basic"
 	requireWaitForPodReady(t, egNamespace, egSelector)
 
-	t.Run("/chat/completions", func(t *testing.T) {
-		for _, tc := range []struct {
-			name      string
-			modelName string
-		}{
+	testUpstreamCase := examplesBasicTestCase{name: "testupsream", modelName: "some-cool-self-hosted-model"}
+	testUpstreamCase.run(t, egNamespace, egSelector)
+
+	// This requires the following environment variables to be set:
+	//   - TEST_AWS_ACCESS_KEY_ID
+	//   - TEST_AWS_SECRET_ACCESS_KEY
+	//   - TEST_OPENAI_API_KEY
+	//
+	// The test will be skipped if any of these are not set.
+	t.Run("with credentials", func(t *testing.T) {
+		openAiApiKey := getEnvVarOrSkip(t, "TEST_OPENAI_API_KEY")
+		awsAccessKeyID := getEnvVarOrSkip(t, "TEST_AWS_ACCESS_KEY_ID")
+		awsSecretAccessKey := getEnvVarOrSkip(t, "TEST_AWS_SECRET_ACCESS_KEY")
+		read, err := os.ReadFile(manifest)
+		require.NoError(t, err)
+		// Replace the placeholder with the actual API key.
+		replaced := strings.ReplaceAll(string(read), "OPENAI_API_KEY", openAiApiKey)
+		replaced = strings.ReplaceAll(replaced, "AWS_ACCESS_KEY_ID", awsAccessKeyID)
+		replaced = strings.ReplaceAll(replaced, "AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
+		require.NoError(t, kubectlApplyManifestStdin(ctx, replaced))
+
+		time.Sleep(5 * time.Second) // At least 10 seconds for the updated secret to be propagated.
+
+		for _, tc := range []examplesBasicTestCase{
 			{
 				name:      "openai",
 				modelName: "gpt-4o-mini",
@@ -55,41 +57,46 @@ func Test_Examples_Basic(t *testing.T) {
 				name:      "aws",
 				modelName: "us.meta.llama3-2-1b-instruct-v1:0",
 			},
-			{
-				name:      "testupsream",
-				modelName: "some-cool-self-hosted-model",
-			},
 		} {
-			t.Run(tc.name, func(t *testing.T) {
-				require.Eventually(t, func() bool {
-					fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
-					defer fwd.kill()
-
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-					defer cancel()
-
-					client := openai.NewClient(option.WithBaseURL(fwd.address() + "/v1/"))
-
-					chatCompletion, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
-						Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
-							openai.UserMessage("Say this is a test"),
-						}),
-						Model: openai.F(tc.modelName),
-					})
-					if err != nil {
-						t.Logf("error: %v", err)
-						return false
-					}
-					var choiceNonEmpty bool
-					for _, choice := range chatCompletion.Choices {
-						t.Logf("choice: %s", choice.Message.Content)
-						if choice.Message.Content != "" {
-							choiceNonEmpty = true
-						}
-					}
-					return choiceNonEmpty
-				}, 10*time.Second, 1*time.Second)
-			})
+			tc.run(t, egNamespace, egSelector)
 		}
+	})
+}
+
+type examplesBasicTestCase struct {
+	name      string
+	modelName string
+}
+
+func (tc examplesBasicTestCase) run(t *testing.T, egNamespace, egSelector string) {
+	t.Run(tc.name, func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+			defer fwd.kill()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			client := openai.NewClient(option.WithBaseURL(fwd.address() + "/v1/"))
+
+			chatCompletion, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("Say this is a test"),
+				}),
+				Model: openai.F(tc.modelName),
+			})
+			if err != nil {
+				t.Logf("error: %v", err)
+				return false
+			}
+			var choiceNonEmpty bool
+			for _, choice := range chatCompletion.Choices {
+				t.Logf("choice: %s", choice.Message.Content)
+				if choice.Message.Content != "" {
+					choiceNonEmpty = true
+				}
+			}
+			return choiceNonEmpty
+		}, 20*time.Second, 3*time.Second)
 	})
 }


### PR DESCRIPTION
**Commit Message**:

Without triggering pods into the reconcile loop of k8s server,
the config map updates will take a few minutes to be picked up
and reflected on the actual file of the pod [^1].

This commit changes the config sink so that it will add the config
uuid to the extproc pods annotations.

[^1]: https://neonmirrors.net/post/2022-12/reducing-pod-volume-update-times/


**Related Issues/PRs (if applicable)**:

Follow up on #219 
