### PR TITLE
controller: consistent logger prefix for controllers

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -72,7 +72,7 @@ func main() {
 	}()
 
 	// Start the controller.
-	if err := controller.StartControllers(ctx, k8sConfig, setupLog, options); err != nil {
+	if err := controller.StartControllers(ctx, k8sConfig, ctrl.Log.WithName("controller"), options); err != nil {
 		setupLog.Error(err, "failed to start controller")
 	}
 }

--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -44,7 +44,7 @@ func NewAIGatewayRouteController(
 	return &aiGatewayRouteController{
 		client:    client,
 		kube:      kube,
-		logger:    logger.WithName("ai-gateway-route-controller"),
+		logger:    logger,
 		eventChan: ch,
 	}
 }

--- a/internal/controller/ai_service_backend.go
+++ b/internal/controller/ai_service_backend.go
@@ -27,7 +27,7 @@ func NewAIServiceBackendController(client client.Client, kube kubernetes.Interfa
 	return &aiBackendController{
 		client:    client,
 		kube:      kube,
-		logger:    logger.WithName("ai-service-backend-controller"),
+		logger:    logger,
 		eventChan: ch,
 	}
 }

--- a/internal/controller/sink.go
+++ b/internal/controller/sink.go
@@ -72,7 +72,7 @@ func newConfigSink(
 	c := &configSink{
 		client:                        kubeClient,
 		kube:                          kube,
-		logger:                        logger.WithName("config-sink"),
+		logger:                        logger,
 		defaultExtProcImage:           extProcImage,
 		defaultExtProcImagePullPolicy: corev1.PullIfNotPresent,
 		eventChan:                     eventChan,


### PR DESCRIPTION
**Commit Message**:

Previously, all loggers used by controllers are name-prefixed with "setup"
which is not correct and confusing, so this fixes it. Also, this consolidates
all the WithName option handling in StartController function so that we can
ensure all controllers have consistent names.