### PR TITLE
docs: removes the instruction to restart extproc

### DIFF
--- a/site/docs/getting-started/connect-providers/aws-bedrock.md
+++ b/site/docs/getting-started/connect-providers/aws-bedrock.md
@@ -47,7 +47,8 @@ The credentials will be stored in Kubernetes secrets.
 
 ### 2. Apply Configuration
 
-Apply the updated configuration and wait for the Gateway pod to be ready, and restart the ext-proc to pick up the updated secrets:
+Apply the updated configuration and wait for the Gateway pod to be ready. If you already have a Gateway running,
+then the secret credential update will be picked up automatically in a few seconds.
 
 ```shell
 kubectl apply -f basic.yaml
@@ -56,8 +57,6 @@ kubectl wait pods --timeout=2m \
   -l gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-basic \
   -n envoy-gateway-system \
   --for=condition=Ready
-
-kubectl rollout restart deployment/ai-eg-route-extproc-envoy-ai-gateway-basic
 ```
 
 ### 4. Test the Configuration

--- a/site/docs/getting-started/connect-providers/openai.md
+++ b/site/docs/getting-started/connect-providers/openai.md
@@ -32,7 +32,8 @@ The key will be stored in a Kubernetes secret.
 
 ### 2. Apply Configuration
 
-Apply the updated configuration and wait for the Gateway pod to be ready, and restart the ext-proc to pick up the updated secrets:
+Apply the updated configuration and wait for the Gateway pod to be ready. If you already have a Gateway running,
+then the secret credential update will be picked up automatically in a few seconds.
 
 ```shell
 kubectl apply -f basic.yaml
@@ -41,8 +42,6 @@ kubectl wait pods --timeout=2m \
   -l gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-basic \
   -n envoy-gateway-system \
   --for=condition=Ready
-
-kubectl rollout restart deployment/ai-eg-route-extproc-envoy-ai-gateway-basic
 ```
 
 ### 3. Test the Configuration


### PR DESCRIPTION
**Commit Message**:

This was necessary before #219 and #224 landed
the main branch. Now the secret updates will be 
automatically picked up by the extproc without restarts.
This behavior is already being tested in an e2e test.
