### PR TITLE
ci: separates out style checks from tests

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,0 +1,30 @@
+name: Style
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  style:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+            ~/go/pkg/mod
+            ~/go/bin
+          key: code-style-check-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - name: Run code style check
+        run: make check

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,11 +1,21 @@
-name: Commit
+name: Tests
 on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'site/**'
+      - 'netlify.toml'
+
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'site/**'
+      - 'netlify.toml'
+
   # If the PR is coming from a fork, they are not allowed to access secrets by default.
   # This even is triggered only if the PR gets labeled with 'safe to test' which can only be added by the maintainers.
   # Jobs do not use secrets in the workflow will ignore this event.
@@ -20,27 +30,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  style:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    name: Code Style Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          cache: false
-          go-version-file: go.mod
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/.cache/golangci-lint
-            ~/go/pkg/mod
-            ~/go/bin
-          key: code-style-check-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - name: Run code style check
-        run: make check
-
   unittest:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     name: Unit Test
@@ -193,7 +182,7 @@ jobs:
     # Docker builds are verified in test_e2e job, so we only need to push the images when the event is a push event.
     if: github.event_name == 'push'
     name: Push Docker Images
-    needs: [style, unittest, test_cel_validation, test_controller, test_extproc, test_e2e]
+    needs: [unittest, test_cel_validation, test_controller, test_extproc, test_e2e]
     uses: ./.github/workflows/docker_builds_template.yaml
 
   push_helm:


### PR DESCRIPTION
**Commit Message**:

This moves the style checks from the test jobs,
so that we can set the paths-ignores on these
test targets while always running style check
regardless of the changed files.

