### PR TITLE
controller: refactors flags

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -82,7 +82,6 @@ func parseAndValidateFlags(args []string) (
 func main() {
 	setupLog := ctrl.Log.WithName("setup")
 
-	// Parse and validate flags.
 	flagExtProcLogLevel,
 		flagExtProcImage,
 		flagEnableLeaderElection,

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_parseAndValidateFlags(t *testing.T) {
@@ -11,7 +12,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 		extProcLogLevel, extProcImage, enableLeaderElection, logLevel, extensionServerPort, err := parseAndValidateFlags(args)
 		require.Equal(t, "info", extProcLogLevel)
 		require.Equal(t, "ghcr.io/envoyproxy/ai-gateway/extproc:latest", extProcImage)
-		require.Equal(t, true, enableLeaderElection)
+		require.True(t, enableLeaderElection)
 		require.Equal(t, "info", logLevel.String())
 		require.Equal(t, ":1063", extensionServerPort)
 		require.NoError(t, err)
@@ -35,7 +36,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				extProcLogLevel, extProcImage, enableLeaderElection, logLevel, extensionServerPort, err := parseAndValidateFlags(args)
 				require.Equal(t, "debug", extProcLogLevel)
 				require.Equal(t, "example.com/extproc:latest", extProcImage)
-				require.Equal(t, false, enableLeaderElection)
+				require.False(t, enableLeaderElection)
 				require.Equal(t, "debug", logLevel.String())
 				require.Equal(t, ":8080", extensionServerPort)
 				require.NoError(t, err)

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_parseAndValidateFlags(t *testing.T) {
+	t.Run("no flags", func(t *testing.T) {
+		args := []string{}
+		extProcLogLevel, extProcImage, enableLeaderElection, logLevel, extensionServerPort, err := parseAndValidateFlags(args)
+		require.Equal(t, "info", extProcLogLevel)
+		require.Equal(t, "ghcr.io/envoyproxy/ai-gateway/extproc:latest", extProcImage)
+		require.Equal(t, true, enableLeaderElection)
+		require.Equal(t, "info", logLevel.String())
+		require.Equal(t, ":1063", extensionServerPort)
+		require.NoError(t, err)
+	})
+	t.Run("all flags", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			dash string
+		}{
+			{"single dash", "-"},
+			{"double dash", "--"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				args := []string{
+					tc.dash + "extProcLogLevel=debug",
+					tc.dash + "extProcImage=example.com/extproc:latest",
+					tc.dash + "enableLeaderElection=false",
+					tc.dash + "logLevel=debug",
+					tc.dash + "port=:8080",
+				}
+				extProcLogLevel, extProcImage, enableLeaderElection, logLevel, extensionServerPort, err := parseAndValidateFlags(args)
+				require.Equal(t, "debug", extProcLogLevel)
+				require.Equal(t, "example.com/extproc:latest", extProcImage)
+				require.Equal(t, false, enableLeaderElection)
+				require.Equal(t, "debug", logLevel.String())
+				require.Equal(t, ":8080", extensionServerPort)
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("invalid flags", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			flags  []string
+			expErr string
+		}{
+			{
+				name:   "invalid extProcLogLevel",
+				flags:  []string{"--extProcLogLevel=invalid"},
+				expErr: "invalid external processor log level: \"invalid\"",
+			},
+			{
+				name:   "invalid logLevel",
+				flags:  []string{"--logLevel=invalid"},
+				expErr: "invalid log level: \"invalid\"",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, _, _, _, _, err := parseAndValidateFlags(tc.flags)
+				require.ErrorContains(t, err, tc.expErr)
+			})
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/openai/openai-go v0.1.0-alpha.49
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250128144449-3edf0e91c1ae
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.4
@@ -84,7 +85,6 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -44,7 +43,6 @@ type Options struct {
 	ExtProcLogLevel      string
 	ExtProcImage         string
 	EnableLeaderElection bool
-	ZapOptions           zap.Options
 }
 
 // StartControllers starts the controllers for the AI Gateway.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -41,6 +41,7 @@ func MustInitializeScheme(scheme *runtime.Scheme) {
 
 // Options defines the program configurable options that may be passed on the command line.
 type Options struct {
+	ExtProcLogLevel      string
 	ExtProcImage         string
 	EnableLeaderElection bool
 	ZapOptions           zap.Options
@@ -106,7 +107,7 @@ func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logg
 	}
 
 	sink := newConfigSink(c, kubernetes.NewForConfigOrDie(config), logger.
-		WithName("config-sink"), sinkChan, options.ExtProcImage)
+		WithName("config-sink"), sinkChan, options.ExtProcImage, options.ExtProcLogLevel)
 
 	// Before starting the manager, initialize the config sink to sync all AIServiceBackend and AIGatewayRoute objects in the cluster.
 	if err = sink.init(ctx); err != nil {

--- a/internal/controller/sink_test.go
+++ b/internal/controller/sink_test.go
@@ -33,7 +33,7 @@ func TestConfigSink_init(t *testing.T) {
 	kube := fake2.NewClientset()
 
 	eventChan := make(chan ConfigSinkEvent)
-	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 	require.NotNil(t, s)
 }
 
@@ -42,7 +42,7 @@ func TestConfigSink_syncAIGatewayRoute(t *testing.T) {
 	kube := fake2.NewClientset()
 
 	eventChan := make(chan ConfigSinkEvent, 10)
-	s := newConfigSink(fakeClient, kube, logr.FromSlogHandler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{})), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, kube, logr.FromSlogHandler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{})), eventChan, "defaultExtProcImage", "debug")
 	require.NotNil(t, s)
 
 	for _, backend := range []*aigv1a1.AIServiceBackend{
@@ -110,7 +110,7 @@ func TestConfigSink_syncAIGatewayRoute(t *testing.T) {
 func TestConfigSink_syncAIServiceBackend(t *testing.T) {
 	eventChan := make(chan ConfigSinkEvent)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	s := newConfigSink(fakeClient, nil, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, nil, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 	s.syncAIServiceBackend(&aigv1a1.AIServiceBackend{ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"}})
 }
 
@@ -127,14 +127,14 @@ func TestConfigSink_syncBackendSecurityPolicy(t *testing.T) {
 	}
 	require.NoError(t, fakeClient.Create(context.Background(), &backend, &client.CreateOptions{}))
 
-	s := newConfigSink(fakeClient, nil, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, nil, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 	s.syncBackendSecurityPolicy(&aigv1a1.BackendSecurityPolicy{ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns"}})
 }
 
 func Test_newHTTPRoute(t *testing.T) {
 	eventChan := make(chan ConfigSinkEvent)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	s := newConfigSink(fakeClient, nil, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, nil, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 	httpRoute := &gwapiv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"},
 		Spec:       gwapiv1.HTTPRouteSpec{},
@@ -243,7 +243,7 @@ func Test_updateExtProcConfigMap(t *testing.T) {
 	kube := fake2.NewClientset()
 
 	eventChan := make(chan ConfigSinkEvent)
-	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 	require.NoError(t, fakeClient.Create(context.Background(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "some-secret-policy"}}))
 	require.NoError(t, fakeClient.Create(context.Background(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "some-secret-policy-2"}}))
 
@@ -439,7 +439,7 @@ func TestConfigSink_SyncExtprocDeployment(t *testing.T) {
 	kube := fake2.NewClientset()
 
 	eventChan := make(chan ConfigSinkEvent)
-	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "envoyproxy/ai-gateway-extproc:foo")
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "envoyproxy/ai-gateway-extproc:foo", "debug")
 	err := fakeClient.Create(context.Background(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "some-secret-policy"}})
 	require.NoError(t, err)
 
@@ -603,7 +603,7 @@ func TestConfigSink_MountBackendSecurityPolicySecrets(t *testing.T) {
 	kube := fake2.NewClientset()
 
 	eventChan := make(chan ConfigSinkEvent)
-	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 	err := s.init(context.Background())
 	require.NoError(t, err)
 	require.NoError(t, fakeClient.Create(context.Background(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "some-secret-policy"}}))
@@ -790,7 +790,7 @@ func Test_annotateExtProcPods(t *testing.T) {
 	kube := fake2.NewClientset()
 
 	eventChan := make(chan ConfigSinkEvent)
-	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage")
+	s := newConfigSink(fakeClient, kube, logr.Discard(), eventChan, "defaultExtProcImage", "debug")
 
 	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "myroute", Namespace: "foons"},

--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -35,7 +35,8 @@ spec:
             - containerPort: 9090
           args:
             - -zap-log-level={{ .Values.controller.logLevel }}
-            - --extprocImage={{ .Values.extProcImage.repository }}:{{ .Values.extProcImage.tag | default .Chart.AppVersion }}
+            - --extProcImage={{ .Values.extProc.repository }}:{{ .Values.extProc.tag | default .Chart.AppVersion }}
+            - --extProcLogLevel={{ .Values.extProc.logLevel }}
           livenessProbe:
             grpc:
               port: 1063

--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - containerPort: 1063
             - containerPort: 9090
           args:
-            - -zap-log-level={{ .Values.controller.logLevel }}
+            - -logLevel={{ .Values.controller.logLevel }}
             - --extProcImage={{ .Values.extProc.repository }}:{{ .Values.extProc.tag | default .Chart.AppVersion }}
             - --extProcLogLevel={{ .Values.extProc.logLevel }}
           livenessProbe:

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -4,7 +4,7 @@ extProc:
   repository: ghcr.io/envoyproxy/ai-gateway/extproc
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
-  # One of "info", "debug", "trace", "warn", "error", "fatal", "panic"
+  # One of "info", "debug", "trace", "warn", "error", "fatal", "panic".
   logLevel: info
 
 controller:

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -1,9 +1,11 @@
 # Default values for ai-gateway-helm.
 
-extProcImage:
+extProc:
   repository: ghcr.io/envoyproxy/ai-gateway/extproc
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
+  # One of "info", "debug", "trace", "warn", "error", "fatal", "panic"
+  logLevel: info
 
 controller:
   logLevel: info


### PR DESCRIPTION
**Commit Message**:

This refactors the main function of controller.
Previously it was conflated with the implementation detail
(zap) and that is exposed unnecessarily as controller main
arguments. This resolves it and expose the only necessary
one to have the consistency with extproc.

Notably, this also adds an new controller argument/helm 
value that configures the log level of external processor.
More fine tuned, per-route log level can be added later 
as in #204.

This also increases the test coverage.

**Related Issues/PRs (if applicable)**:

Supersedes #204 