### PR TITLE
docs: fixes CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-Envoy Gateway follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+Envoy AI Gateway follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
**Commit Message**:

This was copied from Envoy Gateway as-is
and should be "Envoy AI Gateawy" instead of
Envoy Gateway.