### PR TITLE
docs: removal of deprecated kubectl command in installation.md

### DIFF
--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -19,8 +19,6 @@ helm upgrade -i aieg oci://ghcr.io/envoyproxy/ai-gateway/ai-gateway-helm \
     --namespace envoy-ai-gateway-system \
     --create-namespace
 
-kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-controller --for=create
-
 kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-controller --for=condition=Available
 ```
 


### PR DESCRIPTION
**Commit Message**: 

Removal of deprecated kubectl command below from [the installation getting started guide](https://github.com/envoyproxy/ai-gateway/blob/main/site/docs/getting-started/installation.md).

`kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-controller --for=create
`
It seems to include a deprecated arg ```--for=create```

**Related Issues/PRs (if applicable)**: Fixes [Issue 262](https://github.com/envoyproxy/ai-gateway/issues/262)


**Special notes for reviewers (if applicable)**:
