### PR TITLE
ci: relaxes PR title length check

### DIFF
--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -73,11 +73,11 @@ jobs:
         env:
           # Do not use ${{ github.event.pull_request.title }} directly in run command.
           TITLE: ${{ github.event.pull_request.title }}
-        # We want to make sure that each commit "subject" is under 53 characters not to
+        # We want to make sure that each commit "subject" is under 60 characters not to
         # be truncated in the git log as well as in the GitHub UI.
         # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst?id=bc7938deaca7f474918c41a0372a410049bd4e13#n664
         run: |
-          if (( ${#TITLE} >= 53 )); then
-            echo "The PR title is too long. Please keep it under 52 characters."
+          if (( ${#TITLE} >= 60 )); then
+            echo "The PR title is too long. Please keep it under 60 characters."
             exit 1
           fi


### PR DESCRIPTION
**Commit Message**

This follows up on #266 and relaxes the PR title length 
restriction to 60 characters. It was too strict.