### PR TITLE
ci: add issue title check

### DIFF
--- a/.github/workflows/issue_title_check.yaml
+++ b/.github/workflows/issue_title_check.yaml
@@ -11,23 +11,7 @@ jobs:
   check_title_length:
     runs-on: ubuntu-latest
     steps:
-      - name: Check issue title length
-        id: check_length
-        run: |
-          TITLE="${{ github.event.issue.title }}"
-          LENGTH=$(echo -n "$TITLE" | wc -m)
-
-          echo "Title: $TITLE"
-          echo "Length: $LENGTH"
-
-          if [ "$LENGTH" -ge 60 ]; then
-            echo "title_is_too_long=true" >> $GITHUB_OUTPUT
-          else
-            echo "title_is_too_long=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Comment if title is too long
-        if: steps.check_length.outputs.title_is_too_long == 'true'
+      - name: Check Issue Title Length
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,15 +19,18 @@ jobs:
             const issueNumber = context.issue.number;
             const repoOwner = context.repo.owner;
             const repoName = context.repo.repo;
-            await github.rest.issues.createComment({
-              owner: repoOwner,
-              repo: repoName,
-              issue_number: issueNumber,
-              body: "The issue title is too long (over 60 characters). Please shorten it and ensure it is well summarized."
-            });
 
-      - name: Fail job if title is too long
-        if: steps.check_length.outputs.title_is_too_long == 'true'
-        run: |
-          echo "The issue title is too long. Failing job..."
-          exit 1
+            const issueTitle = context.payload.issue.title;
+            const length = issueTitle.length;
+
+            console.log(`Title: ${issueTitle}`);
+            console.log(`Length: ${length}`);
+
+            if (length >= 60) {
+              await github.rest.issues.createComment({
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: issueNumber,
+                body: "The issue title is too long (over 60 characters). Please shorten it and ensure it is well summarized."
+              });
+            }

--- a/.github/workflows/issue_title_check.yaml
+++ b/.github/workflows/issue_title_check.yaml
@@ -4,11 +4,15 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  issues: write
+
 jobs:
   check_title_length:
     runs-on: ubuntu-latest
     steps:
       - name: Check issue title length
+        id: check_length
         run: |
           TITLE="${{ github.event.issue.title }}"
           LENGTH=$(echo -n "$TITLE" | wc -m)
@@ -17,19 +21,14 @@ jobs:
           echo "Length: $LENGTH"
 
           if [ "$LENGTH" -ge 60 ]; then
-            echo "Too long!"
-            exit 1
+            echo "title_is_too_long=true" >> $GITHUB_OUTPUT
+          else
+            echo "title_is_too_long=false" >> $GITHUB_OUTPUT
           fi
-          echo "OK"
 
-  comment_if_long:
-    runs-on: ubuntu-latest
-    needs: [check_title_length]
-    if: always()
-    steps:
-      - name: Create comment if previous job failed
+      - name: Comment if title is too long
+        if: steps.check_length.outputs.title_is_too_long == 'true'
         uses: actions/github-script@v6
-        if: ${{ needs.check_title_length.result == 'failure' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -40,5 +39,11 @@ jobs:
               owner: repoOwner,
               repo: repoName,
               issue_number: issueNumber,
-              body: "The issue title is too long (over 60 characters). Please shorten it."
+              body: "The issue title is too long (over 60 characters). Please shorten it and ensure it is well summarized."
             });
+
+      - name: Fail job if title is too long
+        if: steps.check_length.outputs.title_is_too_long == 'true'
+        run: |
+          echo "The issue title is too long. Failing job..."
+          exit 1

--- a/.github/workflows/issue_title_check.yaml
+++ b/.github/workflows/issue_title_check.yaml
@@ -1,0 +1,44 @@
+name: Issue Title Check
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  check_title_length:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check issue title length
+        run: |
+          TITLE="${{ github.event.issue.title }}"
+          LENGTH=$(echo -n "$TITLE" | wc -m)
+
+          echo "Title: $TITLE"
+          echo "Length: $LENGTH"
+
+          if [ "$LENGTH" -ge 60 ]; then
+            echo "Too long!"
+            exit 1
+          fi
+          echo "OK"
+
+  comment_if_long:
+    runs-on: ubuntu-latest
+    needs: [check_title_length]
+    if: always()
+    steps:
+      - name: Create comment if previous job failed
+        uses: actions/github-script@v6
+        if: ${{ needs.check_title_length.result == 'failure' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = context.issue.number;
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+            await github.rest.issues.createComment({
+              owner: repoOwner,
+              repo: repoName,
+              issue_number: issueNumber,
+              body: "The issue title is too long (over 60 characters). Please shorten it."
+            });


### PR DESCRIPTION
**Commit Message**

This introduces a new GitHub Actions workflow to check the length of issue titles and provide feedback if they exceed a specified limit. 

**Related Issues/PRs (if applicable)**

Fixes https://github.com/envoyproxy/ai-gateway/issues/270


**Special notes for reviewers (if applicable)**

`.github/workflows/issue_title_check.yaml`: Created a new workflow named "Issue Title Check" that triggers on issue creation and edits. It includes two jobs: `check_title_length` to validate the title length and `comment_if_long` to leave a comment if the title is too long.
I checked the behavior with the forked repository.
![image](https://github.com/user-attachments/assets/16724aec-e486-45c6-95a1-a488ba35ca5c)
