### PR TITLE
ci: run golang linter in docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ GO_TEST_E2E_ARGS ?= -count=1
 help:
 	@echo "Usage: make <target>"
 	@echo ""
+	@echo "Prerequisites:"
+	@echo "  - Docker: Required for linting and some build operations"
+	@echo "  - Go: Required for building and testing"
+	@echo ""
 	@echo "All core targets needed for contributing:"
 	@echo "  precommit       	 Run all necessary steps to prepare for a commit."
 	@echo "  test            	 Run the unit tests for the codebase."
@@ -42,13 +46,13 @@ help:
 	@echo "For example, 'make precommit test' should be enough for initial iterations, and later 'make test-cel' etc. for the normal development cycle."
 	@echo "Note that some cases run by test-e2e or test-extproc use credentials and these will be skipped when not available."
 	@echo ""
+	@echo "First time setup:"
+	@echo "  The first run of any target may take longer as it downloads required Docker images and tools."
 	@echo ""
 
 # This runs the linter, formatter, and tidy on the codebase.
 .PHONY: lint
-lint: golangci-lint
-	@echo "lint => ./..."
-	@$(GOLANGCI_LINT) run --build-tags==test_cel_validation,test_controller,test_extproc ./...
+lint: docker-golangci-lint
 
 .PHONY: codespell
 CODESPELL_SKIP := $(shell cat .codespell.skip | tr \\n ',')
@@ -56,11 +60,6 @@ CODESPELL_IGNORE_WORDS := ".codespell.ignorewords"
 codespell: $(CODESPELL)
 	@echo "spell => ./..."
 	@$(CODESPELL) --skip $(CODESPELL_SKIP) --ignore-words $(CODESPELL_IGNORE_WORDS)
-
-.PHONY: yamllint
-yamllint: $(YAMLLINT)
-	@echo "yamllint => ./..."
-	@$(YAMLLINT) --config-file=.yamllint $$(git ls-files :*.yml :*.yaml | xargs -L1 dirname | sort -u)
 
 # This runs the formatter on the codebase as well as goimports via gci.
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ codespell: $(CODESPELL)
 	@echo "spell => ./..."
 	@$(CODESPELL) --skip $(CODESPELL_SKIP) --ignore-words $(CODESPELL_IGNORE_WORDS)
 
+.PHONY: yamllint
+yamllint: $(YAMLLINT)
+	@echo "yamllint => ./..."
+	@$(YAMLLINT) --config-file=.yamllint $$(git ls-files :*.yml :*.yaml | xargs -L1 dirname | sort -u)
+
 # This runs the formatter on the codebase as well as goimports via gci.
 .PHONY: format
 format: gci gofumpt

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -142,11 +142,6 @@ $(CODESPELL): .bin/.venv/codespell@v2.3.0
 
 $(YAMLLINT): .bin/.venv/yamllint@1.35.1
 
-.PHONY: yamllint
-yamllint: $(YAMLLINT)
-	@echo "yamllint => ./..."
-	@$(YAMLLINT) --config-file=.yamllint $$(git ls-files :*.yml :*.yaml | xargs -L1 dirname | sort -u)
-
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed


### PR DESCRIPTION
**Commit Message**

Running golinter in a docker container to make it easier to run on local and making local and ci consistent.
I have issues on my local mac setup if I don't run it in a docker container.

---

**When I run `make lint` on main:**
```console
erica@Ericas-MacBook-Pro ai-gateway % make lint
lint => ./...
Error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.5)
Failed executing command with error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.5)
make: *** [lint] Error 3
```

**When I run `make lint` with this docker implementation:**
```console
erica@Ericas-MacBook-Pro ai-gateway % make lint
lint => ./...
Starting analysis...
* Analysis completed in 00:51                              
✨ Congratulations! No linting errors! ✨
```

---

**Checklist** (you don't need to keep in your PR description):
- [x] The PR title follows the same format as the merged PRs.
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) (for first-time contributors).
- [x] I have made sure that `make precommit test` passes locally.
- [x] I have written tests for any new line of code unless there's existing tests that cover the changes.
- [x] I have updated the documentation accordingly.
- [x] I am sure the coding style is consistent with the rest of the codebase.
