### PR TITLE
ci: skip style checks for dependabot PRs

### DIFF
--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -17,6 +17,7 @@ jobs:
     env:
       # Do not use ${{ github.event.pull_request.body }} directly in run command.
       BODY: ${{ github.event.pull_request.body }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Check comment out lines
         run: |
@@ -41,6 +42,7 @@ jobs:
   title:
     name: Title
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
**Commit Message**

Dependabot PRs do not conform to the repository's title and body standards, causing the workflow to always fail. This change prevents unnecessary workflow executions by skipping style checks for Dependabot PRs.

Signed-off-by: Sébastien Han <seb@redhat.com>
