### PR TITLE
test: resolve warnings in envoy.yaml

### DIFF
--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -16,9 +16,10 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                       path: ACCESS_LOG_PATH
-                      json_format:
-                        "used_token": "%DYNAMIC_METADATA(ai_gateway_llm_ns:used_token)%"
-                        "some_cel": "%DYNAMIC_METADATA(ai_gateway_llm_ns:some_cel)%"
+                      log_format:
+                        json_format:
+                          used_token: "%DYNAMIC_METADATA(ai_gateway_llm_ns:used_token)%"
+                          some_cel: "%DYNAMIC_METADATA(ai_gateway_llm_ns:some_cel)%"
                 route_config:
                   virtual_hosts:
                     - name: local_route
@@ -142,3 +143,11 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: api.openai.com
+
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 1000


### PR DESCRIPTION
**Commit Message**

Addressed warnings observed during `make test-extproc`, except for the `reuse_port` warning, which is platform-dependent and cannot be fixed on non-Linux systems.

- Updated `json_format` to be nested under `log_format` to align with Envoy's expected configuration.
- Added `overload_manager` configuration to manage downstream connection limits.
- The warning related to `reuse_port` being force disabled on non-Linux platforms was **not** fixed, as it is platform-dependent.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Related Issues/PRs (if applicable)**

#274

**Special notes for reviewers (if applicable)**

The warning related to `reuse_port` being force disabled on non-Linux platforms was **not** fixed, as it is platform-dependent. Any suggestions for a fix are welcome.