### PR TITLE
ci: adjust issue/pr style checks

### DIFF
--- a/.github/workflows/issue_title_check.yaml
+++ b/.github/workflows/issue_title_check.yaml
@@ -26,11 +26,11 @@ jobs:
             console.log(`Title: ${issueTitle}`);
             console.log(`Length: ${length}`);
 
-            if (length >= 60) {
+            if (length > 80) {
               await github.rest.issues.createComment({
                 owner: repoOwner,
                 repo: repoName,
                 issue_number: issueNumber,
-                body: "The issue title is too long (over 60 characters). Please shorten it and ensure it is well summarized."
+                body: "The issue title is too long (over 80 characters). Please shorten it and ensure it is well summarized."
               });
             }

--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -79,7 +79,7 @@ jobs:
         # be truncated in the git log as well as in the GitHub UI.
         # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst?id=bc7938deaca7f474918c41a0372a410049bd4e13#n664
         run: |
-          if (( ${#TITLE} >= 60 )); then
-            echo "The PR title is too long. Please keep it under 60 characters."
+          if (( ${#TITLE} > 60 )); then
+            echo "The PR title is too long. Please keep it <=60 characters."
             exit 1
           fi


### PR DESCRIPTION
**Commit Message**

This adjusts the issue title check as well as the PR style check. For issue title, I adopt the suggestion by @leseb as indeed 60 was too strict. For the PR stuff, it simply changes it to forbid >60.