### PR TITLE
examples: simplifies token_ratelimit.yaml

### DIFF
--- a/examples/token_ratelimit/token_ratelimit.yaml
+++ b/examples/token_ratelimit/token_ratelimit.yaml
@@ -37,7 +37,6 @@ spec:
               value: gpt-4o-mini
       backendRefs:
         - name: envoy-ai-gateway-token-ratelimit-testupstream
-          weight: 100
   # The following metadata keys are used to store the costs from the LLM request.
   llmRequestCosts:
     - metadataKey: llm_input_token

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -93,7 +93,7 @@ func Test_Examples_TokenRateLimit(t *testing.T) {
 
 	// Test the CEL token limit.
 	usedID = strconv.Itoa(baseID + 3)
-	// When the input number is 7, the CEL expression returns 100000000 which exceeds the limit.
+	// When the input number is 3, the CEL expression returns 100000000 which exceeds the limit.
 	makeRequest(usedID, 3, 0, 0, 200)
 	// Any request with the same user ID should be rejected.
 	makeRequest(usedID, 0, 0, 0, 429)


### PR DESCRIPTION
**Commit Message**

The weight field does not need to be specified if there's only 
one backend since #156. This removes it in token_ratelimit.yaml.

**Related Issues/PRs (if applicable)**

Follow up on #289 

