### PR TITLE
feat: add extproc prometheus metrics

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -20,10 +21,12 @@ import (
 	"time"
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/envoyproxy/ai-gateway/internal/extproc"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
 	"github.com/envoyproxy/ai-gateway/internal/version"
 )
 
@@ -32,6 +35,7 @@ type extProcFlags struct {
 	configPath  string     // path to the configuration file.
 	extProcAddr string     // gRPC address for the external processor.
 	logLevel    slog.Level // log level for the external processor.
+	promPort    string     // Prometheus port
 }
 
 // parseAndValidateFlags parses and validates the flas passed to the external processor.
@@ -57,6 +61,12 @@ func parseAndValidateFlags(args []string) (extProcFlags, error) {
 		"logLevel",
 		"info",
 		"log level for the external processor. One of 'debug', 'info', 'warn', or 'error'.",
+	)
+
+	fs.StringVar(&flags.promPort,
+		"promPort",
+		":9190",
+		"port for prometheus metrics, default is 9190",
 	)
 
 	if err := fs.Parse(args); err != nil {
@@ -87,6 +97,7 @@ func Main() {
 		slog.String("version", version.Version),
 		slog.String("address", flags.extProcAddr),
 		slog.String("configPath", flags.configPath),
+		slog.String("promPort", flags.promPort),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -120,6 +131,28 @@ func Main() {
 		<-ctx.Done()
 		s.GracefulStop()
 	}()
+
+	// Add prometheus metrics
+	metricsInstance := metrics.GetOrCreate()
+
+	// Setup prometheus handler
+	http.Handle("/metrics", promhttp.HandlerFor(metricsInstance.Registry, promhttp.HandlerOpts{}))
+
+	go func() {
+		server := &http.Server{
+			Addr:              flags.promPort,
+			Handler:           nil,
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       15 * time.Second,
+		}
+
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Metrics server failed: %v", err)
+		}
+	}()
+
 	_ = s.Serve(lis)
 }
 

--- a/cmd/extproc/mainlib/main_test.go
+++ b/cmd/extproc/mainlib/main_test.go
@@ -21,6 +21,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			configPath string
 			addr       string
 			logLevel   slog.Level
+			promPort   string
 		}{
 			{
 				name:       "minimal extProcFlags",
@@ -28,6 +29,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelInfo,
+				promPort:   ":9190",
 			},
 			{
 				name:       "custom addr",
@@ -35,6 +37,15 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       "unix:///tmp/ext_proc.sock",
 				logLevel:   slog.LevelInfo,
+				promPort:   ":9190",
+			},
+			{
+				name:       "custom promPort",
+				args:       []string{"-configPath", "/path/to/config.yaml", "-promPort", ":8080"},
+				configPath: "/path/to/config.yaml",
+				addr:       ":1063",
+				logLevel:   slog.LevelInfo,
+				promPort:   ":8080",
 			},
 			{
 				name:       "log level debug",
@@ -42,6 +53,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelDebug,
+				promPort:   ":9190",
 			},
 			{
 				name:       "log level warn",
@@ -49,6 +61,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelWarn,
+				promPort:   ":9190",
 			},
 			{
 				name:       "log level error",
@@ -56,17 +69,20 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelError,
+				promPort:   ":9190",
 			},
 			{
-				name: "all extProcFlags",
+				name: "all flags",
 				args: []string{
 					"-configPath", "/path/to/config.yaml",
 					"-extProcAddr", "unix:///tmp/ext_proc.sock",
 					"-logLevel", "debug",
+					"-promPort", ":8080",
 				},
 				configPath: "/path/to/config.yaml",
 				addr:       "unix:///tmp/ext_proc.sock",
 				logLevel:   slog.LevelDebug,
+				promPort:   ":8080",
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -75,6 +91,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				assert.Equal(t, tc.configPath, flags.configPath)
 				assert.Equal(t, tc.addr, flags.extProcAddr)
 				assert.Equal(t, tc.logLevel, flags.logLevel)
+				assert.Equal(t, tc.promPort, flags.promPort)
 			})
 		}
 	})

--- a/cmd/extproc/mainlib/main_test.go
+++ b/cmd/extproc/mainlib/main_test.go
@@ -21,7 +21,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			configPath string
 			addr       string
 			logLevel   slog.Level
-			promPort   string
+			promAddr   string
 		}{
 			{
 				name:       "minimal extProcFlags",
@@ -29,7 +29,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelInfo,
-				promPort:   ":9190",
+				promAddr:   ":9190",
 			},
 			{
 				name:       "custom addr",
@@ -37,15 +37,15 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       "unix:///tmp/ext_proc.sock",
 				logLevel:   slog.LevelInfo,
-				promPort:   ":9190",
+				promAddr:   ":9190",
 			},
 			{
-				name:       "custom promPort",
-				args:       []string{"-configPath", "/path/to/config.yaml", "-promPort", ":8080"},
+				name:       "custom promAddr",
+				args:       []string{"-configPath", "/path/to/config.yaml", "-promAddr", ":8080"},
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelInfo,
-				promPort:   ":8080",
+				promAddr:   ":8080",
 			},
 			{
 				name:       "log level debug",
@@ -53,7 +53,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelDebug,
-				promPort:   ":9190",
+				promAddr:   ":9190",
 			},
 			{
 				name:       "log level warn",
@@ -61,7 +61,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelWarn,
-				promPort:   ":9190",
+				promAddr:   ":9190",
 			},
 			{
 				name:       "log level error",
@@ -69,7 +69,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
 				logLevel:   slog.LevelError,
-				promPort:   ":9190",
+				promAddr:   ":9190",
 			},
 			{
 				name: "all flags",
@@ -77,12 +77,12 @@ func Test_parseAndValidateFlags(t *testing.T) {
 					"-configPath", "/path/to/config.yaml",
 					"-extProcAddr", "unix:///tmp/ext_proc.sock",
 					"-logLevel", "debug",
-					"-promPort", ":8080",
+					"-promAddr", ":8080",
 				},
 				configPath: "/path/to/config.yaml",
 				addr:       "unix:///tmp/ext_proc.sock",
 				logLevel:   slog.LevelDebug,
-				promPort:   ":8080",
+				promAddr:   ":8080",
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -91,7 +91,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				assert.Equal(t, tc.configPath, flags.configPath)
 				assert.Equal(t, tc.addr, flags.extProcAddr)
 				assert.Equal(t, tc.logLevel, flags.logLevel)
-				assert.Equal(t, tc.promPort, flags.promPort)
+				assert.Equal(t, tc.promAddr, flags.promAddr)
 			})
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/cel-go v0.23.2
 	github.com/google/go-cmp v0.7.0
 	github.com/openai/openai-go v0.1.0-alpha.59
+	github.com/prometheus/client_golang v1.20.5
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -90,7 +90,11 @@ func TestChatCompletion_ProcessResponseHeaders(t *testing.T) {
 func TestChatCompletion_ProcessResponseBody(t *testing.T) {
 	t.Run("error translation", func(t *testing.T) {
 		mt := &mockTranslator{t: t}
-		p := &chatCompletionProcessor{translator: mt}
+		p := &chatCompletionProcessor{
+			translator: mt,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
+			config:     &processorConfig{},
+		}
 		mt.retErr = errors.New("test error")
 		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{})
 		require.ErrorContains(t, err, "test error")

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
 )
 
 func TestChatCompletion_Scheema(t *testing.T) {
@@ -38,7 +39,7 @@ func TestChatCompletion_Scheema(t *testing.T) {
 }
 
 func TestChatCompletion_SelectTranslator(t *testing.T) {
-	c := &chatCompletionProcessor{}
+	c := &chatCompletionProcessor{metrics: metrics.NewTokenMetrics()}
 	t.Run("unsupported", func(t *testing.T) {
 		err := c.selectTranslator(filterapi.VersionedAPISchema{Name: "Bar", Version: "v123"})
 		require.ErrorContains(t, err, "unsupported API schema: backend={Bar v123}")
@@ -56,7 +57,7 @@ func TestChatCompletion_SelectTranslator(t *testing.T) {
 }
 
 func TestChatCompletion_ProcessRequestHeaders(t *testing.T) {
-	p := &chatCompletionProcessor{}
+	p := &chatCompletionProcessor{metrics: metrics.NewTokenMetrics()}
 	res, err := p.ProcessRequestHeaders(t.Context(), &corev3.HeaderMap{
 		Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}},
 	})
@@ -68,7 +69,7 @@ func TestChatCompletion_ProcessRequestHeaders(t *testing.T) {
 func TestChatCompletion_ProcessResponseHeaders(t *testing.T) {
 	t.Run("error translation", func(t *testing.T) {
 		mt := &mockTranslator{t: t, expHeaders: make(map[string]string)}
-		p := &chatCompletionProcessor{translator: mt}
+		p := &chatCompletionProcessor{translator: mt, metrics: metrics.NewTokenMetrics()}
 		mt.retErr = errors.New("test error")
 		_, err := p.ProcessResponseHeaders(t.Context(), nil)
 		require.ErrorContains(t, err, "test error")
@@ -79,7 +80,7 @@ func TestChatCompletion_ProcessResponseHeaders(t *testing.T) {
 		}
 		expHeaders := map[string]string{"foo": "bar", "dog": "cat"}
 		mt := &mockTranslator{t: t, expHeaders: expHeaders}
-		p := &chatCompletionProcessor{translator: mt}
+		p := &chatCompletionProcessor{translator: mt, metrics: metrics.NewTokenMetrics()}
 		res, err := p.ProcessResponseHeaders(t.Context(), inHeaders)
 		require.NoError(t, err)
 		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseHeaders).ResponseHeaders.Response
@@ -94,6 +95,7 @@ func TestChatCompletion_ProcessResponseBody(t *testing.T) {
 			translator: mt,
 			logger:     slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
 			config:     &processorConfig{},
+			metrics:    metrics.NewTokenMetrics(),
 		}
 		mt.retErr = errors.New("test error")
 		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{})
@@ -113,21 +115,23 @@ func TestChatCompletion_ProcessResponseBody(t *testing.T) {
 		require.NoError(t, err)
 		celProgUint, err := llmcostcel.NewProgram("uint(9999)")
 		require.NoError(t, err)
-		p := &chatCompletionProcessor{translator: mt, logger: slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})), config: &processorConfig{
-			metadataNamespace: "ai_gateway_llm_ns",
-			requestCosts: []processorConfigRequestCost{
-				{LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "output_token_usage"}},
-				{LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeInputToken, MetadataKey: "input_token_usage"}},
-				{
-					celProg:        celProgInt,
-					LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeCEL, MetadataKey: "cel_int"},
+		p := &chatCompletionProcessor{translator: mt, logger: slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
+			metrics: metrics.NewTokenMetrics(),
+			config: &processorConfig{
+				metadataNamespace: "ai_gateway_llm_ns",
+				requestCosts: []processorConfigRequestCost{
+					{LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "output_token_usage"}},
+					{LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeInputToken, MetadataKey: "input_token_usage"}},
+					{
+						celProg:        celProgInt,
+						LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeCEL, MetadataKey: "cel_int"},
+					},
+					{
+						celProg:        celProgUint,
+						LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeCEL, MetadataKey: "cel_uint"},
+					},
 				},
-				{
-					celProg:        celProgUint,
-					LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeCEL, MetadataKey: "cel_uint"},
-				},
-			},
-		}}
+			}}
 		res, err := p.ProcessResponseBody(t.Context(), inBody)
 		require.NoError(t, err)
 		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseBody).ResponseBody.Response
@@ -156,21 +160,23 @@ func TestChatCompletion_ProcessRequestBody(t *testing.T) {
 		return bytes
 	}
 	t.Run("body parser error", func(t *testing.T) {
-		p := &chatCompletionProcessor{}
+		p := &chatCompletionProcessor{
+			metrics: metrics.NewTokenMetrics(),
+		}
 		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: []byte("nonjson")})
 		require.ErrorContains(t, err, "invalid character 'o' in literal null")
 	})
 	t.Run("router error", func(t *testing.T) {
 		headers := map[string]string{":path": "/foo"}
 		rt := mockRouter{t: t, expHeaders: headers, retErr: errors.New("test error")}
-		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default()}
+		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default(), metrics: metrics.NewTokenMetrics()}
 		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
 		require.ErrorContains(t, err, "failed to calculate route: test error")
 	})
 	t.Run("router error 404", func(t *testing.T) {
 		headers := map[string]string{":path": "/foo"}
 		rt := mockRouter{t: t, expHeaders: headers, retErr: x.ErrNoMatchingRule}
-		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default()}
+		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default(), metrics: metrics.NewTokenMetrics()}
 		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -185,7 +191,7 @@ func TestChatCompletion_ProcessRequestBody(t *testing.T) {
 			t: t, expHeaders: headers, retBackendName: "some-backend",
 			retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
 		}
-		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default()}
+		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default(), metrics: metrics.NewTokenMetrics()}
 		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
 		require.ErrorContains(t, err, "unsupported API schema: backend={some-schema v10.0}")
 	})
@@ -202,6 +208,7 @@ func TestChatCompletion_ProcessRequestBody(t *testing.T) {
 		p := &chatCompletionProcessor{
 			config:         &processorConfig{router: rt},
 			requestHeaders: headers, logger: slog.Default(), translator: tr,
+			metrics: metrics.NewTokenMetrics(),
 		}
 		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: someBody})
 		require.ErrorContains(t, err, "failed to transform request: test error")
@@ -223,7 +230,7 @@ func TestChatCompletion_ProcessRequestBody(t *testing.T) {
 			router:                   rt,
 			selectedBackendHeaderKey: "x-ai-gateway-backend-key",
 			modelNameHeaderKey:       "x-ai-gateway-model-key",
-		}, requestHeaders: headers, logger: slog.Default(), translator: mt}
+		}, requestHeaders: headers, logger: slog.Default(), translator: mt, metrics: metrics.NewTokenMetrics()}
 		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: someBody})
 		require.NoError(t, err)
 		require.Equal(t, mt, p.translator)

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -101,7 +101,7 @@ func (m mockTranslator) ResponseError(_ map[string]string, body io.Reader) (head
 }
 
 // ResponseBody implements [translator.Translator.ResponseBody].
-func (m mockTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, tokenUsage translator.LLMTokenUsage, err error) {
+func (m mockTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool, _, _ string) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, tokenUsage translator.LLMTokenUsage, err error) {
 	if m.expResponseBody != nil {
 		buf, err := io.ReadAll(body)
 		require.NoError(m.t, err)

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -8,6 +8,7 @@ package extproc
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -16,6 +17,7 @@ import (
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/filterapi/x"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
 )
 
 // processorConfig is the configuration for the processor.
@@ -29,12 +31,19 @@ type processorConfig struct {
 	metadataNamespace                            string
 	requestCosts                                 []processorConfigRequestCost
 	declaredModels                               []string
+	requestStart                                 time.Time
+	modelName                                    string
+	backendName                                  string
+	metrics                                      *metrics.Metrics
 }
 
 // processorConfigRequestCost is the configuration for the request cost.
 type processorConfigRequestCost struct {
 	*filterapi.LLMRequestCost
 	celProg cel.Program
+}
+
+type processorMetrics struct {
 }
 
 // ProcessorFactory is the factory function used to create new instances of a processor.

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -43,9 +43,6 @@ type processorConfigRequestCost struct {
 	celProg cel.Program
 }
 
-type processorMetrics struct {
-}
-
 // ProcessorFactory is the factory function used to create new instances of a processor.
 type ProcessorFactory func(*processorConfig, map[string]string, *slog.Logger) (Processor, error)
 

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -727,7 +727,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_Streaming_ResponseBody(t *
 
 		var results []string
 		for i := 0; i < len(buf); i++ {
-			hm, bm, tokenUsage, err := o.ResponseBody(nil, bytes.NewBuffer([]byte{buf[i]}), i == len(buf)-1)
+			hm, bm, tokenUsage, err := o.ResponseBody(nil, bytes.NewBuffer([]byte{buf[i]}), i == len(buf)-1, "", "")
 			require.NoError(t, err)
 			require.Nil(t, hm)
 			require.NotNil(t, bm)
@@ -868,7 +868,7 @@ func TestOpenAIToAWSBedrockTranslator_ResponseError(t *testing.T) {
 func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T) {
 	t.Run("invalid body", func(t *testing.T) {
 		o := &openAIToAWSBedrockTranslatorV1ChatCompletion{}
-		_, _, _, err := o.ResponseBody(nil, bytes.NewBuffer([]byte("invalid")), false)
+		_, _, _, err := o.ResponseBody(nil, bytes.NewBuffer([]byte("invalid")), false, "", "")
 		require.Error(t, err)
 	})
 	tests := []struct {
@@ -1006,7 +1006,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 			require.NoError(t, err)
 
 			o := &openAIToAWSBedrockTranslatorV1ChatCompletion{}
-			hm, bm, usedToken, err := o.ResponseBody(nil, bytes.NewBuffer(body), false)
+			hm, bm, usedToken, err := o.ResponseBody(nil, bytes.NewBuffer(body), false, "", "")
 			require.NoError(t, err)
 			require.NotNil(t, bm)
 			require.NotNil(t, bm.Mutation)

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -65,7 +65,7 @@ type Translator interface {
 	//  - This returns `tokenUsage` that is extracted from the body and will be used to do token rate limiting.
 	//
 	// TODO: this is coupled with "LLM" specific. Once we have another use case, we need to refactor this.
-	ResponseBody(respHeaders map[string]string, body io.Reader, endOfStream bool) (
+	ResponseBody(respHeaders map[string]string, body io.Reader, endOfStream bool, backendName, modelName string) (
 		headerMutation *extprocv3.HeaderMutation,
 		bodyMutation *extprocv3.BodyMutation,
 		tokenUsage LLMTokenUsage,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics holds all prometheus metrics
+type Metrics struct {
+	BackendLatency    *prometheus.HistogramVec
+	TokensTotal       *prometheus.CounterVec
+	RequestsTotal     *prometheus.CounterVec
+	FirstTokenLatency *prometheus.HistogramVec
+	InterTokenLatency *prometheus.HistogramVec
+	Registry          *prometheus.Registry
+}
+
+var (
+	instance *Metrics
+	once     sync.Once
+)
+
+// New creates a new Metrics instance
+func New() *Metrics {
+	m := &Metrics{
+		Registry: prometheus.NewRegistry(),
+		BackendLatency: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "aigateway_backend_request_duration_seconds",
+				Help:    "Time spent processing request by the LLM backend",
+				Buckets: []float64{.1, .5, 1, 2.5, 5, 10, 20, 30, 60},
+			},
+			[]string{"backend", "model", "status"},
+		),
+		TokensTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "aigateway_model_tokens_total",
+				Help: "Total number of tokens processed by model and type",
+			},
+			[]string{"model", "type"},
+		),
+		RequestsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "aigateway_requests_total",
+				Help: "Total number of requests processed",
+			},
+			[]string{"backend", "model", "status"},
+		),
+		FirstTokenLatency: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "aigateway_first_token_latency_seconds",
+				Help:    "Time to receive first token in streaming responses",
+				Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10},
+			},
+			[]string{"backend", "model"},
+		),
+		InterTokenLatency: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "aigateway_inter_token_latency_seconds",
+				Help:    "Time between consecutive tokens in streaming responses",
+				Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10},
+			},
+			[]string{"backend", "model"},
+		),
+	}
+
+	// Register all metrics
+	m.Registry.MustRegister(m.BackendLatency)
+	m.Registry.MustRegister(m.TokensTotal)
+	m.Registry.MustRegister(m.RequestsTotal)
+	m.Registry.MustRegister(m.FirstTokenLatency)
+	m.Registry.MustRegister(m.InterTokenLatency)
+
+	return m
+}
+
+// GetOrCreate returns the singleton metrics instance
+func GetOrCreate() *Metrics {
+	once.Do(func() {
+		instance = New()
+	})
+	return instance
+}
+
+// GetRegistry returns the metrics registry
+func GetRegistry() *prometheus.Registry {
+	return GetOrCreate().Registry
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 
 // Metrics holds all prometheus metrics
 type Metrics struct {
-	BackendLatency    *prometheus.HistogramVec
+	TotalLatency      *prometheus.HistogramVec
 	TokensTotal       *prometheus.CounterVec
 	RequestsTotal     *prometheus.CounterVec
 	FirstTokenLatency *prometheus.HistogramVec
@@ -21,14 +21,14 @@ var (
 	once     sync.Once
 )
 
-// New creates a new Metrics instance
-func New() *Metrics {
+// new creates a new Metrics instance
+func new() *Metrics {
 	m := &Metrics{
 		Registry: prometheus.NewRegistry(),
-		BackendLatency: prometheus.NewHistogramVec(
+		TotalLatency: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "aigateway_backend_request_duration_seconds",
-				Help:    "Time spent processing request by the LLM backend",
+				Name:    "aigateway_total_latency_seconds",
+				Help:    "Time spent processing request",
 				Buckets: []float64{.1, .5, 1, 2.5, 5, 10, 20, 30, 60},
 			},
 			[]string{"backend", "model", "status"},
@@ -38,7 +38,7 @@ func New() *Metrics {
 				Name: "aigateway_model_tokens_total",
 				Help: "Total number of tokens processed by model and type",
 			},
-			[]string{"model", "type"},
+			[]string{"backend", "model", "type"},
 		),
 		RequestsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -66,7 +66,7 @@ func New() *Metrics {
 	}
 
 	// Register all metrics
-	m.Registry.MustRegister(m.BackendLatency)
+	m.Registry.MustRegister(m.TotalLatency)
 	m.Registry.MustRegister(m.TokensTotal)
 	m.Registry.MustRegister(m.RequestsTotal)
 	m.Registry.MustRegister(m.FirstTokenLatency)
@@ -78,7 +78,7 @@ func New() *Metrics {
 // GetOrCreate returns the singleton metrics instance
 func GetOrCreate() *Metrics {
 	once.Do(func() {
-		instance = New()
+		instance = new()
 	})
 	return instance
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,30 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetrics(t *testing.T) {
+	m := New()
+	require.NotNil(t, m)
+	require.NotNil(t, m.Registry)
+	require.NotNil(t, m.BackendLatency)
+	require.NotNil(t, m.TokensTotal)
+	require.NotNil(t, m.RequestsTotal)
+	require.NotNil(t, m.FirstTokenLatency)
+	require.NotNil(t, m.InterTokenLatency)
+}
+
+func TestGetOrCreate(t *testing.T) {
+	m1 := GetOrCreate()
+	m2 := GetOrCreate()
+	require.Same(t, m1, m2)
+}
+
+func TestGetRegistry(t *testing.T) {
+	reg := GetRegistry()
+	require.NotNil(t, reg)
+	require.Same(t, GetOrCreate().Registry, reg)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,14 +7,12 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	m := New()
+	m := new()
 	require.NotNil(t, m)
 	require.NotNil(t, m.Registry)
-	require.NotNil(t, m.BackendLatency)
+	require.NotNil(t, m.TotalLatency)
 	require.NotNil(t, m.TokensTotal)
 	require.NotNil(t, m.RequestsTotal)
-	require.NotNil(t, m.FirstTokenLatency)
-	require.NotNil(t, m.InterTokenLatency)
 }
 
 func TestGetOrCreate(t *testing.T) {

--- a/internal/metrics/token_metrics.go
+++ b/internal/metrics/token_metrics.go
@@ -1,0 +1,69 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import "time"
+
+// TokenMetrics tracks token latency metrics for LLM responses
+type TokenMetrics struct {
+	metrics        *Metrics
+	firstTokenSent bool
+	requestStart   time.Time
+	lastTokenTime  time.Time
+}
+
+// NewTokenMetrics creates a new TokenMetrics instance
+func NewTokenMetrics() *TokenMetrics {
+	m := GetOrCreate()
+	return &TokenMetrics{
+		metrics: m,
+	}
+}
+
+// StartRequest initializes timing for a new request
+func (t *TokenMetrics) StartRequest(backendName, modelName string) {
+	t.requestStart = time.Now()
+	t.firstTokenSent = false
+}
+
+// UpdateTokenMetrics updates the token metrics
+func (t *TokenMetrics) UpdateTokenMetrics(backendName, modelName string, outputTokens, inputTokens, totalTokens uint32) {
+	t.metrics.TokensTotal.WithLabelValues(backendName, modelName, "completion").Add(float64(outputTokens))
+	t.metrics.TokensTotal.WithLabelValues(backendName, modelName, "prompt").Add(float64(inputTokens))
+	t.metrics.TokensTotal.WithLabelValues(backendName, modelName, "total").Add(float64(totalTokens))
+}
+
+// UpdateLatencyMetrics updates the latency metrics
+func (t *TokenMetrics) UpdateLatencyMetrics(backendName, modelName string, outputTokens uint32) {
+	now := time.Now()
+	if !t.firstTokenSent {
+		t.firstTokenSent = true
+		t.metrics.FirstTokenLatency.WithLabelValues(backendName, modelName).
+			Observe(now.Sub(t.requestStart).Seconds())
+	} else {
+		// Calculate the time between tokens.
+		// Since we are only interested in the time between tokens, and streaming is by chunk,
+		// we can calculate the time between tokens by the time between the last token and the current token, divided by the number of tokens.
+		// And in some cases, the number of tokens can be 0, so we need to check for that.
+		div := outputTokens
+		if div == 0 {
+			div = 1
+		}
+		itl := now.Sub(t.lastTokenTime).Seconds() / float64(div)
+		t.metrics.InterTokenLatency.WithLabelValues(backendName, modelName).
+			Observe(itl)
+	}
+	t.lastTokenTime = now
+}
+
+// UpdateRequestMetrics updates request-related metrics
+func (t *TokenMetrics) UpdateRequestMetrics(backendName, modelName string, status string) {
+	t.metrics.RequestsTotal.WithLabelValues(backendName, modelName, status).Inc()
+	if status == "success" {
+		t.metrics.TotalLatency.WithLabelValues(backendName, modelName, status).
+			Observe(time.Since(t.requestStart).Seconds())
+	}
+}

--- a/internal/metrics/token_metrics_test.go
+++ b/internal/metrics/token_metrics_test.go
@@ -1,0 +1,155 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTokenMetrics(t *testing.T) {
+	tm := NewTokenMetrics()
+	assert.NotNil(t, tm)
+	assert.NotNil(t, tm.metrics)
+	assert.False(t, tm.firstTokenSent)
+}
+
+func TestStartRequest(t *testing.T) {
+	tm := NewTokenMetrics()
+	before := time.Now()
+	tm.StartRequest("test-backend", "test-model")
+	after := time.Now()
+
+	assert.False(t, tm.firstTokenSent)
+	assert.True(t, tm.requestStart.After(before) || tm.requestStart.Equal(before))
+	assert.True(t, tm.requestStart.Before(after) || tm.requestStart.Equal(after))
+}
+
+func TestUpdateTokenMetrics(t *testing.T) {
+	// Reset the default registry to avoid conflicts with other tests
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	tm := NewTokenMetrics()
+	tm.UpdateTokenMetrics("test-backend", "test-model", 10, 5, 15)
+
+	// Get the current value of the metrics
+	completion := getCounterValue(t, tm.metrics.TokensTotal, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+		"type":    "completion",
+	})
+	prompt := getCounterValue(t, tm.metrics.TokensTotal, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+		"type":    "prompt",
+	})
+	total := getCounterValue(t, tm.metrics.TokensTotal, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+		"type":    "total",
+	})
+
+	assert.Equal(t, float64(10), completion)
+	assert.Equal(t, float64(5), prompt)
+	assert.Equal(t, float64(15), total)
+}
+
+func TestUpdateLatencyMetrics(t *testing.T) {
+	// Reset the default registry to avoid conflicts with other tests
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	tm := NewTokenMetrics()
+	tm.StartRequest("test-backend", "test-model")
+
+	// Test first token
+	time.Sleep(10 * time.Millisecond)
+	tm.UpdateLatencyMetrics("test-backend", "test-model", 1)
+	assert.True(t, tm.firstTokenSent)
+
+	firstTokenLatency := getHistogramValue(t, tm.metrics.FirstTokenLatency, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+	})
+	assert.Greater(t, firstTokenLatency, 0.0)
+
+	// Test subsequent tokens
+	time.Sleep(10 * time.Millisecond)
+	tm.UpdateLatencyMetrics("test-backend", "test-model", 2)
+
+	interTokenLatency := getHistogramValue(t, tm.metrics.InterTokenLatency, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+	})
+	assert.Greater(t, interTokenLatency, 0.0)
+
+	// Test zero tokens case
+	time.Sleep(10 * time.Millisecond)
+	tm.UpdateLatencyMetrics("test-backend", "test-model", 0)
+	assert.True(t, tm.firstTokenSent)
+
+	// Test zero tokens case
+	time.Sleep(10 * time.Millisecond)
+	tm.UpdateLatencyMetrics("test-backend", "test-model", 0)
+	assert.True(t, tm.firstTokenSent)
+}
+
+func TestUpdateRequestMetrics(t *testing.T) {
+	// Reset the default registry to avoid conflicts with other tests
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	tm := NewTokenMetrics()
+	tm.StartRequest("test-backend", "test-model")
+
+	time.Sleep(10 * time.Millisecond)
+	tm.UpdateRequestMetrics("test-backend", "test-model", "success")
+
+	// Test requests counter
+	requests := getCounterValue(t, tm.metrics.RequestsTotal, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+		"status":  "success",
+	})
+	assert.Equal(t, float64(1), requests)
+
+	// Test total latency histogram
+	totalLatency := getHistogramValue(t, tm.metrics.TotalLatency, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+		"status":  "success",
+	})
+	assert.Greater(t, totalLatency, 0.0)
+
+	// Test failed request
+	tm.UpdateRequestMetrics("test-backend", "test-model", "error")
+	failedRequests := getCounterValue(t, tm.metrics.RequestsTotal, map[string]string{
+		"backend": "test-backend",
+		"model":   "test-model",
+		"status":  "error",
+	})
+	assert.Equal(t, float64(1), failedRequests)
+}
+
+// Helper function to get the current value of a counter metric
+func getCounterValue(t *testing.T, metric *prometheus.CounterVec, labels map[string]string) float64 {
+	t.Helper()
+	m, err := metric.GetMetricWith(labels)
+	assert.NoError(t, err, "Error getting metric")
+
+	metric_pb := &dto.Metric{}
+	assert.NoError(t, m.(prometheus.Metric).Write(metric_pb), "Error writing metric")
+	return metric_pb.Counter.GetValue()
+}
+
+// Helper function to get the current sum of a histogram metric
+func getHistogramValue(t *testing.T, metric *prometheus.HistogramVec, labels map[string]string) float64 {
+	t.Helper()
+	m, err := metric.GetMetricWith(labels)
+	assert.NoError(t, err, "Error getting metric")
+
+	metric_pb := &dto.Metric{}
+	assert.NoError(t, m.(prometheus.Metric).Write(metric_pb), "Error writing metric")
+	return metric_pb.Histogram.GetSampleSum()
+}


### PR DESCRIPTION
**Commit Message**
Add prometheus metrics to extproc to track data plan metrics. These metrics help understand requests or token level usage on models and backends.

**Commit Message**

**Related Issues/PRs (if applicable)**

**Special notes for reviewers (if applicable)**

Below is an example output from extproc:
```console
# curl localhost:9190/metrics  
# HELP aigateway_first_token_latency_seconds Time to receive first token in streaming responses
# TYPE aigateway_first_token_latency_seconds histogram
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="0.1"} 0
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="0.25"} 0
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="0.5"} 0
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="1"} 1
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="2.5"} 1
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="5"} 1
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="10"} 1
aigateway_first_token_latency_seconds_bucket{backend="ollama",model="phi4",le="+Inf"} 1
aigateway_first_token_latency_seconds_sum{backend="ollama",model="phi4"} 0.566842292
aigateway_first_token_latency_seconds_count{backend="ollama",model="phi4"} 1
# HELP aigateway_inter_token_latency_seconds Time between consecutive tokens in streaming responses
# TYPE aigateway_inter_token_latency_seconds histogram
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="0.1"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="0.25"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="0.5"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="1"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="2.5"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="5"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="10"} 7
aigateway_inter_token_latency_seconds_bucket{backend="ollama",model="phi4",le="+Inf"} 7
aigateway_inter_token_latency_seconds_sum{backend="ollama",model="phi4"} 4.837e-05
aigateway_inter_token_latency_seconds_count{backend="ollama",model="phi4"} 7
# HELP aigateway_model_tokens_total Total number of tokens processed by model and type
# TYPE aigateway_model_tokens_total counter
aigateway_model_tokens_total{backend="ollama",model="phi4",type="completion"} 1048
aigateway_model_tokens_total{backend="ollama",model="phi4",type="prompt"} 34
aigateway_model_tokens_total{backend="ollama",model="phi4",type="total"} 1082
# HELP aigateway_requests_total Total number of requests processed
# TYPE aigateway_requests_total counter
aigateway_requests_total{backend="ollama",model="phi4",status="success"} 2
# HELP aigateway_total_latency_seconds Time spent processing request
# TYPE aigateway_total_latency_seconds histogram
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="0.1"} 0
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="0.5"} 0
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="1"} 1
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="2.5"} 1
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="5"} 1
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="10"} 1
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="20"} 2
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="30"} 2
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="60"} 2
aigateway_total_latency_seconds_bucket{backend="ollama",model="phi4",status="success",le="+Inf"} 2
aigateway_total_latency_seconds_sum{backend="ollama",model="phi4",status="success"} 14.449215641
aigateway_total_latency_seconds_count{backend="ollama",model="phi4",status="success"} 2
```


