### PR TITLE
controller: removes unnecessary gvks setter

### DIFF
--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -69,15 +69,6 @@ func (c *aiGatewayRouteController) Reconcile(ctx context.Context, req reconcile.
 		return ctrl.Result{}, err
 	}
 
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/1517#issuecomment-844703142
-	gvks, unversioned, err := c.client.Scheme().ObjectKinds(&aiGatewayRoute)
-	if err != nil {
-		panic(err)
-	}
-	if !unversioned && len(gvks) == 1 {
-		aiGatewayRoute.SetGroupVersionKind(gvks[0])
-	}
-
 	if err := c.ensuresExtProcConfigMapExists(ctx, &aiGatewayRoute); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure extproc configmap exists: %w", err)
 	}

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -395,7 +395,6 @@ func TestAIGatewayRouteController(t *testing.T) {
 		// Verify that they are the same.
 		created := item.(*aigv1a1.AIGatewayRoute)
 		require.Equal(t, "myroute", created.Name)
-		require.Equal(t, "AIGatewayRoute", created.Kind)
 
 		created.TypeMeta = metav1.TypeMeta{} // This will be populated by the controller internally, so we ignore it.
 		require.Equal(t, origin, created)


### PR DESCRIPTION
**Commit Message**

This removes the unnecessary code path of settings object kinds during the reconciliation of AIGatewayRoute. Previously, it existed only because there was a check in tests/controller.