### PR TITLE
chore: moves redis.yaml to manifests/envoy-gateway-config

### DIFF
--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -40,7 +40,7 @@ jobs:
           fi
       - name: Check no markdown format link in PR description.
         run: |
-          if echo "$BODY" | grep -q '\[.*\]\(.*\)'; then
+          if echo "$BODY" | grep -q '\[[^]]\+\](\([^)]\+\))'; then
             echo "PR description contains markdown format link. Please remove all of them."
             exit 1
           fi

--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -45,10 +45,10 @@ jobs:
             echo "If you want to refer to a link, please use the following format where you place the link at the end of the PR description:"
             echo ""
             echo "**Commit Message**:"
-            echo "This modifies foo bar. The official documentation can be found [1] and [2]. Please refer to them for more details."
+            echo "This modifies foo bar. The official documentation can be found at [1] and [2]. Please refer to them for more details."
             echo ""
-            echo "[1]: https://example.com"
-            echo "[2]: https://another.com"
+            echo "1: https://example.com"
+            echo "2: https://another.com"
             exit 1
           fi
 

--- a/manifests/envoy-gateway-config/redis.yaml
+++ b/manifests/envoy-gateway-config/redis.yaml
@@ -1,3 +1,7 @@
+# This is a simple example of a Redis deployment that is used
+# by the default Envoy Gateway setting in config.yaml.
+#
+# This is only necessary if you want to use the rate limit feature.
 ---
 kind: Namespace
 apiVersion: v1

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -27,6 +27,7 @@ kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-contr
 After installing Envoy AI Gateway, apply the AI Gateway-specific configuration to Envoy Gateway, restart the deployment, and wait for it to be ready:
 
 ```shell
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-config/redis.yaml
 kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-config/config.yaml
 kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-config/rbac.yaml
 
@@ -34,6 +35,9 @@ kubectl rollout restart -n envoy-gateway-system deployment/envoy-gateway
 
 kubectl wait --timeout=2m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 ```
+
+Note that the redis configuration is only used for the rate limiting feature. If you don't need rate limiting, you can skip the redis configuration,
+but you need to remove the relevant configuration in the `config.yaml` file as well.
 
 :::tip Verify Installation
 


### PR DESCRIPTION
**Commit Message**

Previously, redis was not part of manifests/envoy-gateway/config and only deployed during e2e tests, not mentioned in the documentation site. However, the Envoy Gateway config assumes the existence of redis deployment hence users followed the tutorial might have observed the crashing deployment of rate-limit-service. In addition, we now have a rate limit doc[1], so the deployment of the redis must be a part of the set up.


1: https://envoy-ai-gateway.netlify.app/docs/capabilities/usage-based-ratelimiting 