### PR TITLE
e2e: adds admin interface in extproc test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ out/
 *for_tests.yaml
 .vscode
 
+# This is the placeholder for the access log file during extproc tests.
+ACCESS_LOG_PATH
+
 # Files and directories to ignore in the site directory
 # dependencies
 site/node_modules

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -5,7 +5,9 @@
 
 admin:
   address:
-    socket_address: { address: 127.0.0.1, port_value: 9901 }
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
 
 static_resources:
   listeners:

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -3,6 +3,10 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+admin:
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+
 static_resources:
   listeners:
     - address:


### PR DESCRIPTION
**Commit Message**

This will be helpful in debugging connectivity especially. Now you can spawn `envoy -c ./tests/extproc/envoy.yaml` and open `localhost:9901` on your browser to debug the connectivity.