### PR TITLE
extproc: removes Iface suffix from processor

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -22,8 +22,8 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )
 
-// NewChatCompletionProcessor implements [ProcessorIface] for the /chat/completions endpoint.
-func NewChatCompletionProcessor(config *processorConfig, requestHeaders map[string]string, logger *slog.Logger) ProcessorIface {
+// NewChatCompletionProcessor implements [Processor] for the /chat/completions endpoint.
+func NewChatCompletionProcessor(config *processorConfig, requestHeaders map[string]string, logger *slog.Logger) Processor {
 	return &chatCompletionProcessor{
 		config:         config,
 		requestHeaders: requestHeaders,
@@ -60,7 +60,7 @@ func (c *chatCompletionProcessor) selectTranslator(out filterapi.VersionedAPISch
 	return nil
 }
 
-// ProcessRequestHeaders implements [ProcessorIface.ProcessRequestHeaders].
+// ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
 func (c *chatCompletionProcessor) ProcessRequestHeaders(_ context.Context, _ *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
 	// The request headers have already been at the time the processor was created
 	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestHeaders{
@@ -68,7 +68,7 @@ func (c *chatCompletionProcessor) ProcessRequestHeaders(_ context.Context, _ *co
 	}}, nil
 }
 
-// ProcessRequestBody implements [ProcessorIface.ProcessRequestBody].
+// ProcessRequestBody implements [Processor.ProcessRequestBody].
 func (c *chatCompletionProcessor) ProcessRequestBody(ctx context.Context, rawBody *extprocv3.HttpBody) (res *extprocv3.ProcessingResponse, err error) {
 	path := c.requestHeaders[":path"]
 	model, body, err := c.config.bodyParser(path, rawBody)
@@ -124,7 +124,7 @@ func (c *chatCompletionProcessor) ProcessRequestBody(ctx context.Context, rawBod
 	return resp, nil
 }
 
-// ProcessResponseHeaders implements [ProcessorIface.ProcessResponseHeaders].
+// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
 func (c *chatCompletionProcessor) ProcessResponseHeaders(_ context.Context, headers *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
 	c.responseHeaders = headersToMap(headers)
 	if enc := c.responseHeaders["content-encoding"]; enc != "" {
@@ -148,7 +148,7 @@ func (c *chatCompletionProcessor) ProcessResponseHeaders(_ context.Context, head
 	}}, nil
 }
 
-// ProcessResponseBody implements [ProcessorIface.ProcessResponseBody].
+// ProcessResponseBody implements [Processor.ProcessResponseBody].
 func (c *chatCompletionProcessor) ProcessResponseBody(_ context.Context, body *extprocv3.HttpBody) (res *extprocv3.ProcessingResponse, err error) {
 	var br io.Reader
 	switch c.responseEncoding {

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -24,12 +24,12 @@ import (
 )
 
 var (
-	_ ProcessorIface        = &mockProcessor{}
+	_ Processor             = &mockProcessor{}
 	_ translator.Translator = &mockTranslator{}
 	_ x.Router              = &mockRouter{}
 )
 
-func newMockProcessor(_ *processorConfig, _ *slog.Logger) ProcessorIface {
+func newMockProcessor(_ *processorConfig, _ *slog.Logger) Processor {
 	return &mockProcessor{}
 }
 
@@ -42,25 +42,25 @@ type mockProcessor struct {
 	retErr                error
 }
 
-// ProcessRequestHeaders implements [ProcessorIface.ProcessRequestHeaders].
+// ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
 func (m mockProcessor) ProcessRequestHeaders(_ context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
 	require.Equal(m.t, m.expHeaderMap, headerMap)
 	return m.retProcessingResponse, m.retErr
 }
 
-// ProcessRequestBody implements [ProcessorIface.ProcessRequestBody].
+// ProcessRequestBody implements [Processor.ProcessRequestBody].
 func (m mockProcessor) ProcessRequestBody(_ context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
 	require.Equal(m.t, m.expBody, body)
 	return m.retProcessingResponse, m.retErr
 }
 
-// ProcessResponseHeaders implements [ProcessorIface.ProcessResponseHeaders].
+// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
 func (m mockProcessor) ProcessResponseHeaders(_ context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
 	require.Equal(m.t, m.expHeaderMap, headerMap)
 	return m.retProcessingResponse, m.retErr
 }
 
-// ProcessResponseBody implements [ProcessorIface.ProcessResponseBody].
+// ProcessResponseBody implements [Processor.ProcessResponseBody].
 func (m mockProcessor) ProcessResponseBody(_ context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
 	require.Equal(m.t, m.expBody, body)
 	return m.retProcessingResponse, m.retErr

--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -21,20 +21,20 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 )
 
-// modelsProcessor implements [ProcessorIface] for the `/v1/models` endpoint.
+// modelsProcessor implements [Processor] for the `/v1/models` endpoint.
 // This processor returns an immediate response with the list of models that are declared in the filter
 // configuration.
 // Since it returns an immediate response after processing the headers, the rest of the methods of the
-// ProcessorIface are not implemented. Those should never be called.
+// Processor are not implemented. Those should never be called.
 type modelsProcessor struct {
 	logger *slog.Logger
 	models openai.ModelList
 }
 
-var _ ProcessorIface = (*modelsProcessor)(nil)
+var _ Processor = (*modelsProcessor)(nil)
 
 // NewModelsProcessor creates a new processor that returns the list of declared models
-func NewModelsProcessor(config *processorConfig, _ map[string]string, logger *slog.Logger) ProcessorIface {
+func NewModelsProcessor(config *processorConfig, _ map[string]string, logger *slog.Logger) Processor {
 	models := openai.ModelList{
 		Object: "list",
 		Data:   make([]openai.Model, 0, len(config.declaredModels)),
@@ -50,7 +50,7 @@ func NewModelsProcessor(config *processorConfig, _ map[string]string, logger *sl
 	return &modelsProcessor{logger: logger, models: models}
 }
 
-// ProcessRequestHeaders implements [ProcessorIface.ProcessRequestHeaders].
+// ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
 func (m *modelsProcessor) ProcessRequestHeaders(_ context.Context, _ *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
 	m.logger.Info("Serving list of declared models")
 
@@ -77,17 +77,17 @@ func (m *modelsProcessor) ProcessRequestHeaders(_ context.Context, _ *corev3.Hea
 
 var errUnexpectedCall = errors.New("unexpected method call")
 
-// ProcessRequestBody implements [ProcessorIface.ProcessRequestBody].
+// ProcessRequestBody implements [Processor.ProcessRequestBody].
 func (m *modelsProcessor) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
 	return nil, fmt.Errorf("%w: ProcessRequestBody", errUnexpectedCall)
 }
 
-// ProcessResponseHeaders implements [ProcessorIface.ProcessResponseHeaders].
+// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
 func (m *modelsProcessor) ProcessResponseHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
 	return nil, fmt.Errorf("%w: ProcessResponseHeaders", errUnexpectedCall)
 }
 
-// ProcessResponseBody implements [ProcessorIface.ProcessResponseBody].
+// ProcessResponseBody implements [Processor.ProcessResponseBody].
 func (m *modelsProcessor) ProcessResponseBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
 	return nil, fmt.Errorf("%w: ProcessResponseBody", errUnexpectedCall)
 }

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -39,11 +39,11 @@ type processorConfigRequestCost struct {
 }
 
 // ProcessorFactory is the factory function used to create new instances of a processor.
-type ProcessorFactory func(*processorConfig, map[string]string, *slog.Logger) ProcessorIface
+type ProcessorFactory func(*processorConfig, map[string]string, *slog.Logger) Processor
 
-// ProcessorIface is the interface for the processor.
+// Processor is the interface for the processor.
 // This decouples the processor implementation detail from the server implementation.
-type ProcessorIface interface {
+type Processor interface {
 	// ProcessRequestHeaders processes the request headers message.
 	ProcessRequestHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error)
 	// ProcessRequestBody processes the request body message.

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -124,7 +124,7 @@ func (s *Server) Register(path string, newProcessor ProcessorFactory) {
 
 // processorForPath returns the processor for the given path.
 // Only exact path matching is supported currently
-func (s *Server) processorForPath(requestHeaders map[string]string) (ProcessorIface, error) {
+func (s *Server) processorForPath(requestHeaders map[string]string) (Processor, error) {
 	path := requestHeaders[":path"]
 	newProcessor, ok := s.processors[path]
 	if !ok {
@@ -140,7 +140,7 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 
 	// The processor will be instantiated when the first message containing the request headers is received.
 	// The :path header is used to determine the processor to use, based on the registered ones.
-	var p ProcessorIface
+	var p Processor
 
 	for {
 		select {
@@ -182,7 +182,7 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 	}
 }
 
-func (s *Server) processMsg(ctx context.Context, p ProcessorIface, req *extprocv3.ProcessingRequest) (*extprocv3.ProcessingResponse, error) {
+func (s *Server) processMsg(ctx context.Context, p Processor, req *extprocv3.ProcessingRequest) (*extprocv3.ProcessingResponse, error) {
 	switch value := req.Request.(type) {
 	case *extprocv3.ProcessingRequest_RequestHeaders:
 		requestHdrs := req.GetRequestHeaders().Headers

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -31,7 +31,7 @@ func requireNewServerWithMockProcessor(t *testing.T) (*Server, *mockProcessor) {
 	s.config = &processorConfig{}
 
 	m := newMockProcessor(s.config, s.logger)
-	s.Register("/", func(*processorConfig, map[string]string, *slog.Logger) ProcessorIface { return m })
+	s.Register("/", func(*processorConfig, map[string]string, *slog.Logger) Processor { return m })
 
 	return s, m.(*mockProcessor)
 }
@@ -266,11 +266,11 @@ func TestServer_ProcessorSelection(t *testing.T) {
 	require.NotNil(t, s)
 
 	s.config = &processorConfig{}
-	s.Register("/one", func(*processorConfig, map[string]string, *slog.Logger) ProcessorIface {
+	s.Register("/one", func(*processorConfig, map[string]string, *slog.Logger) Processor {
 		// Returning nil guarantees that the test will fail if this processor is selected
 		return nil
 	})
-	s.Register("/two", func(*processorConfig, map[string]string, *slog.Logger) ProcessorIface {
+	s.Register("/two", func(*processorConfig, map[string]string, *slog.Logger) Processor {
 		return &mockProcessor{
 			t:                     t,
 			expHeaderMap:          &corev3.HeaderMap{Headers: []*corev3.HeaderValue{{Key: ":path", Value: "/two"}}},


### PR DESCRIPTION
**Commit Message**

This removes the unnecessary suffix "Iface" from extproc.ProcessorIface interface. 

**Related Issues/PRs (if applicable)**

Follow up on  #325