### PR TITLE
e2e: collect kind logs on failure and destroy cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ out/
 # This is the placeholder for the access log file during extproc tests.
 ACCESS_LOG_PATH
 
+tests/e2e/logs
+
 # Files and directories to ignore in the site directory
 # dependencies
 site/node_modules


### PR DESCRIPTION
**Commit Message**

e2e: collect kind logs on failure and destroy cluster

When e2e tests succeed, destroy the kind cluster. When e2e tests fail, keep the kind cluster up & running for troubleshooting, and collect the logs to the `tests/e2e/logs` directory to facilitate log analysis.
These logs are also uploaded as CI artifacts when e2e fail, to help troubleshoot why e2e tests could have failed on CI.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
