### PR TITLE
docs: use correct JSON key names in basic-usage.md

### DIFF
--- a/site/docs/getting-started/basic-usage.md
+++ b/site/docs/getting-started/basic-usage.md
@@ -136,8 +136,8 @@ For real AI model responses, see the [Connect Providers](./connect-providers) gu
 ### Understanding the Response Format
 
 The basic setup includes a mock backend that demonstrates the API structure but doesn't provide real AI responses. The response format follows the standard chat completion format with:
-- A `completions` array containing responses
-- Each response having a `role` and `content`
+- A `choices` array containing responses
+- Each message having a `role` and `content`
 
 ## Next Steps
 

--- a/tests/internal/testupstreamlib/testupstream/main.go
+++ b/tests/internal/testupstreamlib/testupstream/main.go
@@ -356,7 +356,7 @@ var chatCompletionFakeResponses = []string{
 func getFakeResponse(path string) ([]byte, error) {
 	switch path {
 	case "/v1/chat/completions":
-		const template = `{"choices":[{"message":{"content":"%s"}}]}`
+		const template = `{"choices":[{"message":{"role":"assistant", "content":"%s"}}]}`
 		msg := fmt.Sprintf(template,
 			//nolint:gosec
 			chatCompletionFakeResponses[rand.New(rand.NewSource(uint64(time.Now().UnixNano()))).


### PR DESCRIPTION
**Commit Message**

docs: use correct JSON key names in basic-usage.md for the example chat completion.

Also make the `testupstream` server return a `.choices[].message.role` field to
be consistent with docs.
