### PR TITLE
docs: update AWS Bedrock next steps

### DIFF
--- a/site/docs/getting-started/connect-providers/aws-bedrock.md
+++ b/site/docs/getting-started/connect-providers/aws-bedrock.md
@@ -100,4 +100,4 @@ If you encounter issues:
 ## Next Steps
 
 After configuring AWS Bedrock:
-- [Connect OpenAI](./openai.md) to add another provider
+- [Connect Local Model](./localmodel.md) to add another provider


### PR DESCRIPTION
**Commit Message**

to link to next page for "Connect Local Model"
instead of linking to previous page "Connect OpenAI."