### PR TITLE
docs: fixes maintainers url in Chart.yaml

### DIFF
--- a/manifests/charts/ai-gateway-helm/Chart.yaml
+++ b/manifests/charts/ai-gateway-helm/Chart.yaml
@@ -14,7 +14,7 @@ icon: https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/heads/main/si
 
 maintainers:
   - name: envoy-ai-gateway-maintainers
-    url: https://github.com/envoyproxy/gateway/blob/main/CODEOWNERS
+    url: https://github.com/envoyproxy/ai-gateway/blob/main/CODEOWNERS
 
 keywords:
   - gateway-api


### PR DESCRIPTION
**Commit Message**

This fixes the maintainers url in our helm chart which previously incorrectly pointed to EG.