### PR TITLE
controller: fixes extproc config update on removal

### DIFF
--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -181,15 +181,17 @@ func extProcName(route *aigv1a1.AIGatewayRoute) string {
 
 func applyExtProcDeploymentConfigUpdate(d *appsv1.DeploymentSpec, filterConfig *aigv1a1.AIGatewayFilterConfig) {
 	if filterConfig == nil || filterConfig.ExternalProcessor == nil {
+		d.Replicas = nil
+		d.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
 		return
 	}
 	extProc := filterConfig.ExternalProcessor
 	if resource := extProc.Resources; resource != nil {
 		d.Template.Spec.Containers[0].Resources = *resource
+	} else {
+		d.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
 	}
-	if replica := extProc.Replicas; replica != nil {
-		d.Replicas = replica
-	}
+	d.Replicas = extProc.Replicas
 }
 
 // syncAIGatewayRoute implements syncAIGatewayRouteFn.


### PR DESCRIPTION
**Commit Message**

Previously, the deployment config is populated with the values specified in the AIGatewayRoute resource and not removed if the values is not specified. For example, after a replica value is specified, if a user removes it from AIGatewayFilterConfig, then the replica is not reverted to a default value. This fixes applyExtProcDeploymentConfigUpdate so that it will remove the previously specified value.

Thanks for pointing out @sanposhiho !