### PR TITLE
chore: local default settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 .idea
 *for_tests.yaml
 .vscode
+.makerc
 
 # This is the placeholder for the access log file during extproc tests.
 ACCESS_LOG_PATH

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+# Read any local configuration. This is an optional, local git-ignored file that can be used
+# to set any value commonly used for development. This helps not having to set the overrides
+# in the command line every time.
+-include .makerc
+
 # The Go-based tools are defined in Makefile.tools.mk.
 include Makefile.tools.mk
 


### PR DESCRIPTION
**Commit Message**

chore: local default settings file

Allows having a local `.makerc` file with the custom values for the make variables.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
