### PR TITLE
docs: removes --fail flags

### DIFF
--- a/site/docs/capabilities/usage-based-ratelimiting.md
+++ b/site/docs/capabilities/usage-based-ratelimiting.md
@@ -154,8 +154,7 @@ For proper cost control and rate limiting, requests must include:
 
 Example request:
 ```shell
-curl --fail \
-    -H "Content-Type: application/json" \
+curl -H "Content-Type: application/json" \
     -H "x-user-id: user123" \
     -d '{
         "model": "gpt-4",

--- a/site/docs/getting-started/basic-usage.md
+++ b/site/docs/getting-started/basic-usage.md
@@ -90,8 +90,7 @@ kubectl port-forward -n envoy-gateway-system svc/$ENVOY_SERVICE 8080:80
 Open a new terminal and send a test request to the AI Gateway using the `GATEWAY_URL` we set up:
 
 ```shell
-curl --fail \
-    -H "Content-Type: application/json" \
+curl -H "Content-Type: application/json" \
     -d '{
         "model": "some-cool-self-hosted-model",
         "messages": [

--- a/site/docs/getting-started/connect-providers/aws-bedrock.md
+++ b/site/docs/getting-started/connect-providers/aws-bedrock.md
@@ -65,8 +65,7 @@ You should have set `$GATEWAY_URL` as part of the basic setup before connecting 
 See the [Basic Usage](../basic-usage.md) page for instructions.
 
 ```shell
-curl --fail \
-  -H "Content-Type: application/json" \
+curl -H "Content-Type: application/json" \
   -d '{
     "model": "us.meta.llama3-2-1b-instruct-v1:0",
     "messages": [

--- a/site/docs/getting-started/connect-providers/openai.md
+++ b/site/docs/getting-started/connect-providers/openai.md
@@ -54,8 +54,7 @@ You should have set `$GATEWAY_URL` as part of the basic setup before connecting 
 See the [Basic Usage](../basic-usage.md) page for instructions.
 
 ```shell
-curl --fail \
-  -H "Content-Type: application/json" \
+curl -H "Content-Type: application/json" \
   -d '{
     "model": "gpt-4o-mini",
     "messages": [


### PR DESCRIPTION
**Commit Message**

At the first iteration of the "getting started guide", I added `--fail` in all commands as we had an automated testing of the site documentation and it allowed us to detect if the curl command not is working. However, now we don't have any tests like that + `--fail` prevents users from seeing the actual error response from the upstream which makes it difficult to troubleshoot since it suppresses the response body due to the early cancel of requests. 

**Related Issues/PRs (if applicable)**

The root cause of #379 #375 

