### PR TITLE
extproc: remove noise when reloading config

### DIFF
--- a/internal/extproc/watcher.go
+++ b/internal/extproc/watcher.go
@@ -24,11 +24,12 @@ type ConfigReceiver interface {
 }
 
 type configWatcher struct {
-	lastMod time.Time
-	path    string
-	rcv     ConfigReceiver
-	l       *slog.Logger
-	current string
+	lastMod         time.Time
+	path            string
+	rcv             ConfigReceiver
+	l               *slog.Logger
+	current         string
+	usingDefaultCfg bool
 }
 
 // StartConfigWatcher starts a watcher for the given path and Receiver.
@@ -81,13 +82,18 @@ func (cw *configWatcher) loadConfig(ctx context.Context) error {
 	}
 
 	if cfg != nil {
+		if cw.usingDefaultCfg { // Do not re-reload the same thing on every tick
+			return nil
+		}
 		cw.l.Info("config file does not exist; loading default config", slog.String("path", cw.path))
 		cw.lastMod = time.Now()
+		cw.usingDefaultCfg = true
 	} else {
-		cw.l.Info("loading a new config", slog.String("path", cw.path))
+		cw.usingDefaultCfg = false
 		if stat.ModTime().Sub(cw.lastMod) <= 0 {
 			return nil
 		}
+		cw.l.Info("loading a new config", slog.String("path", cw.path))
 		cw.lastMod = stat.ModTime()
 		cfg, raw, err = filterapi.UnmarshalConfigYaml(cw.path)
 		if err != nil {


### PR DESCRIPTION
**Commit Message**

extproc: remove noise when reloading config

Reduce the noise when configuration is reloaded. Only print logs when the configuration actually changes and do not reload the default config on every tick.

**Related Issues/PRs (if applicable)**

Related to https://github.com/envoyproxy/ai-gateway/pull/376

**Special notes for reviewers (if applicable)**

N/A