### PR TITLE
docs: add note on enabling model access

### DIFF
--- a/site/docs/getting-started/connect-providers/aws-bedrock.md
+++ b/site/docs/getting-started/connect-providers/aws-bedrock.md
@@ -23,6 +23,9 @@ Ensure you have:
    - `bedrock:InvokeModel`
    - `bedrock:ListFoundationModels`
 3. Your AWS access key ID and secret access key
+4. Enabled model access to "Llama 3.2 1B Instruct" in the `us-east-1` region
+   - If you want to use a different AWS region, you must update all instances of the string
+     `us-east-1` with the desired region in `basic.yaml`.
 
 :::tip AWS Best Practices
 Consider using AWS IAM roles and limited-scope credentials for production environments.


### PR DESCRIPTION
**Commit Message**

docs: add note on enabling model access in the Connect AWS Bedrock page for the Llama 3.2 1B Instruct model in the `us-east-1` region specifically.

Otherwise, user will get this error.

```console
$ curl --silent \
        -H "Content-Type: application/json" \
        -d '{
      "model": "us.meta.llama3-2-1b-instruct-v1:0",
      "messages": [
        {
          "role": "user",
          "content": "Hi."
        }
      ]
    }' \
        $GATEWAY_URL/v1/chat/completions | jq .
{
  "type": "error",
  "error": {
    "type": "AccessDeniedException:http://internal.amazon.com/coral/com.amazon.bedrock/",
    "code": "403",
    "message": "You don't have access to the model with the specified model ID."
  }
}
```