### PR TITLE
build: pin container tags to the release tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,12 +285,14 @@ helm-package: helm-lint
 	@go tool helm package ${HELM_DIR} --app-version ${HELM_CHART_VERSION} --version ${HELM_CHART_VERSION} -d ${OUTPUT_DIR}
 
 .PHONY: helm-test
+helm-test: HELM_CHART_PATH = $(OUTPUT_DIR)/ai-gateway-helm-v9.9.9.tgz
+helm-test: HELM_CHART_VERSION = v9.9.9
 helm-test:
 	$(MAKE) helm-package HELM_CHART_VERSION=v9.9.9
-	@go tool helm show chart $(OUTPUT_DIR)/ai-gateway-helm-v9.9.9.tgz | grep -q "version: v9.9.9"
-	@go tool helm show chart $(OUTPUT_DIR)/ai-gateway-helm-v9.9.9.tgz | grep -q "appVersion: v9.9.9"
-	@go tool helm template $(OUTPUT_DIR)/ai-gateway-helm-v9.9.9.tgz | grep -q "ghcr.io/envoyproxy/ai-gateway/extproc:v9.9.9"
-	@go tool helm template $(OUTPUT_DIR)/ai-gateway-helm-v9.9.9.tgz | grep -q "ghcr.io/envoyproxy/ai-gateway/controller:v9.9.9"
+	@go tool helm show chart ${HELM_CHART_PATH} | grep -q "version: ${HELM_CHART_VERSION}"
+	@go tool helm show chart ${HELM_CHART_PATH} | grep -q "appVersion: ${HELM_CHART_VERSION}"
+	@go tool helm template ${HELM_CHART_PATH} | grep -q "ghcr.io/envoyproxy/ai-gateway/extproc:${HELM_CHART_VERSION}"
+	@go tool helm template ${HELM_CHART_PATH} | grep -q "ghcr.io/envoyproxy/ai-gateway/controller:${HELM_CHART_VERSION}"
 
 # This pushes the helm chart to the OCI registry, requiring the access to the registry endpoint.
 .PHONY: helm-push

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ helm-package: helm-lint
 	@echo "helm-package => ${HELM_DIR}"
 	@go tool helm package ${HELM_DIR} --app-version ${HELM_CHART_VERSION} --version ${HELM_CHART_VERSION} -d ${OUTPUT_DIR}
 
+# This tests the helm chart, ensuring that the container images are set to have the correct version tag.
 .PHONY: helm-test
 helm-test: HELM_CHART_VERSION = v9.9.9
 helm-test: HELM_CHART_PATH = $(OUTPUT_DIR)/ai-gateway-helm-${HELM_CHART_VERSION}.tgz

--- a/Makefile
+++ b/Makefile
@@ -285,10 +285,9 @@ helm-package: helm-lint
 	@go tool helm package ${HELM_DIR} --app-version ${HELM_CHART_VERSION} --version ${HELM_CHART_VERSION} -d ${OUTPUT_DIR}
 
 .PHONY: helm-test
-helm-test: HELM_CHART_PATH = $(OUTPUT_DIR)/ai-gateway-helm-v9.9.9.tgz
 helm-test: HELM_CHART_VERSION = v9.9.9
-helm-test:
-	$(MAKE) helm-package HELM_CHART_VERSION=v9.9.9
+helm-test: HELM_CHART_PATH = $(OUTPUT_DIR)/ai-gateway-helm-${HELM_CHART_VERSION}.tgz
+helm-test: helm-package
 	@go tool helm show chart ${HELM_CHART_PATH} | grep -q "version: ${HELM_CHART_VERSION}"
 	@go tool helm show chart ${HELM_CHART_PATH} | grep -q "appVersion: ${HELM_CHART_VERSION}"
 	@go tool helm template ${HELM_CHART_PATH} | grep -q "ghcr.io/envoyproxy/ai-gateway/extproc:${HELM_CHART_VERSION}"

--- a/manifests/charts/ai-gateway-helm/Chart.yaml
+++ b/manifests/charts/ai-gateway-helm/Chart.yaml
@@ -12,7 +12,7 @@ type: application
 # version must be a semver version number like 0.0.1-rc1, 1.0.0, etc., vs appVersion can be anything.
 #
 # Since we release both the chart and the application together from the same repo, we don't need to differentiate
-# between the two versions. Since version here cannot be "latest" or "main" or "master", we use appVersion for
+# between the two versions. version here cannot be "latest" or "main" or "master", so we use appVersion for
 # the container image tags.
 version: v0.0.0-latest
 appVersion: "latest"

--- a/manifests/charts/ai-gateway-helm/Chart.yaml
+++ b/manifests/charts/ai-gateway-helm/Chart.yaml
@@ -8,6 +8,12 @@ name: ai-gateway-helm
 description: The Helm chart for Envoy AI Gateway
 type: application
 
+# Note: in general version means the version of the chart, not the version of the application.
+# version must be a semver version number like 0.0.1-rc1, 1.0.0, etc., vs appVersion can be anything.
+#
+# Since we release both the chart and the application together from the same repo, we don't need to differentiate
+# between the two versions. Since version here cannot be "latest" or "main" or "master", we use appVersion for
+# the container image tags.
 version: v0.0.0-latest
 appVersion: "latest"
 icon: https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/heads/main/site/static/img/logo.svg

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -8,7 +8,7 @@
 extProc:
   repository: ghcr.io/envoyproxy/ai-gateway/extproc
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
   # One of "info", "debug", "trace", "warn", "error", "fatal", "panic".
   logLevel: info
 
@@ -32,7 +32,7 @@ controller:
     repository: ghcr.io/envoyproxy/ai-gateway/controller
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "latest"
+    tag: ""
   replicaCount: 1
   imagePullSecrets: []
   podAnnotations: {}


### PR DESCRIPTION
**Commit Message**

Previously, the container tags were pined to "latest" despite the version of helm chart being set to a release tag. This fixes it and adds a test.

