### PR TITLE
extproc: return HTTP 404 when no matching route

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -10,16 +10,19 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )
@@ -84,6 +87,17 @@ func (c *chatCompletionProcessor) ProcessRequestBody(ctx context.Context, rawBod
 	c.requestHeaders[c.config.modelNameHeaderKey] = model
 	b, err := c.config.router.Calculate(c.requestHeaders)
 	if err != nil {
+		if errors.Is(err, router.ErrNoMatchingRule) {
+			return &extprocv3.ProcessingResponse{
+				Response: &extprocv3.ProcessingResponse_ImmediateResponse{
+					ImmediateResponse: &extprocv3.ImmediateResponse{
+						Status: &typev3.HttpStatus{Code: typev3.StatusCode_NotFound},
+						Body:   []byte(err.Error()),
+					},
+				},
+			}, nil
+		}
+
 		return nil, fmt.Errorf("failed to calculate route: %w", err)
 	}
 	c.logger.Info("Selected backend", "backend", b.Name)

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -15,6 +15,9 @@ import (
 	"github.com/envoyproxy/ai-gateway/filterapi/x"
 )
 
+// ErrNoMatchingRule is the error when no matching rule is found.
+var ErrNoMatchingRule = errors.New("no matching rule found")
+
 // router implements [x.Router].
 type router struct {
 	rules []filterapi.RouteRule
@@ -46,7 +49,7 @@ func (r *router) Calculate(headers map[string]string) (backend *filterapi.Backen
 		}
 	}
 	if rule == nil {
-		return nil, errors.New("no matching rule found")
+		return nil, ErrNoMatchingRule
 	}
 	return r.selectBackendFromRule(rule), nil
 }


### PR DESCRIPTION
**Commit Message**

extproc: return HTTP 404 when no matching route
in `AIGatewayRoute` instead of a 500 status code.

## Before

```console
$ curl \
    -H "Content-Type: application/json" \
    -d '{
    "model": "DEADBEEF",
    "messages": [
        {
            "role": "user",
            "content": "Who should be king of the world? Be direct, decisive, and opinionated."
        }
    ]
}' $GATEWAY_URL/v1/chat/completions -i
HTTP/1.1 500 Not Found
content-length: 22
content-type: text/plain
date: Fri, 21 Feb 2025 12:51:06 GMT
```

## After

```console
$ curl \
    -H "Content-Type: application/json" \
    -d '{
    "model": "DEADBEEF",
    "messages": [
        {
            "role": "user",
            "content": "Who should be king of the world? Be direct, decisive, and opinionated."
        }
    ]
}' $GATEWAY_URL/v1/chat/completions -i
HTTP/1.1 404 Not Found
content-length: 22
content-type: text/plain
date: Fri, 21 Feb 2025 12:51:06 GMT

no matching rule found
```