### PR TITLE
extproc: make the route not found error public

### DIFF
--- a/filterapi/x/x.go
+++ b/filterapi/x/x.go
@@ -6,11 +6,18 @@
 // Package x is an experimental package that provides the customizability of the AI Gateway filter.
 package x
 
-import "github.com/envoyproxy/ai-gateway/filterapi"
+import (
+	"errors"
+
+	"github.com/envoyproxy/ai-gateway/filterapi"
+)
 
 // NewCustomRouter is the function to create a custom router over the default router.
 // This is nil by default and can be set by the custom build of external processor.
 var NewCustomRouter NewCustomRouterFn
+
+// ErrNoMatchingRule is the error the router function must return if there is no matching rule.
+var ErrNoMatchingRule = errors.New("no matching rule found")
 
 // NewCustomRouterFn is the function signature for [NewCustomRouter].
 //

--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -21,8 +21,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
+	"github.com/envoyproxy/ai-gateway/filterapi/x"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
-	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )
@@ -87,7 +87,7 @@ func (c *chatCompletionProcessor) ProcessRequestBody(ctx context.Context, rawBod
 	c.requestHeaders[c.config.modelNameHeaderKey] = model
 	b, err := c.config.router.Calculate(c.requestHeaders)
 	if err != nil {
-		if errors.Is(err, router.ErrNoMatchingRule) {
+		if errors.Is(err, x.ErrNoMatchingRule) {
 			return &extprocv3.ProcessingResponse{
 				Response: &extprocv3.ProcessingResponse_ImmediateResponse{
 					ImmediateResponse: &extprocv3.ImmediateResponse{

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
+	"github.com/envoyproxy/ai-gateway/filterapi/x"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
-	"github.com/envoyproxy/ai-gateway/internal/extproc/router"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )
@@ -165,7 +165,7 @@ func TestChatCompletion_ProcessRequestBody(t *testing.T) {
 	})
 	t.Run("router error 404", func(t *testing.T) {
 		headers := map[string]string{":path": "/foo"}
-		rt := mockRouter{t: t, expHeaders: headers, retErr: router.ErrNoMatchingRule}
+		rt := mockRouter{t: t, expHeaders: headers, retErr: x.ErrNoMatchingRule}
 		p := &chatCompletionProcessor{config: &processorConfig{router: rt}, requestHeaders: headers, logger: slog.Default()}
 		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
 		require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestChatCompletion_ProcessRequestBody(t *testing.T) {
 		ir := resp.GetImmediateResponse()
 		require.NotNil(t, ir)
 		require.Equal(t, typev3.StatusCode_NotFound, ir.GetStatus().GetCode())
-		require.Equal(t, router.ErrNoMatchingRule.Error(), string(ir.GetBody()))
+		require.Equal(t, x.ErrNoMatchingRule.Error(), string(ir.GetBody()))
 	})
 	t.Run("translator not found", func(t *testing.T) {
 		headers := map[string]string{":path": "/foo"}

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -6,7 +6,6 @@
 package router
 
 import (
-	"errors"
 	"time"
 
 	"golang.org/x/exp/rand"
@@ -14,9 +13,6 @@ import (
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/filterapi/x"
 )
-
-// ErrNoMatchingRule is the error when no matching rule is found.
-var ErrNoMatchingRule = errors.New("no matching rule found")
 
 // router implements [x.Router].
 type router struct {
@@ -49,7 +45,7 @@ func (r *router) Calculate(headers map[string]string) (backend *filterapi.Backen
 		}
 	}
 	if rule == nil {
-		return nil, ErrNoMatchingRule
+		return nil, x.ErrNoMatchingRule
 	}
 	return r.selectBackendFromRule(rule), nil
 }


### PR DESCRIPTION
**Commit Message**

extproc: make the route not found error public

This moves the route not found error to the `x` package together with the router interfaces so that custom implementations of the routing function can import and return it.


**Related Issues/PRs (if applicable)**

Follow-up for the post-merge comment in https://github.com/envoyproxy/ai-gateway/pull/399

**Special notes for reviewers (if applicable)**

N/A