### PR TITLE
extproc: pick random backend when multiple unweighted ones

### DIFF
--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -57,9 +57,12 @@ func (r *router) selectBackendFromRule(rule *filterapi.RouteRule) (backend *filt
 	for _, b := range rule.Backends {
 		totalWeight += b.Weight
 	}
+
+	// Pick a random backend if none of them have a weight.
 	if totalWeight == 0 {
-		return &rule.Backends[0]
+		return &rule.Backends[r.rng.Intn(len(rule.Backends))]
 	}
+
 	selected := r.rng.Intn(totalWeight)
 	for i := range rule.Backends {
 		b := &rule.Backends[i]


### PR DESCRIPTION
**Commit Message**

Right now if there are multiple, unweighted `backendRefs` in a [AIGatewayRouteRule], the first one is always returned. The correct behavior is to return a random one since they're essentially all weighted the same.

[AIGatewayRouteRule]: https://envoy-ai-gateway.netlify.app/docs/api/#aigatewayrouterule

**Related Issues/PRs (if applicable)**

contributes to #53 