### PR TITLE
extproc: fix openai response choice conversion for tool use

### DIFF
--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -889,8 +889,6 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 						Role: "assistant",
 						Content: []*awsbedrock.ContentBlock{
 							{Text: ptr.To("response")},
-							{Text: ptr.To("from")},
-							{Text: ptr.To("assistant")},
 						},
 					},
 				},
@@ -907,22 +905,6 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 						Index: 0,
 						Message: openai.ChatCompletionResponseChoiceMessage{
 							Content: ptr.To("response"),
-							Role:    "assistant",
-						},
-						FinishReason: openai.ChatCompletionChoicesFinishReasonStop,
-					},
-					{
-						Index: 1,
-						Message: openai.ChatCompletionResponseChoiceMessage{
-							Content: ptr.To("from"),
-							Role:    "assistant",
-						},
-						FinishReason: openai.ChatCompletionChoicesFinishReasonStop,
-					},
-					{
-						Index: 2,
-						Message: openai.ChatCompletionResponseChoiceMessage{
-							Content: ptr.To("assistant"),
 							Role:    "assistant",
 						},
 						FinishReason: openai.ChatCompletionChoicesFinishReasonStop,
@@ -974,9 +956,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 				Output: &awsbedrock.ConverseOutput{
 					Message: awsbedrock.Message{
 						Role: awsbedrock.ConversationRoleAssistant,
+						// Text and ToolUse are sent in two different content blocks for AWS Bedrock, OpenAI merges them in one message.
 						Content: []*awsbedrock.ContentBlock{
 							{
 								Text: ptr.To("response"),
+							},
+							{
 								ToolUse: &awsbedrock.ToolUseBlock{
 									Name:      "exec_python_code",
 									ToolUseID: "call_6g7a",

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -889,6 +889,8 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 						Role: "assistant",
 						Content: []*awsbedrock.ContentBlock{
 							{Text: ptr.To("response")},
+							{Text: ptr.To("from")},
+							{Text: ptr.To("assistant")},
 						},
 					},
 				},

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -120,7 +120,7 @@ func TestWithTestUpstream(t *testing.T) {
 			responseBody:    `{"output":{"message":{"content":[{"text":"response"},{"text":"from"},{"text":"assistant"}],"role":"assistant"}},"stopReason":null,"usage":{"inputTokens":10,"outputTokens":20,"totalTokens":30}}`,
 			expRequestBody:  `{"inferenceConfig":{},"messages":[],"modelId":null,"system":[{"text":"You are a chatbot."}]}`,
 			expStatus:       http.StatusOK,
-			expResponseBody: `{"choices":[{"finish_reason":"stop","index":0,"logprobs":{},"message":{"content":"response","role":"assistant"}},{"finish_reason":"stop","index":1,"logprobs":{},"message":{"content":"from","role":"assistant"}},{"finish_reason":"stop","index":2,"logprobs":{},"message":{"content":"assistant","role":"assistant"}}],"object":"chat.completion","usage":{"completion_tokens":20,"prompt_tokens":10,"total_tokens":30}}`,
+			expResponseBody: `{"choices":[{"finish_reason":"stop","index":0,"logprobs":{},"message":{"content":"response","role":"assistant"}}],"object":"chat.completion","usage":{"completion_tokens":20,"prompt_tokens":10,"total_tokens":30}}`,
 		},
 		{
 			name:            "openai - /v1/chat/completions",


### PR DESCRIPTION
**Commit Message**
This fixes the OpenAI chat completion response choices conversion, there could only be one choice as AWS Bedrock does not support N choices. The previous code translated multiple content blocks to multiple choices which was wrong and for converse response there could be only one text block, however there can be multiple content blocks for text and toolUse.

**Related Issues/PRs (if applicable)**
Fixes #405 

**Special notes for reviewers (if applicable)**

Tested with the real AWS Bedrock with converse response including both text and toolUse content blocks.
This is an example of converse response and the previous code made wrong assumption that it is in the same content block:
```json
{
  "message": {
    "role": "assistant",
    "content": [
      {
        "text": "To get the weather information for Queens, NY, I'll need to use the get_weather function. Let me fetch that information for you."
      },
      {
        "toolUse": {
          "toolUseId": "tooluse_qYVb7Vo1QpWkmbgCm1VTZg",
          "name": "get_weather",
          "input": {
            "city": "Queens",
            "state": "NY"
          }
        }
      }
    ]
  }
}
```