### PR TITLE
ci: migrate to docker.io from ghcr

### DIFF
--- a/.github/workflows/docker_builds_template.yaml
+++ b/.github/workflows/docker_builds_template.yaml
@@ -40,12 +40,11 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db  # v3.6.1
 
-      - name: Login into GitHub Container Registry
+      - name: Login into DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       # Push images for the push events, e.g. when a new tag is pushed as well as PR merges.
       # * Only use the tag if the event is a tag event, otherwise use "latest".

--- a/.github/workflows/docker_builds_template.yaml
+++ b/.github/workflows/docker_builds_template.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Login into DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_TMP }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       # Push images for the push events, e.g. when a new tag is pushed as well as PR merges.

--- a/.github/workflows/docker_builds_template.yaml
+++ b/.github/workflows/docker_builds_template.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Login into DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME_TMP }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       # Push images for the push events, e.g. when a new tag is pushed as well as PR merges.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ jobs:
   docker_push:
     name: Push Docker Images
     uses: ./.github/workflows/docker_builds_template.yaml
+    secrets: inherit
 
   release:
     needs: [docker_push]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,12 +22,11 @@ jobs:
 
       # To include the helm chart in the release artifact, we build and push it here instead of the separate job.
       - uses: actions/checkout@v4
-      - name: Login into GitHub Container Registry
+      - name: Login into DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Push Helm chart
         run: make helm-push HELM_CHART_VERSION=${HELM_CHART_VERSION}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,7 @@ on:
 
   push:
     branches:
+      # TODO: revert.
       - 'dockerregistrymigration'
       - 'release/**'
     paths-ignore:
@@ -41,154 +42,155 @@ permissions:
   packages: write
 
 jobs:
-  unittest:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    name: Unit Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          cache: false
-          go-version-file: go.mod
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/go/bin
-          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - run: make test-coverage
-
-  test_crdcel:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    name: CRD CEL Validation Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          cache: false
-          go-version-file: go.mod
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/go/bin
-          key: celvalidation-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - run: make test-crdcel
-
-  test_controller:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    name: Controller Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          cache: false
-          go-version-file: go.mod
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/go/bin
-          key: controller-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - run: make test-controller
-
-  test_extproc:
-    name: External Processor Test (Envoy ${{ matrix.name }})
-    # Not all the cases in E2E require secrets, so we run for all the events.
-    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: v1.33
-            envoy_version: envoyproxy/envoy:v1.33-latest
-          - name: latest
-            envoy_version: envoyproxy/envoy-dev:latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-        if: github.event_name == 'pull_request_target'
-      - uses: actions/setup-go@v5
-        with:
-          cache: false
-          go-version-file: go.mod
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/go/bin
-          key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - name: Install Envoy
-        run: |
-          export ENVOY_BIN_DIR=$HOME/envoy/bin
-          mkdir -p $ENVOY_BIN_DIR
-          docker run -v $ENVOY_BIN_DIR:/tmp/ci -w /tmp/ci \
-          --entrypoint /bin/cp ${{ matrix.envoy_version }} /usr/local/bin/envoy .
-          echo $ENVOY_BIN_DIR >> $GITHUB_PATH
-      - env:
-          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
-          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
-          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
-        run: make test-extproc
-
-  test_e2e:
-    # Not all the cases in E2E require secrets, so we run for all the events.
-    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
-    name: E2E Test (Envoy Gateway ${{ matrix.name }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: v1.3.0
-            envoy_gateway_version: v1.3.0
-          - name: latest
-            envoy_gateway_version: v0.0.0-latest
-    steps:
-      - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-        if: github.event_name == 'pull_request_target'
-      - uses: actions/setup-go@v5
-        with:
-          cache: false
-          go-version-file: go.mod
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/.cache/golangci-lint
-            ~/go/pkg/mod
-            ~/go/bin
-          key: e2e-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - uses: docker/setup-buildx-action@v3
-      - env:
-          EG_VERSION: ${{ matrix.envoy_gateway_version }}
-          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
-          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
-          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
-        run: make test-e2e
+#  unittest:
+#    if: github.event_name == 'pull_request' || github.event_name == 'push'
+#    name: Unit Test
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-go@v5
+#        with:
+#          cache: false
+#          go-version-file: go.mod
+#      - uses: actions/cache@v4
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/go/pkg/mod
+#            ~/go/bin
+#          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+#      - run: make test-coverage
+#
+#  test_crdcel:
+#    if: github.event_name == 'pull_request' || github.event_name == 'push'
+#    name: CRD CEL Validation Test
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-go@v5
+#        with:
+#          cache: false
+#          go-version-file: go.mod
+#      - uses: actions/cache@v4
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/go/pkg/mod
+#            ~/go/bin
+#          key: celvalidation-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+#      - run: make test-crdcel
+#
+#  test_controller:
+#    if: github.event_name == 'pull_request' || github.event_name == 'push'
+#    name: Controller Test
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-go@v5
+#        with:
+#          cache: false
+#          go-version-file: go.mod
+#      - uses: actions/cache@v4
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/go/pkg/mod
+#            ~/go/bin
+#          key: controller-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+#      - run: make test-controller
+#
+#  test_extproc:
+#    name: External Processor Test (Envoy ${{ matrix.name }})
+#    # Not all the cases in E2E require secrets, so we run for all the events.
+#    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - name: v1.33
+#            envoy_version: envoyproxy/envoy:v1.33-latest
+#          - name: latest
+#            envoy_version: envoyproxy/envoy-dev:latest
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        if: github.event_name != 'pull_request_target'
+#      - uses: actions/checkout@v4
+#        with:
+#          ref: ${{ github.event.pull_request.head.ref }}
+#          repository: ${{ github.event.pull_request.head.repo.full_name }}
+#        if: github.event_name == 'pull_request_target'
+#      - uses: actions/setup-go@v5
+#        with:
+#          cache: false
+#          go-version-file: go.mod
+#      - uses: actions/cache@v4
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/go/pkg/mod
+#            ~/go/bin
+#          key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+#      - name: Install Envoy
+#        run: |
+#          export ENVOY_BIN_DIR=$HOME/envoy/bin
+#          mkdir -p $ENVOY_BIN_DIR
+#          docker run -v $ENVOY_BIN_DIR:/tmp/ci -w /tmp/ci \
+#          --entrypoint /bin/cp ${{ matrix.envoy_version }} /usr/local/bin/envoy .
+#          echo $ENVOY_BIN_DIR >> $GITHUB_PATH
+#      - env:
+#          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
+#          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
+#          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
+#        run: make test-extproc
+#
+#  test_e2e:
+#    # Not all the cases in E2E require secrets, so we run for all the events.
+#    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
+#    name: E2E Test (Envoy Gateway ${{ matrix.name }})
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - name: v1.3.0
+#            envoy_gateway_version: v1.3.0
+#          - name: latest
+#            envoy_gateway_version: v0.0.0-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        if: github.event_name != 'pull_request_target'
+#      - uses: actions/checkout@v4
+#        with:
+#          ref: ${{ github.event.pull_request.head.ref }}
+#          repository: ${{ github.event.pull_request.head.repo.full_name }}
+#        if: github.event_name == 'pull_request_target'
+#      - uses: actions/setup-go@v5
+#        with:
+#          cache: false
+#          go-version-file: go.mod
+#      - uses: actions/cache@v4
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/.cache/golangci-lint
+#            ~/go/pkg/mod
+#            ~/go/bin
+#          key: e2e-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+#      - uses: docker/setup-buildx-action@v3
+#      - env:
+#          EG_VERSION: ${{ matrix.envoy_gateway_version }}
+#          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
+#          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
+#          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
+#        run: make test-e2e
 
   docker_push:
     # Docker builds are verified in test_e2e job, so we only need to push the images when the event is a push event.
     if: github.event_name == 'push'
     name: Push Docker Images
-    needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e]
+    # TODO: revert.
+    # needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e]
     uses: ./.github/workflows/docker_builds_template.yaml
 
   helm_push:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,10 +37,6 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.actor }}-${{ github.event_name }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
 #  unittest:
 #    if: github.event_name == 'pull_request' || github.event_name == 'push'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,10 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.actor }}-${{ github.event_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
 #  unittest:
 #    if: github.event_name == 'pull_request' || github.event_name == 'push'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests
 on:
   pull_request:
     branches:
-      - 'dockerregistrymigration'
+      - 'main'
       # Release branches are like "release/v0.1", "release/v0.2", etc. where we backport the changes to non EOL versions.
       # The branch will be created from the main branch after the initial release tag is cut. For example, when we cut v0.8.0 release,
       # we will create a branch "release/v0.8" from the main branch. For rc release, we simply iterate on main branch.
@@ -16,7 +16,7 @@ on:
 
   push:
     branches:
-      - 'main'
+      - 'dockerregistrymigration'
       - 'release/**'
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -192,6 +192,7 @@ jobs:
     # TODO: revert.
     # needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e]
     uses: ./.github/workflows/docker_builds_template.yaml
+    secrets: inherit
 
   helm_push:
     name: Push Helm chart

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests
 on:
   pull_request:
     branches:
-      - 'main'
+      - 'dockerregistrymigration'
       # Release branches are like "release/v0.1", "release/v0.2", etc. where we backport the changes to non EOL versions.
       # The branch will be created from the main branch after the initial release tag is cut. For example, when we cut v0.8.0 release,
       # we will create a branch "release/v0.8" from the main branch. For rc release, we simply iterate on main branch.
@@ -199,10 +199,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Login into GitHub Container Registry
+      - name: Login into DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - run: make helm-push

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,8 +16,7 @@ on:
 
   push:
     branches:
-      # TODO: revert.
-      - 'dockerregistrymigration'
+      - 'main'
       - 'release/**'
     paths-ignore:
       - '**/*.md'
@@ -42,155 +41,154 @@ permissions:
   packages: write
 
 jobs:
-#  unittest:
-#    if: github.event_name == 'pull_request' || github.event_name == 'push'
-#    name: Unit Test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-go@v5
-#        with:
-#          cache: false
-#          go-version-file: go.mod
-#      - uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#            ~/go/bin
-#          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-#      - run: make test-coverage
-#
-#  test_crdcel:
-#    if: github.event_name == 'pull_request' || github.event_name == 'push'
-#    name: CRD CEL Validation Test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-go@v5
-#        with:
-#          cache: false
-#          go-version-file: go.mod
-#      - uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#            ~/go/bin
-#          key: celvalidation-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-#      - run: make test-crdcel
-#
-#  test_controller:
-#    if: github.event_name == 'pull_request' || github.event_name == 'push'
-#    name: Controller Test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-go@v5
-#        with:
-#          cache: false
-#          go-version-file: go.mod
-#      - uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#            ~/go/bin
-#          key: controller-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-#      - run: make test-controller
-#
-#  test_extproc:
-#    name: External Processor Test (Envoy ${{ matrix.name }})
-#    # Not all the cases in E2E require secrets, so we run for all the events.
-#    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - name: v1.33
-#            envoy_version: envoyproxy/envoy:v1.33-latest
-#          - name: latest
-#            envoy_version: envoyproxy/envoy-dev:latest
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        if: github.event_name != 'pull_request_target'
-#      - uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.event.pull_request.head.ref }}
-#          repository: ${{ github.event.pull_request.head.repo.full_name }}
-#        if: github.event_name == 'pull_request_target'
-#      - uses: actions/setup-go@v5
-#        with:
-#          cache: false
-#          go-version-file: go.mod
-#      - uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#            ~/go/bin
-#          key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-#      - name: Install Envoy
-#        run: |
-#          export ENVOY_BIN_DIR=$HOME/envoy/bin
-#          mkdir -p $ENVOY_BIN_DIR
-#          docker run -v $ENVOY_BIN_DIR:/tmp/ci -w /tmp/ci \
-#          --entrypoint /bin/cp ${{ matrix.envoy_version }} /usr/local/bin/envoy .
-#          echo $ENVOY_BIN_DIR >> $GITHUB_PATH
-#      - env:
-#          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
-#          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
-#          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
-#        run: make test-extproc
-#
-#  test_e2e:
-#    # Not all the cases in E2E require secrets, so we run for all the events.
-#    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
-#    name: E2E Test (Envoy Gateway ${{ matrix.name }})
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - name: v1.3.0
-#            envoy_gateway_version: v1.3.0
-#          - name: latest
-#            envoy_gateway_version: v0.0.0-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        if: github.event_name != 'pull_request_target'
-#      - uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.event.pull_request.head.ref }}
-#          repository: ${{ github.event.pull_request.head.repo.full_name }}
-#        if: github.event_name == 'pull_request_target'
-#      - uses: actions/setup-go@v5
-#        with:
-#          cache: false
-#          go-version-file: go.mod
-#      - uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/.cache/golangci-lint
-#            ~/go/pkg/mod
-#            ~/go/bin
-#          key: e2e-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-#      - uses: docker/setup-buildx-action@v3
-#      - env:
-#          EG_VERSION: ${{ matrix.envoy_gateway_version }}
-#          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
-#          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
-#          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
-#        run: make test-e2e
+  unittest:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    name: Unit Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - run: make test-coverage
+
+  test_crdcel:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    name: CRD CEL Validation Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: celvalidation-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - run: make test-crdcel
+
+  test_controller:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    name: Controller Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: controller-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - run: make test-controller
+
+  test_extproc:
+    name: External Processor Test (Envoy ${{ matrix.name }})
+    # Not all the cases in E2E require secrets, so we run for all the events.
+    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: v1.33
+            envoy_version: envoyproxy/envoy:v1.33-latest
+          - name: latest
+            envoy_version: envoyproxy/envoy-dev:latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+        if: github.event_name == 'pull_request_target'
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - name: Install Envoy
+        run: |
+          export ENVOY_BIN_DIR=$HOME/envoy/bin
+          mkdir -p $ENVOY_BIN_DIR
+          docker run -v $ENVOY_BIN_DIR:/tmp/ci -w /tmp/ci \
+          --entrypoint /bin/cp ${{ matrix.envoy_version }} /usr/local/bin/envoy .
+          echo $ENVOY_BIN_DIR >> $GITHUB_PATH
+      - env:
+          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
+          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
+          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
+        run: make test-extproc
+
+  test_e2e:
+    # Not all the cases in E2E require secrets, so we run for all the events.
+    if: (github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    name: E2E Test (Envoy Gateway ${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: v1.3.0
+            envoy_gateway_version: v1.3.0
+          - name: latest
+            envoy_gateway_version: v0.0.0-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+        if: github.event_name == 'pull_request_target'
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version-file: go.mod
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+            ~/go/pkg/mod
+            ~/go/bin
+          key: e2e-test-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+      - uses: docker/setup-buildx-action@v3
+      - env:
+          EG_VERSION: ${{ matrix.envoy_gateway_version }}
+          TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
+          TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
+          TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
+        run: make test-e2e
 
   docker_push:
     # Docker builds are verified in test_e2e job, so we only need to push the images when the event is a push event.
     if: github.event_name == 'push'
     name: Push Docker Images
-    # TODO: revert.
-    # needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e]
+    needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e]
     uses: ./.github/workflows/docker_builds_template.yaml
     secrets: inherit
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Trivy vulnerability scanner for ${{ matrix.target.command_name }}
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/envoyproxy/ai-gateway/${{ matrix.target.command_name }}:${{ github.sha }}
+          image-ref: docker.io/envoyproxy/ai-gateway-${{ matrix.target.command_name }}:${{ github.sha }}
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
           vuln-type: 'os,library'

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ GO_LDFLAGS += -X $(VERSION_PACKAGE).Version=$(GIT_COMMIT)
 OUTPUT_DIR ?= out
 
 # Arguments for docker builds.
-OCI_REGISTRY ?= ghcr.io/envoyproxy/ai-gateway
+OCI_REGISTRY ?= docker.io/envoyproxy
+OCI_REPOSITORY_PREFIX ?= ${OCI_REGISTRY}/ai-gateway
 TAG ?= latest
 ENABLE_MULTI_PLATFORMS ?= false
 HELM_CHART_VERSION ?= v0.0.0-latest
@@ -257,7 +258,7 @@ endif
 docker-build.%:
 	$(eval COMMAND_NAME := $(subst docker-build.,,$@))
 	@$(MAKE) build.$(COMMAND_NAME) GOOS_LIST="linux" GOARCH_LIST="$(GOARCH_LIST)"
-	docker buildx build . -t $(OCI_REGISTRY)/$(COMMAND_NAME):$(TAG) --build-arg COMMAND_NAME=$(COMMAND_NAME) $(PLATFORMS) $(DOCKER_BUILD_ARGS)
+	docker buildx build . -t $(OCI_REPOSITORY_PREFIX)-$(COMMAND_NAME):$(TAG) --build-arg COMMAND_NAME=$(COMMAND_NAME) $(PLATFORMS) $(DOCKER_BUILD_ARGS)
 
 # This builds docker images for all commands under cmd/ directory. All options for `docker-build.%` apply.
 #
@@ -291,8 +292,8 @@ helm-test: HELM_CHART_PATH = $(OUTPUT_DIR)/ai-gateway-helm-${HELM_CHART_VERSION}
 helm-test: helm-package
 	@go tool helm show chart ${HELM_CHART_PATH} | grep -q "version: ${HELM_CHART_VERSION}"
 	@go tool helm show chart ${HELM_CHART_PATH} | grep -q "appVersion: ${HELM_CHART_VERSION}"
-	@go tool helm template ${HELM_CHART_PATH} | grep -q "ghcr.io/envoyproxy/ai-gateway/extproc:${HELM_CHART_VERSION}"
-	@go tool helm template ${HELM_CHART_PATH} | grep -q "ghcr.io/envoyproxy/ai-gateway/controller:${HELM_CHART_VERSION}"
+	@go tool helm template ${HELM_CHART_PATH} | grep -q "docker.io/envoyproxy/ai-gateway-extproc:${HELM_CHART_VERSION}"
+	@go tool helm template ${HELM_CHART_PATH} | grep -q "docker.io/envoyproxy/ai-gateway-controller:${HELM_CHART_VERSION}"
 
 # This pushes the helm chart to the OCI registry, requiring the access to the registry endpoint.
 .PHONY: helm-push

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,7 +42,7 @@ func parseAndValidateFlags(args []string) (
 	)
 	extProcImagePtr := fs.String(
 		"extProcImage",
-		"ghcr.io/envoyproxy/ai-gateway/extproc:latest",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest",
 		"The image for the external processor",
 	)
 	enableLeaderElectionPtr := fs.Bool(

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -15,7 +15,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 	t.Run("no flags", func(t *testing.T) {
 		extProcLogLevel, extProcImage, enableLeaderElection, logLevel, extensionServerPort, err := parseAndValidateFlags([]string{})
 		require.Equal(t, "info", extProcLogLevel)
-		require.Equal(t, "ghcr.io/envoyproxy/ai-gateway/extproc:latest", extProcImage)
+		require.Equal(t, "docker.io/envoyproxy/ai-gateway-extproc:latest", extProcImage)
 		require.True(t, enableLeaderElection)
 		require.Equal(t, "info", logLevel.String())
 		require.Equal(t, ":1063", extensionServerPort)

--- a/examples/basic/basic.yaml
+++ b/examples/basic/basic.yaml
@@ -218,7 +218,7 @@ spec:
     spec:
       containers:
         - name: testupstream
-          image: ghcr.io/envoyproxy/ai-gateway/testupstream:latest
+          image: docker.io/envoyproxy/ai-gateway-testupstream:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -6,7 +6,7 @@
 # Default values for ai-gateway-helm.
 
 extProc:
-  repository: ghcr.io/envoyproxy/ai-gateway/extproc
+  repository: docker.io/envoyproxy/ai-gateway-extproc
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # One of "info", "debug", "trace", "warn", "error", "fatal", "panic".
@@ -29,7 +29,7 @@ controller:
 
   # -- Deployment configs --
   image:
-    repository: ghcr.io/envoyproxy/ai-gateway/controller
+    repository: docker.io/envoyproxy/ai-gateway-controller
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/site/docs/getting-started/index.md
+++ b/site/docs/getting-started/index.md
@@ -44,7 +44,7 @@ helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
   --namespace envoy-gateway-system \
   --create-namespace
 
-helm upgrade -i aieg oci://ghcr.io/envoyproxy/ai-gateway/ai-gateway-helm \
+helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
   --version v0.0.0-latest \
   --namespace envoy-ai-gateway-system \
   --create-namespace

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ This guide will walk you through installing Envoy AI Gateway and its required co
 The easiest way to install Envoy AI Gateway is using the Helm chart. First, install the AI Gateway Helm chart and wait for the deployment to be ready:
 
 ```shell
-helm upgrade -i aieg oci://ghcr.io/envoyproxy/ai-gateway/ai-gateway-helm \
+helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
     --version v0.0.0-latest \
     --namespace envoy-ai-gateway-system \
     --create-namespace

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -121,9 +121,9 @@ func initKindCluster(ctx context.Context) (err error) {
 
 	initLog("\tLoading Docker images into kind cluster")
 	for _, image := range []string{
-		"ghcr.io/envoyproxy/ai-gateway/controller:latest",
-		"ghcr.io/envoyproxy/ai-gateway/extproc:latest",
-		"ghcr.io/envoyproxy/ai-gateway/testupstream:latest",
+		"docker.io/envoyproxy/ai-gateway-controller:latest",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest",
+		"docker.io/envoyproxy/ai-gateway-testupstream:latest",
 	} {
 		cmd := exec.CommandContext(ctx, "go", "tool", "kind", "load", "docker-image", image, "--name", kindClusterName)
 		cmd.Stdout = os.Stdout

--- a/tests/e2e/init/testupstream/manifest.yaml
+++ b/tests/e2e/init/testupstream/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: testupstream
-          image: ghcr.io/envoyproxy/ai-gateway/testupstream:latest
+          image: docker.io/envoyproxy/ai-gateway-testupstream:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
         - name: testupstream-canary
-          image: ghcr.io/envoyproxy/ai-gateway/testupstream:latest
+          image: docker.io/envoyproxy/ai-gateway-testupstream:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: TESTUPSTREAM_ID


### PR DESCRIPTION
**Commit Message**

This will switch to Docker Hub from GHCR for analytics purpose. Envoy organization is sponsored by Docker and it provides useful features that are not available with GHCR. The workflow is already verified to work. After this commit, our images will be published at

* https://hub.docker.com/r/envoyproxy/ai-gateway-helm
* https://hub.docker.com/r/envoyproxy/ai-gateway-controller
* https://hub.docker.com/r/envoyproxy/ai-gateway-extproc
* https://hub.docker.com/r/envoyproxy/ai-gateway-testupstream