### PR TITLE
chore: ignore test debug log dir from codespell

### DIFF
--- a/.codespell.skip
+++ b/.codespell.skip
@@ -8,3 +8,4 @@
 ./site/yarn-error.log*
 ./go.mod
 ./go.sum
+./tests/e2e/logs


### PR DESCRIPTION
**Commit Message**

This makes codespell ignore the log directory of e2e test.

**Related Issues/PRs (if applicable)**

follow up on #359
