### PR TITLE
extproc: fixes race condition with RNG

### DIFF
--- a/internal/extproc/router/router_test.go
+++ b/internal/extproc/router/router_test.go
@@ -6,6 +6,7 @@
 package router
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -109,6 +110,19 @@ func TestRouter_Calculate(t *testing.T) {
 		require.Greater(t, chosenNames["bar"], chosenNames["foo"])
 		require.Greater(t, chosenNames["bar"], 700)
 		require.Greater(t, chosenNames["foo"], 200)
+	})
+
+	t.Run("concurrent access", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(100)
+		for range 100 {
+			go func() {
+				defer wg.Done()
+				b, err := r.Calculate(map[string]string{"x-model-name": "llama3.3333"})
+				require.NoError(t, err)
+				require.NotNil(t, b)
+			}()
+		}
 	})
 }
 

--- a/internal/extproc/router/router_test.go
+++ b/internal/extproc/router/router_test.go
@@ -134,6 +134,7 @@ func TestRouter_Calculate(t *testing.T) {
 			}()
 		}
 		wg.Wait()
+		require.Equal(t, int32(1000), bar.Load()+foo.Load())
 		require.Greater(t, bar.Load(), foo.Load())
 		require.Greater(t, bar.Load(), int32(700))
 		require.Greater(t, foo.Load(), int32(200))

--- a/internal/extproc/router/router_test.go
+++ b/internal/extproc/router/router_test.go
@@ -123,6 +123,7 @@ func TestRouter_Calculate(t *testing.T) {
 				require.NotNil(t, b)
 			}()
 		}
+		wg.Wait()
 	})
 }
 


### PR DESCRIPTION
**Commit Message**

Previously, router instance shared the rng among multiple goroutines which is not a thread safe. This fixes it by having a goroutine local RNG. 


**Related Issues/PRs (if applicable)**

Contributes to #53 
