### PR TITLE
extproc: properly handle early response

### DIFF
--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -56,18 +56,22 @@ type Processor interface {
 // passThroughProcessor implements the Processor interface.
 type passThroughProcessor struct{}
 
-func (p *passThroughProcessor) ProcessRequestHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+// ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
+func (p passThroughProcessor) ProcessRequestHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
 	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{}}, nil
 }
 
-func (p *passThroughProcessor) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+// ProcessRequestBody implements [Processor.ProcessRequestBody].
+func (p passThroughProcessor) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
 	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseBody{}}, nil
 }
 
-func (p *passThroughProcessor) ProcessResponseHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
+func (p passThroughProcessor) ProcessResponseHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
 	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{}}, nil
 }
 
-func (p *passThroughProcessor) ProcessResponseBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+// ProcessResponseBody implements [Processor.ProcessResponseBody].
+func (p passThroughProcessor) ProcessResponseBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
 	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseBody{}}, nil
 }

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -52,3 +52,22 @@ type Processor interface {
 	// ProcessResponseBody processes the response body message.
 	ProcessResponseBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error)
 }
+
+// passThroughProcessor implements the Processor interface.
+type passThroughProcessor struct{}
+
+func (p *passThroughProcessor) ProcessRequestHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{}}, nil
+}
+
+func (p *passThroughProcessor) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseBody{}}, nil
+}
+
+func (p *passThroughProcessor) ProcessResponseHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{}}, nil
+}
+
+func (p *passThroughProcessor) ProcessResponseBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseBody{}}, nil
+}

--- a/internal/extproc/processor_test.go
+++ b/internal/extproc/processor_test.go
@@ -1,0 +1,40 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"testing"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_passThroughProcessor(t *testing.T) { // This is mostly for coverage.
+	p := passThroughProcessor{}
+	resp, err := p.ProcessRequestHeaders(t.Context(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_, ok := resp.Response.(*extprocv3.ProcessingResponse_ResponseHeaders)
+	require.True(t, ok)
+
+	resp, err = p.ProcessRequestBody(t.Context(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_, ok = resp.Response.(*extprocv3.ProcessingResponse_ResponseBody)
+	require.True(t, ok)
+
+	resp, err = p.ProcessResponseHeaders(t.Context(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_, ok = resp.Response.(*extprocv3.ProcessingResponse_ResponseHeaders)
+	require.True(t, ok)
+
+	resp, err = p.ProcessResponseBody(t.Context(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_, ok = resp.Response.(*extprocv3.ProcessingResponse_ResponseBody)
+	require.True(t, ok)
+}

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -141,7 +141,7 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 	// an earlier filter has already processed the request headers/bodies and decided to terminate
 	// the request by sending an immediate response. In this case, we will use the passThroughProcessor
 	// to pass the request through without any processing as there would be nothing to process from AI Gateway's perspective.
-	var p Processor = &passThroughProcessor{}
+	var p Processor = passThroughProcessor{}
 
 	for {
 		select {
@@ -170,6 +170,8 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 				return status.Error(codes.NotFound, err.Error())
 			}
 		}
+
+		// At this point, p is guaranteed to be a valid processor either from the concrete processor or the passThroughProcessor.
 
 		resp, err := s.processMsg(ctx, p, req)
 		if err != nil {

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -136,7 +136,12 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 
 	// The processor will be instantiated when the first message containing the request headers is received.
 	// The :path header is used to determine the processor to use, based on the registered ones.
-	var p Processor
+	//
+	// If this extproc filter is invoked without going through a RequestHeaders phase, that means
+	// an earlier filter has already processed the request headers/bodies and decided to terminate
+	// the request by sending an immediate response. In this case, we will use the passThroughProcessor
+	// to pass the request through without any processing as there would be nothing to process from AI Gateway's perspective.
+	var p Processor = &passThroughProcessor{}
 
 	for {
 		select {


### PR DESCRIPTION
**Commit Message**

This fixes the edge case of extproc where response header processing phase is called with request header processing being skipped. That happens when an earlier filter sends some immediate response before it even reaches the AI Gateway filter. 

**Related Issues/PRs (if applicable)**

Closes #403
