### PR TITLE
extproc: wip proposal for chat completion instrumentation

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -20,8 +21,10 @@ import (
 	"time"
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/envoyproxy/ai-gateway/internal/extproc"
 	"github.com/envoyproxy/ai-gateway/internal/version"
@@ -32,6 +35,7 @@ type extProcFlags struct {
 	configPath  string     // path to the configuration file.
 	extProcAddr string     // gRPC address for the external processor.
 	logLevel    slog.Level // log level for the external processor.
+	promAddr    string     // Prometheus address
 }
 
 // parseAndValidateFlags parses and validates the flas passed to the external processor.
@@ -57,6 +61,11 @@ func parseAndValidateFlags(args []string) (extProcFlags, error) {
 		"logLevel",
 		"info",
 		"log level for the external processor. One of 'debug', 'info', 'warn', or 'error'.",
+	)
+	fs.StringVar(&flags.promAddr,
+		"promAddr",
+		":9190",
+		"address for Prometheus metrics",
 	)
 
 	if err := fs.Parse(args); err != nil {
@@ -87,6 +96,7 @@ func Main() {
 		slog.String("version", version.Version),
 		slog.String("address", flags.extProcAddr),
 		slog.String("configPath", flags.configPath),
+		slog.String("promAddr", flags.promAddr),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -102,16 +112,36 @@ func Main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 
+	metricsProvider := extproc.NewTokenMetrics()
+
 	server, err := extproc.NewServer(l)
 	if err != nil {
 		log.Fatalf("failed to create external processor server: %v", err)
 	}
-	server.Register("/v1/chat/completions", extproc.NewChatCompletionProcessor)
+	server.Register("/v1/chat/completions", extproc.InstrumentChatCompletion(extproc.NewChatCompletionProcessor, metricsProvider))
 	server.Register("/v1/models", extproc.NewModelsProcessor)
 
 	if err := extproc.StartConfigWatcher(ctx, flags.configPath, server, l, time.Second*5); err != nil {
 		log.Fatalf("failed to start config watcher: %v", err)
 	}
+
+	handlers := http.NewServeMux()
+	handlers.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{}))
+
+	metricsServer := &http.Server{
+		Handler:           handlers,
+		Addr:              flags.promAddr,
+		ReadTimeout:       10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       15 * time.Second,
+	}
+	go func() {
+		l.Info("starting metrics server", slog.String("address", flags.promAddr))
+		if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("start metrics server failed: %v", err)
+		}
+	}()
 
 	s := grpc.NewServer()
 	extprocv3.RegisterExternalProcessorServer(s, server)
@@ -119,6 +149,7 @@ func Main() {
 	go func() {
 		<-ctx.Done()
 		s.GracefulStop()
+		_ = metricsServer.Shutdown(context.Background())
 	}()
 	_ = s.Serve(lis)
 }

--- a/cmd/extproc/mainlib/main_test.go
+++ b/cmd/extproc/mainlib/main_test.go
@@ -20,6 +20,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			args       []string
 			configPath string
 			addr       string
+			promAddr   string
 			logLevel   slog.Level
 		}{
 			{
@@ -27,6 +28,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				args:       []string{"-configPath", "/path/to/config.yaml"},
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
+				promAddr:   ":9190",
 				logLevel:   slog.LevelInfo,
 			},
 			{
@@ -34,13 +36,24 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				args:       []string{"-configPath", "/path/to/config.yaml", "-extProcAddr", "unix:///tmp/ext_proc.sock"},
 				configPath: "/path/to/config.yaml",
 				addr:       "unix:///tmp/ext_proc.sock",
+				promAddr:   ":9190",
 				logLevel:   slog.LevelInfo,
 			},
+			{
+				name:       "custom promAddr",
+				args:       []string{"-configPath", "/path/to/config.yaml", "-promAddr", ":8080"},
+				configPath: "/path/to/config.yaml",
+				addr:       ":1063",
+				promAddr:   ":8080",
+				logLevel:   slog.LevelInfo,
+			},
+
 			{
 				name:       "log level debug",
 				args:       []string{"-configPath", "/path/to/config.yaml", "-logLevel", "debug"},
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
+				promAddr:   ":9190",
 				logLevel:   slog.LevelDebug,
 			},
 			{
@@ -48,6 +61,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				args:       []string{"-configPath", "/path/to/config.yaml", "-logLevel", "warn"},
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
+				promAddr:   ":9190",
 				logLevel:   slog.LevelWarn,
 			},
 			{
@@ -55,6 +69,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				args:       []string{"-configPath", "/path/to/config.yaml", "-logLevel", "error"},
 				configPath: "/path/to/config.yaml",
 				addr:       ":1063",
+				promAddr:   ":9190",
 				logLevel:   slog.LevelError,
 			},
 			{
@@ -63,9 +78,11 @@ func Test_parseAndValidateFlags(t *testing.T) {
 					"-configPath", "/path/to/config.yaml",
 					"-extProcAddr", "unix:///tmp/ext_proc.sock",
 					"-logLevel", "debug",
+					"-promAddr", ":8080",
 				},
 				configPath: "/path/to/config.yaml",
 				addr:       "unix:///tmp/ext_proc.sock",
+				promAddr:   ":8080",
 				logLevel:   slog.LevelDebug,
 			},
 		} {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/cel-go v0.23.2
 	github.com/google/go-cmp v0.7.0
 	github.com/openai/openai-go v0.1.0-alpha.59
+	github.com/prometheus/client_golang v1.20.5
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -271,7 +272,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polyfloyd/go-errorlint v1.7.1 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/extproc/instrumented_chatcompletion_processor.go
+++ b/internal/extproc/instrumented_chatcompletion_processor.go
@@ -1,0 +1,124 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+)
+
+var _ Processor = (*instrumentedChatCompletionProcessor)(nil)
+
+// instrumentedChatCompletionProcessor is a Processor that records metrics for chat completion requests.
+type instrumentedChatCompletionProcessor struct {
+	delegate       *chatCompletionProcessor
+	metrics        TokenMetrics
+	logger         *slog.Logger
+	config         *processorConfig
+	requestStart   time.Time
+	backendName    string
+	modelName      string
+	firstTokenSent bool
+	lastTokenTime  time.Time
+}
+
+// InstrumentChatCompletion wraps a ProcessorFactory with metrics recording for chat completion requests.
+func InstrumentChatCompletion(factory ProcessorFactory, metrics TokenMetrics) ProcessorFactory {
+	return func(config *processorConfig, requestHeaders map[string]string, logger *slog.Logger) (Processor, error) {
+		processor, err := factory(config, requestHeaders, logger)
+		if err != nil {
+			return nil, err
+		}
+		ccp, ok := processor.(*chatCompletionProcessor)
+		if !ok {
+			return nil, fmt.Errorf("unsupported processor type for the chat completion instrumentation: %T", processor)
+		}
+		return &instrumentedChatCompletionProcessor{
+			delegate: ccp,
+			metrics:  metrics,
+			logger:   logger,
+			config:   config,
+		}, nil
+	}
+}
+
+// ProcessRequestHeaders implements [Processor].
+func (i *instrumentedChatCompletionProcessor) ProcessRequestHeaders(ctx context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	i.logger.Debug("Request instrumentation start")
+	i.requestStart = time.Now()
+	return i.delegate.ProcessRequestHeaders(ctx, headerMap)
+}
+
+// ProcessRequestBody implements [Processor].
+func (i *instrumentedChatCompletionProcessor) ProcessRequestBody(ctx context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	resp, err := i.delegate.ProcessRequestBody(ctx, body)
+	if err != nil {
+		i.metrics.RecordRequestMetrics(i.backendName, i.modelName, false, time.Since(i.requestStart))
+		return resp, err
+	}
+	i.modelName = headerValue(resp.GetRequestBody().GetResponse().GetHeaderMutation().GetSetHeaders(), i.config.modelNameHeaderKey)
+	i.backendName = headerValue(resp.GetRequestBody().GetResponse().GetHeaderMutation().GetSetHeaders(), i.config.selectedBackendHeaderKey)
+	return resp, err
+}
+
+// ProcessResponseHeaders implements [Processor].
+func (i *instrumentedChatCompletionProcessor) ProcessResponseHeaders(ctx context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	return i.delegate.ProcessResponseHeaders(ctx, headerMap)
+}
+
+// ProcessResponseBody implements [Processor].
+func (i *instrumentedChatCompletionProcessor) ProcessResponseBody(ctx context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	resp, err := i.delegate.ProcessResponseBody(ctx, body)
+	if err != nil {
+		i.metrics.RecordRequestMetrics(i.backendName, i.modelName, false, time.Since(i.requestStart))
+		return resp, err
+	}
+
+	// If we have some token information, and it's the first time we see tokens in the response,
+	// record the timme to first token.
+	if i.delegate.costs.InputTokens > 0 {
+		now := time.Now()
+		if !i.firstTokenSent {
+			i.logger.Debug("First token sent", "model", i.modelName, "backend", i.backendName)
+			i.metrics.RecordTimeToFirstToken(i.backendName, i.modelName, now.Sub(i.requestStart))
+			i.firstTokenSent = true
+		} else {
+			div := i.delegate.costs.OutputTokens
+			if div == 0 {
+				div = 1
+			}
+			itl := now.Sub(i.lastTokenTime).Seconds() / float64(div)
+			i.metrics.RecordInterTokenLatency(i.backendName, i.modelName, itl)
+		}
+		i.lastTokenTime = time.Now()
+	}
+
+	// If the response is the end of the stream, record the request metrics, as the request will be completed.
+	if body.EndOfStream {
+		i.logger.Debug("Request instrumentation completed", "model", i.modelName, "backend", i.backendName)
+		i.metrics.RecordRequestMetrics(i.backendName, i.modelName, true, time.Since(i.requestStart))
+		i.metrics.RecordTokenMetrics(i.backendName, i.modelName, "input", float64(i.delegate.costs.InputTokens))
+		i.metrics.RecordTokenMetrics(i.backendName, i.modelName, "output", float64(i.delegate.costs.OutputTokens))
+		i.metrics.RecordTokenMetrics(i.backendName, i.modelName, "total", float64(i.delegate.costs.TotalTokens))
+	}
+
+	return resp, err
+}
+
+// headerValue returns the value of a header with the given name, if present.
+func headerValue(headers []*corev3.HeaderValueOption, name string) string {
+	for _, h := range headers {
+		if h.Header.Key == name {
+			return string(h.Header.RawValue)
+		}
+	}
+	return ""
+}

--- a/internal/extproc/monitoring.go
+++ b/internal/extproc/monitoring.go
@@ -1,0 +1,111 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// TokenMetrics is the interface for recording token and request metrics.
+type TokenMetrics interface {
+	// RecordTokenMetrics records the number of tokens processed by model and backend.
+	RecordTokenMetrics(backendName, modelName string, valueType string, value float64)
+	// RecordRequestMetrics records the number of requests processed by model and backend.
+	RecordRequestMetrics(backendName, modelName string, success bool, duration time.Duration)
+	// RecordTimeToFirstToken records the time to receive the first token.
+	RecordTimeToFirstToken(backendName, modelName string, duration time.Duration)
+	// RecordInterTokenLatency records the time between consecutive tokens.
+	RecordInterTokenLatency(backendName, modelName string, latency float64)
+}
+
+var (
+	tokensTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aigateway_model_tokens_total",
+			Help: "Total number of tokens processed by model and type",
+		},
+		[]string{"backend", "model", "type"},
+	)
+
+	requestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aigateway_requests_total",
+			Help: "Total number of requests processed",
+		},
+		[]string{"backend", "model", "status"},
+	)
+	totalLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "aigateway_total_latency_seconds",
+			Help:    "Time spent processing request",
+			Buckets: []float64{.1, .5, 1, 2.5, 5, 10, 20, 30, 60},
+		},
+		[]string{"backend", "model", "status"},
+	)
+
+	firstTokenLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "aigateway_first_token_latency_seconds",
+			Help:    "Time to receive first token in streaming responses",
+			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"backend", "model"},
+	)
+
+	interTokenLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "aigateway_inter_token_latency_seconds",
+			Help:    "Time between consecutive tokens in streaming responses",
+			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"backend", "model"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(tokensTotal)
+	metrics.Registry.MustRegister(requestsTotal)
+	metrics.Registry.MustRegister(totalLatency)
+	metrics.Registry.MustRegister(firstTokenLatency)
+	metrics.Registry.MustRegister(interTokenLatency)
+}
+
+var _ TokenMetrics = (*tokenMetrics)(nil)
+
+type tokenMetrics struct{}
+
+// NewTokenMetrics creates a new TokenMetrics.
+func NewTokenMetrics() TokenMetrics {
+	return &tokenMetrics{}
+}
+
+// RecordTokenMetrics implements [TokenMetrics].
+func (t tokenMetrics) RecordTokenMetrics(backendName, modelName string, valueType string, value float64) {
+	tokensTotal.WithLabelValues(backendName, modelName, valueType).Add(value)
+}
+
+// RecordRequestMetrics implements [TokenMetrics].
+func (t tokenMetrics) RecordRequestMetrics(backendName, modelName string, success bool, duration time.Duration) {
+	status := "success"
+	if !success {
+		status = "error"
+	}
+	requestsTotal.WithLabelValues(backendName, modelName, status).Inc()
+	totalLatency.WithLabelValues(backendName, modelName, status).Observe(duration.Seconds())
+}
+
+// RecordTimeToFirstToken implements [TokenMetrics].
+func (t tokenMetrics) RecordTimeToFirstToken(backendName, modelName string, duration time.Duration) {
+	firstTokenLatency.WithLabelValues(backendName, modelName).Observe(duration.Seconds())
+}
+
+// RecordInterTokenLatency implements [TokenMetrics].
+func (t tokenMetrics) RecordInterTokenLatency(backendName, modelName string, latency float64) {
+	interTokenLatency.WithLabelValues(backendName, modelName).Observe(latency)
+}


### PR DESCRIPTION
**Commit Message**

exproc: instrument requests tot eh chat completion endpoint

**Related Issues/PRs (if applicable)**

Related to: https://github.com/envoyproxy/ai-gateway/pull/316

**Special notes for reviewers (if applicable)**

Opening as a draft to get early feedback on the direction.

This takes the good work that was done in https://github.com/envoyproxy/ai-gateway/pull/316 around metrics as the starting point.

The approach in this PR, however, is to just create an instrumentation decorator for the chat completion processor, to keep the metrics logic independent. This allows us to:
* Fully enable/disable instrumentation if desired.
* Properly separate concerns and responsibilities. With this we're able to test independently the processor and the instrumentation logic, keeping the processor and translator logic unmodified.
* Allow to inject mocks for the metrics provider so that we can properly unit test the instrumented processor and make sure we record metrics when needed.

@mathetake @rootfs WDYT? 

If this looks OK, I'll proceed with adding unit tests, etc, but want to get some validation on direction first, as there are things that could be discussed (such as having logic not inside and int he middle of some methods, but after they return), or this approach not be the preferred one.