### PR TITLE
controller: refactors controller.go

### DIFF
--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -366,8 +366,7 @@ func (c *AIGatewayRouteController) reconcileExtProcConfigMap(ctx context.Context
 			if err = ctrlutil.SetControllerReference(aiGatewayRoute, configMap, c.client.Scheme()); err != nil {
 				panic(fmt.Errorf("BUG: failed to set controller reference for extproc configmap: %w", err))
 			}
-			_, err = c.kube.CoreV1().ConfigMaps(aiGatewayRoute.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
-			if err != nil {
+			if _, err = c.kube.CoreV1().ConfigMaps(aiGatewayRoute.Namespace).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 				return fmt.Errorf("failed to create configmap %s: %w", name, err)
 			}
 			return nil

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -80,7 +80,7 @@ func Test_extProcName(t *testing.T) {
 }
 
 func TestAIGatewayRouteController_reconcileExtProcExtensionPolicy(t *testing.T) {
-	c := &AIGatewayRouteController{client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	c := &AIGatewayRouteController{client: fake.NewClientBuilder().WithScheme(Scheme).Build()}
 	name := "myroute"
 	ownerRef := []metav1.OwnerReference{
 		{APIVersion: "aigateway.envoyproxy.io/v1alpha1", Kind: "AIGatewayRoute", Name: name, Controller: ptr.To(true), BlockOwnerDeletion: ptr.To(true)},
@@ -214,7 +214,7 @@ func Test_applyExtProcDeploymentConfigUpdate(t *testing.T) {
 }
 
 func requireNewFakeClientWithIndexes(t *testing.T) client.Client {
-	builder := fake.NewClientBuilder().WithScheme(scheme).
+	builder := fake.NewClientBuilder().WithScheme(Scheme).
 		WithStatusSubresource(&aigv1a1.AIGatewayRoute{}).
 		WithStatusSubresource(&aigv1a1.AIServiceBackend{}).
 		WithStatusSubresource(&aigv1a1.BackendSecurityPolicy{})

--- a/internal/controller/ai_service_backend_test.go
+++ b/internal/controller/ai_service_backend_test.go
@@ -85,7 +85,7 @@ func TestAIServiceBackendController_Reconcile(t *testing.T) {
 
 func Test_AiServiceBackendIndexFunc(t *testing.T) {
 	c := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(Scheme).
 		WithIndex(&aigv1a1.AIServiceBackend{}, k8sClientIndexBackendSecurityPolicyToReferencingAIServiceBackend, aiServiceBackendIndexFunc).
 		Build()
 

--- a/internal/controller/backend_security_policy_test.go
+++ b/internal/controller/backend_security_policy_test.go
@@ -102,7 +102,7 @@ func (m *mockSTSClient) AssumeRoleWithWebIdentity(_ context.Context, _ *sts.Assu
 
 func TestBackendSecurityPolicyController_ReconcileOIDC(t *testing.T) {
 	syncFn := internaltesting.NewSyncFnImpl[aigv1a1.AIServiceBackend]()
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cl := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	c := NewBackendSecurityPolicyController(cl, fake2.NewClientset(), ctrl.Log, syncFn.Sync)
 	backendSecurityPolicyName := "mybackendSecurityPolicy"
 	namespace := "default"
@@ -143,7 +143,7 @@ func TestBackendSecurityController_RotateCredentials(t *testing.T) {
 	}))
 	defer discoveryServer.Close()
 
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cl := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	c := NewBackendSecurityPolicyController(cl, fake2.NewClientset(), ctrl.Log, internaltesting.NewSyncFnImpl[aigv1a1.AIServiceBackend]().Sync)
 	bspName := "mybackendSecurityPolicy"
 	bspNamespace := "default"

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -27,26 +27,26 @@ import (
 	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 )
 
-func init() { MustInitializeScheme(scheme) }
-
-// scheme contains the necessary schemas for the AI Gateway.
-var scheme = runtime.NewScheme()
-
-// MustInitializeScheme initializes the scheme with the necessary schemas for the AI Gateway.
-// This is exported for the testing purposes.
-func MustInitializeScheme(scheme *runtime.Scheme) {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(aigv1a1.AddToScheme(scheme))
-	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
-	utilruntime.Must(egv1a1.AddToScheme(scheme))
-	utilruntime.Must(gwapiv1.Install(scheme))
-	utilruntime.Must(gwapiv1b1.Install(scheme))
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
+	utilruntime.Must(aigv1a1.AddToScheme(Scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(Scheme))
+	utilruntime.Must(egv1a1.AddToScheme(Scheme))
+	utilruntime.Must(gwapiv1.Install(Scheme))
+	utilruntime.Must(gwapiv1b1.Install(Scheme))
 }
+
+// Scheme contains the necessary schemes for the AI Gateway.
+var Scheme = runtime.NewScheme()
 
 // Options defines the program configurable options that may be passed on the command line.
 type Options struct {
-	ExtProcLogLevel      string
-	ExtProcImage         string
+	// ExtProcLogLevel is the log level for the external processor, e.g., debug, info, warn, or error.
+	ExtProcLogLevel string
+	// ExtProcImage is the image for the external processor set on Deployment.
+	ExtProcImage string
+	// EnableLeaderElection enables leader election for the controller manager.
+	// Enabling this ensures there is only one active controller manager.
 	EnableLeaderElection bool
 }
 
@@ -68,7 +68,7 @@ type (
 // Note: this is tested with envtest, hence the test exists outside of this package. See /tests/controller_test.go.
 func StartControllers(ctx context.Context, config *rest.Config, logger logr.Logger, options Options) error {
 	opt := ctrl.Options{
-		Scheme:           scheme,
+		Scheme:           Scheme,
 		LeaderElection:   options.EnableLeaderElection,
 		LeaderElectionID: "envoy-ai-gateway-controller",
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -37,6 +37,8 @@ func init() {
 }
 
 // Scheme contains the necessary schemes for the AI Gateway.
+//
+// This is exported for testing purposes.
 var Scheme = runtime.NewScheme()
 
 // Options defines the program configurable options that may be passed on the command line.

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 
 func Test_aiGatewayRouteIndexFunc(t *testing.T) {
 	c := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(Scheme).
 		WithIndex(&aigv1a1.AIGatewayRoute{}, k8sClientIndexBackendToReferencingAIGatewayRoute, aiGatewayRouteIndexFunc).
 		Build()
 
@@ -138,7 +138,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 	} {
 		t.Run(bsp.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().
-				WithScheme(scheme).
+				WithScheme(Scheme).
 				WithIndex(&aigv1a1.BackendSecurityPolicy{}, k8sClientIndexSecretToReferencingBackendSecurityPolicy, backendSecurityPolicyIndexFunc).
 				Build()
 

--- a/tests/internal/envtest.go
+++ b/tests/internal/envtest.go
@@ -69,10 +69,8 @@ func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.I
 		}
 	})
 
-	c, err = client.New(cfg, client.Options{})
+	c, err = client.New(cfg, client.Options{Scheme: controller.Scheme})
 	require.NoError(t, err)
-
-	controller.MustInitializeScheme(c.Scheme())
 	k = kubernetes.NewForConfigOrDie(cfg)
 	return c, cfg, k
 }


### PR DESCRIPTION
**Commit Message**


This refactors controller.go. Notably, this removes the unnecessary MustInitializeScheme and just expose the initialized schema and use it in test as well. 