### PR TITLE
controller: adds comments on default / rule

### DIFF
--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -405,13 +405,12 @@ func Test_newHTTPRoute(t *testing.T) {
 				require.Equal(t, expRules[i].Matches, r.Matches)
 				require.Equal(t, expRules[i].BackendRefs, r.BackendRefs)
 				require.Equal(t, expRules[i].Timeouts, r.Timeouts)
+				// Each rule should have a host rewrite filter by default.
+				require.Len(t, r.Filters, 1)
+				require.Equal(t, gwapiv1.HTTPRouteFilterExtensionRef, r.Filters[0].Type)
+				require.NotNil(t, r.Filters[0].ExtensionRef)
+				require.Equal(t, hostRewriteHTTPFilterName, string(r.Filters[0].ExtensionRef.Name))
 			}
-
-			// Each rule should have a host rewrite filter by default.
-			require.Len(t, r.Filters, 1)
-			require.Equal(t, gwapiv1.HTTPRouteFilterExtensionRef, r.Filters[0].Type)
-			require.NotNil(t, r.Filters[0].ExtensionRef)
-			require.Equal(t, hostRewriteHTTPFilterName, string(r.Filters[0].ExtensionRef.Name))
 		})
 	}
 }

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -222,8 +222,8 @@ func TestStartControllers(t *testing.T) {
 				require.Equal(t, "x-ai-eg-selected-backend", string(httpRoute.Spec.Rules[1].Matches[0].Headers[0].Name))
 				require.Equal(t, "backend2.default", httpRoute.Spec.Rules[1].Matches[0].Headers[0].Value)
 
-				// Check all rule has the host rewrite filter.
-				for _, rule := range httpRoute.Spec.Rules {
+				// Check all rule has the host rewrite filter except for the last rule.
+				for _, rule := range httpRoute.Spec.Rules[:len(httpRoute.Spec.Rules)-1] {
 					require.Len(t, rule.Filters, 1)
 					require.NotNil(t, rule.Filters[0].ExtensionRef)
 					require.Equal(t, "ai-eg-host-rewrite", string(rule.Filters[0].ExtensionRef.Name))


### PR DESCRIPTION
**Commit Message**

This adds a code comment on why each translated HTTPRoute has a default route / on the first backend. This was brought up in the conversation in #384 and it is definitely worth a code comment on why it exists.
