### PR TITLE
chore: allows backport prefix in commit title

### DIFF
--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -80,6 +80,7 @@ jobs:
             examples
             blog
             site
+            backport
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"


### PR DESCRIPTION
**Commit Message**

This allows `backport` to be used as a commit title / PR title prefix.

**Related Issues/PRs (if applicable)**

Related to #437 