### PR TITLE
cli: adds translation for HTTPRouteFilter

### DIFF
--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -15,7 +15,6 @@ metadata:
       kind: AIGatewayRoute
       name: envoy-ai-gateway-basic
       uid: ""
-  resourceVersion: "1"
 spec:
   parentRefs:
     - name: envoy-ai-gateway-basic
@@ -85,7 +84,6 @@ metadata:
       kind: AIGatewayRoute
       name: envoy-ai-gateway-basic
       uid: ""
-  resourceVersion: "1"
 spec:
   extProc:
     - backendRefs:
@@ -253,7 +251,6 @@ kind: HTTPRouteFilter
 metadata:
   name: ai-eg-host-rewrite
   namespace: default
-  resourceVersion: "1"
 spec:
   urlRewrite:
     hostname:

--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -247,3 +247,14 @@ spec:
   selector:
     app: ai-eg-route-extproc-envoy-ai-gateway-basic
     app.kubernetes.io/managed-by: envoy-ai-gateway
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: ai-eg-host-rewrite
+  namespace: default
+  resourceVersion: "1"
+spec:
+  urlRewrite:
+    hostname:
+      type: Backend

--- a/cmd/aigw/translate.go
+++ b/cmd/aigw/translate.go
@@ -173,6 +173,11 @@ func translateCustomResourceObjects(
 	if err != nil {
 		return fmt.Errorf("error listing EnvoyExtensionPolicies: %w", err)
 	}
+	var httpRouteFilter egv1a1.HTTPRouteFilterList
+	err = fakeClient.List(ctx, &httpRouteFilter)
+	if err != nil {
+		return fmt.Errorf("error listing HTTPRouteFilters: %w", err)
+	}
 	configMaps, err := fakeClientSet.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing ConfigMaps: %w", err)
@@ -196,6 +201,9 @@ func translateCustomResourceObjects(
 	}
 	for _, extensionPolicy := range extensionPolicies.Items {
 		mustWriteObj(&extensionPolicy.TypeMeta, &extensionPolicy, output)
+	}
+	for _, filter := range httpRouteFilter.Items {
+		mustWriteObj(&filter.TypeMeta, &filter, output)
 	}
 	for _, configMap := range configMaps.Items {
 		mustWriteObj(&configMap.TypeMeta, &configMap, output)

--- a/cmd/aigw/translate.go
+++ b/cmd/aigw/translate.go
@@ -269,6 +269,8 @@ func mustWriteObj(typedMeta *metav1.TypeMeta, obj client.Object, w io.Writer) {
 	typedMeta.SetGroupVersionKind(gvks[0])
 	// Ignore ManagedFields as they are not relevant to the user.
 	obj.SetManagedFields(nil)
+	// Ignore ResourceVersion as it is not relevant to the user.
+	obj.SetResourceVersion("")
 	marshaled, err := kyaml.Marshal(obj)
 	if err != nil {
 		panic(err)

--- a/cmd/aigw/translate_test.go
+++ b/cmd/aigw/translate_test.go
@@ -40,15 +40,17 @@ func Test_translate(t *testing.T) {
 			require.NoError(t, err)
 			outBuf, err := os.ReadFile(tc.out)
 			require.NoError(t, err)
-			outHTTPRoutes, outEnvoyExtensionPolicy, outConfigMaps, outSecrets, outDeployments, outServices := requireCollectTranslatedObjects(t, buf.String())
-
-			expectedHTTPRoutes, expectedEnvoyExtensionPolicy, expectedConfigMaps, expectedSecrets, expectedDeployments, expectedServices := requireCollectTranslatedObjects(t, string(outBuf))
-			assert.Equal(t, expectedHTTPRoutes, outHTTPRoutes)
-			assert.Equal(t, expectedEnvoyExtensionPolicy, outEnvoyExtensionPolicy)
-			assert.Equal(t, expectedConfigMaps, outConfigMaps)
-			assert.Equal(t, expectedSecrets, outSecrets)
-			assert.Equal(t, expectedDeployments, outDeployments)
-			assert.Equal(t, expectedServices, outServices)
+			outHTTPRoutes, outEnvoyExtensionPolicy, outHTTPRouteFilter,
+				outConfigMaps, outSecrets, outDeployments, outServices := requireCollectTranslatedObjects(t, buf.String())
+			expHTTPRoutes, expEnvoyExtensionPolicy, expHTTPRouteFilter,
+				expConfigMaps, expSecrets, expDeployments, expServices := requireCollectTranslatedObjects(t, string(outBuf))
+			assert.Equal(t, expHTTPRoutes, outHTTPRoutes)
+			assert.Equal(t, expEnvoyExtensionPolicy, outEnvoyExtensionPolicy)
+			assert.Equal(t, expHTTPRouteFilter, outHTTPRouteFilter)
+			assert.Equal(t, expConfigMaps, outConfigMaps)
+			assert.Equal(t, expSecrets, outSecrets)
+			assert.Equal(t, expDeployments, outDeployments)
+			assert.Equal(t, expServices, outServices)
 		})
 	}
 }
@@ -56,6 +58,7 @@ func Test_translate(t *testing.T) {
 func requireCollectTranslatedObjects(t *testing.T, yamlInput string) (
 	outHTTPRoutes []gwapiv1.HTTPRoute,
 	outEnvoyExtensionPolicy []egv1a1.EnvoyExtensionPolicy,
+	outHTTPRouteFilter []egv1a1.HTTPRouteFilter,
 	outConfigMaps []corev1.ConfigMap,
 	outSecrets []corev1.Secret,
 	outDeployments []appsv1.Deployment,
@@ -81,6 +84,8 @@ func requireCollectTranslatedObjects(t *testing.T, yamlInput string) (
 		switch obj.GetKind() {
 		case "HTTPRoute":
 			mustExtractAndAppend(obj, &outHTTPRoutes)
+		case "HTTPRouteFilter":
+			mustExtractAndAppend(obj, &outHTTPRouteFilter)
 		case "EnvoyExtensionPolicy":
 			mustExtractAndAppend(obj, &outEnvoyExtensionPolicy)
 		case "ConfigMap":


### PR DESCRIPTION
**Commit Message**

This adds a translation logic for HTTPRouteFilter resource that was missing from the initial implementation of `aieg translate` command.
  
**Related Issues/PRs (if applicable)**

Follow up on #439 