### PR TITLE
controller: update rotate function to return expiration time

### DIFF
--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -140,10 +140,10 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 		return time.Minute, err
 	}
 	rotationTime := expiration.Add(-preRotationWindow)
-	if rotationTime.Before(time.Now()) {
-		return time.Minute, fmt.Errorf("newly rotate credentials is already expired (%v) for policy %s in %s", rotationTime, policy.Name, policy.Namespace)
+	if requeue := time.Until(rotationTime); requeue > 0 {
+		return requeue, nil
 	}
-	return time.Until(rotationTime), nil
+	return time.Minute, fmt.Errorf("newly rotate credentials is already expired (%v) for policy %s in %s", rotationTime, policy.Name, policy.Namespace)
 }
 
 // getBackendSecurityPolicyAuthOIDC returns the backendSecurityPolicy's OIDC pointer or nil.

--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -140,6 +140,9 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 		return time.Minute, err
 	}
 	rotationTime := expiration.Add(-preRotationWindow)
+	if rotationTime.Before(time.Now()) {
+		return time.Minute, fmt.Errorf("newly rotate credentials is already expired (%v) for policy %s in %s", rotationTime, policy.Name, policy.Namespace)
+	}
 	return time.Until(rotationTime), nil
 }
 

--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -119,7 +119,6 @@ func (c *BackendSecurityPolicyController) reconcile(ctx context.Context, backend
 // rotateCredential rotates the credentials using the access token from OIDC provider and return the requeue time for next rotation.
 func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, policy *aigv1a1.BackendSecurityPolicy, oidcCreds egv1a1.OIDC, rotator rotators.Rotator) (time.Duration, error) {
 	bspKey := backendSecurityPolicyKey(policy.Namespace, policy.Name)
-
 	var err error
 	c.oidcTokenCacheMutex.RLock()
 	validToken, ok := c.oidcTokenCache[bspKey]
@@ -136,14 +135,11 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 	}
 
 	token := validToken.AccessToken
-	err = rotator.Rotate(ctx, token)
+	expiration, err := rotator.Rotate(ctx, token)
 	if err != nil {
 		return time.Minute, err
 	}
-	rotationTime, err := rotator.GetPreRotationTime(ctx)
-	if err != nil {
-		return time.Minute, err
-	}
+	rotationTime := expiration.Add(-preRotationWindow)
 	return time.Until(rotationTime), nil
 }
 

--- a/internal/controller/rotators/aws_oidc_rotator.go
+++ b/internal/controller/rotators/aws_oidc_rotator.go
@@ -144,9 +144,11 @@ func (r *AWSOIDCRotator) Rotate(ctx context.Context, token string) (time.Time, e
 	if err != nil {
 		r.logger.Error(err, "failed to assume role", "role", r.roleArn, "access token", token)
 		return time.Time{}, err
-	} else if awsIdentity == nil || awsIdentity.Credentials == nil || awsIdentity.Credentials.Expiration == nil {
-		return time.Time{}, fmt.Errorf("unexpected nil for awsIdentity for %s in %s", r.backendSecurityPolicyName, r.backendSecurityPolicyNamespace)
+	} else if awsIdentity.Credentials == nil {
+		return time.Time{}, fmt.Errorf("unexpected nil awsIdentity credentials for %s in %s", r.backendSecurityPolicyName, r.backendSecurityPolicyNamespace)
 	}
+	r.logger.Info(fmt.Sprintf("awsIdentity Credentials will expire in '%s'", awsIdentity.Credentials.Expiration.String()), "namespace", bspNamespace, "name", bspName)
+
 	secret, err := LookupSecret(ctx, r.client, bspNamespace, secretName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/controller/rotators/common.go
+++ b/internal/controller/rotators/common.go
@@ -26,8 +26,8 @@ type Rotator interface {
 	IsExpired(preRotationExpirationTime time.Time) bool
 	// GetPreRotationTime gets the time when the credentials need to be renewed.
 	GetPreRotationTime(ctx context.Context) (time.Time, error)
-	// Rotate will update the credential secret file with new credentials.
-	Rotate(ctx context.Context, token string) error
+	// Rotate will update the credential secret file with new credentials and return expiration time.
+	Rotate(ctx context.Context, token string) (time.Time, error)
 }
 
 // LookupSecret retrieves an existing secret.


### PR DESCRIPTION
**Commit Message**

Update `Rotate` to return the expiration time in addition to the error. This will allow us to get the expiration time without having to make a `GET` API request to Kubernetes.



**Related Issues/PRs (if applicable)**

https://github.com/envoyproxy/ai-gateway/blob/8f38c672ee11e6e724fff7b1e430979417fd3ce6/internal/controller/backend_security_policy.go#L106-L108

```
2025-03-02T20:12:23Z    INFO    controller.backend-security-policy      successfully rotated credentials for credentials in namespace default of auth type AWSCredentials, renewing in -0.009733 minutes
```

The requeue time after rotating a set of credentials (AWS in this case) returns a negative number of minutes occasionally.  It requires a manual action/global sync to restart the rotation logic.

Upon further investigation, the issue found lies with `rotator.GetPreRotationTime` returning the incorrect time. GetPreRotation gets the expiration time from the secret's annotation, and the assumption is it's getting a cached previous secret's annotation instead of the new expiration time.

https://github.com/envoyproxy/ai-gateway/blob/8f38c672ee11e6e724fff7b1e430979417fd3ce6/internal/controller/backend_security_policy.go#L143-L147


