### PR TITLE
site: bump latest patch version v0.1.1 -> v0.1.2

### DIFF
--- a/site/blog/2025-02-25-first-ai-gw-release.md
+++ b/site/blog/2025-02-25-first-ai-gw-release.md
@@ -48,7 +48,7 @@ The **roadmap is community-driven**, and we'd love for **more contributors** to 
 ## Join the Movement
 
 Want to be part of the journey? Here's how you can get involved:
-- **Download & Try Envoy AI Gateway** → [GitHub Repo](https://github.com/envoyproxy/ai-gateway/releases/tag/v0.1.1)
+- **Download & Try Envoy AI Gateway** → [GitHub Repo](https://github.com/envoyproxy/ai-gateway/releases/tag/v0.1.2)
 - **Join the Conversation** → [Attend our community meetings](https://docs.google.com/document/d/10e1sfsF-3G3Du5nBHGmLjXw5GVMqqCvFDqp_O65B0_w/edit?tab=t.0#heading=h.6nxfjwmrm5g6) (Mellow might show up too\!)
 - **Join us on Slack** → [Register for Envoy Slack](https://communityinviter.com/apps/envoyproxy/envoy?email=test) and join \#envoy-ai-gateway
 - **Contribute** → Raise issues, suggest improvements, and submit PRs on GitHub

--- a/site/src/pages/release-notes.md
+++ b/site/src/pages/release-notes.md
@@ -5,6 +5,22 @@ description: Release Notes for Envoy AI Gateway
 
 # Release Notes
 ---
+## v0.1.2
+**Date:** 2025-03-05
+
+Rotator bug and extproc image tag fix! Docker ci changes as well.
+
+## Overview
+
+This patch release `v0.1.2` includes fixes to BackendSecurityPolicy requeue bug, docker hub changes, and extproc image tag sync.
+
+## Commits
+
+- controller: fix syncing extproc image tag (https://github.com/envoyproxy/ai-gateway/pull/447)
+- controller: update rotate function to return expiration time (https://github.com/envoyproxy/ai-gateway/pull/455)
+- ci: update dockerhub user (https://github.com/envoyproxy/ai-gateway/pull/441)
+
+---
 ## v0.1.1
 **Date:** 2025-02-28
 

--- a/site/versioned_docs/version-0.1/getting-started/basic-usage.md
+++ b/site/versioned_docs/version-0.1/getting-started/basic-usage.md
@@ -18,7 +18,7 @@ For Windows users, note that you are able to use Windows Subsystem for Linux (WS
 Let's start by deploying a basic AI Gateway setup that includes a test backend:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/examples/basic/basic.yaml
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/examples/basic/basic.yaml
 ```
 
 Wait for the Gateway pod to be ready:

--- a/site/versioned_docs/version-0.1/getting-started/connect-providers/index.md
+++ b/site/versioned_docs/version-0.1/getting-started/connect-providers/index.md
@@ -23,7 +23,7 @@ Before configuring any provider:
 2. Remove the basic configuration with the mock backend
 
    ```shell
-   kubectl delete -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/examples/basic/basic.yaml
+   kubectl delete -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/examples/basic/basic.yaml
 
    kubectl wait pods --timeout=15s \
      -l gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-basic \
@@ -34,7 +34,7 @@ Before configuring any provider:
 3. Download configuration template
 
    ```shell
-   curl -O https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/examples/basic/basic.yaml
+   curl -O https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/examples/basic/basic.yaml
    ```
 
 ## Security Best Practices

--- a/site/versioned_docs/version-0.1/getting-started/index.md
+++ b/site/versioned_docs/version-0.1/getting-started/index.md
@@ -45,11 +45,11 @@ helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
   --create-namespace
 
 helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
-  --version v0.1.1 \
+  --version v0.1.2 \
   --namespace envoy-ai-gateway-system \
   --create-namespace
 
-kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/examples/basic/basic.yaml
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/examples/basic/basic.yaml
 
 kubectl wait --timeout=2m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-controller --for=condition=Available

--- a/site/versioned_docs/version-0.1/getting-started/installation.md
+++ b/site/versioned_docs/version-0.1/getting-started/installation.md
@@ -15,7 +15,7 @@ The easiest way to install Envoy AI Gateway is using the Helm chart. First, inst
 
 ```shell
 helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
-    --version v0.1.1 \
+    --version v0.1.2 \
     --namespace envoy-ai-gateway-system \
     --create-namespace
 
@@ -27,9 +27,9 @@ kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-contr
 After installing Envoy AI Gateway, apply the AI Gateway-specific configuration to Envoy Gateway, restart the deployment, and wait for it to be ready:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/manifests/envoy-gateway-config/redis.yaml
-kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/manifests/envoy-gateway-config/config.yaml
-kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.1/manifests/envoy-gateway-config/rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/manifests/envoy-gateway-config/redis.yaml
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/manifests/envoy-gateway-config/config.yaml
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/refs/tags/v0.1.2/manifests/envoy-gateway-config/rbac.yaml
 
 kubectl rollout restart -n envoy-gateway-system deployment/envoy-gateway
 


### PR DESCRIPTION
**Commit Message**

Released latest patch: https://github.com/envoyproxy/ai-gateway/releases/tag/v0.1.2. Updating site to match!