### PR TITLE
chore: consistently name testupstream special keys

### DIFF
--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -233,15 +233,15 @@ data: [DONE]
 				req.Header.Set("x-test-backend", tc.backend)
 				req.Header.Set(testupstreamlib.ResponseBodyHeaderKey, base64.StdEncoding.EncodeToString([]byte(tc.responseBody)))
 				req.Header.Set(testupstreamlib.ExpectedPathHeaderKey, base64.StdEncoding.EncodeToString([]byte(tc.expPath)))
-				req.Header.Set("x-response-status", tc.responseStatus)
+				req.Header.Set(testupstreamlib.ResponseStatusKey, tc.responseStatus)
 				if tc.responseType != "" {
-					req.Header.Set("testupstream.ResponseTypeKey", tc.responseType)
+					req.Header.Set(testupstreamlib.ResponseTypeKey, tc.responseType)
 				}
 				if tc.responseHeaders != "" {
-					req.Header.Set("x-response-headers", base64.StdEncoding.EncodeToString([]byte(tc.responseHeaders)))
+					req.Header.Set(testupstreamlib.ResponseHeadersKey, base64.StdEncoding.EncodeToString([]byte(tc.responseHeaders)))
 				}
 				if tc.expRequestBody != "" {
-					req.Header.Set("x-expected-request-body", base64.StdEncoding.EncodeToString([]byte(tc.expRequestBody)))
+					req.Header.Set(testupstreamlib.ExpectedRequestBodyHeaderKey, base64.StdEncoding.EncodeToString([]byte(tc.expRequestBody)))
 				}
 
 				resp, err := http.DefaultClient.Do(req)

--- a/tests/internal/testupstreamlib/testupstream.go
+++ b/tests/internal/testupstreamlib/testupstream.go
@@ -13,7 +13,7 @@ const (
 	//	* If this is "aws-event-stream", the response body is expected to be an AWS Event Stream.
 	// 	Each line in x-response-body is treated as a separate event payload.
 	//	* If this is empty, the response body is expected to be a regular JSON response.
-	ResponseTypeKey = "testupstream.ResponseTypeKey"
+	ResponseTypeKey = "x-response-type"
 	// ExpectedHeadersKey is the key for the expected headers in the request.
 	// The value is a base64 encoded string of comma separated key-value pairs.
 	// E.g. "key1:value1,key2:value2".


### PR DESCRIPTION
**Commit Message**

The header to specify the response type (sse, aws, or plain json) was named testupstream.ResponseTypeKey while others are having the standard x-* naming. This fixes the inconsistency and name it `x-response-type`. This was needed to do a fair comparison with LiteLLM that only forwards client headers prefixed with `x-*`.