### PR TITLE
extproc: properly stream chat completions

### DIFF
--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -8,11 +8,13 @@ package extproc
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/require"
@@ -83,7 +85,7 @@ func TestChatCompletion_ProcessResponseHeaders(t *testing.T) {
 		require.ErrorContains(t, err, "test error")
 		mm.RequireRequestFailure(t)
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("ok/non-streaming", func(t *testing.T) {
 		inHeaders := &corev3.HeaderMap{
 			Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}, {Key: "dog", RawValue: []byte("cat")}},
 		}
@@ -99,6 +101,35 @@ func TestChatCompletion_ProcessResponseHeaders(t *testing.T) {
 		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseHeaders).ResponseHeaders.Response
 		require.Equal(t, mt.retHeaderMutation, commonRes.HeaderMutation)
 		mm.RequireRequestNotCompleted(t)
+		require.Nil(t, res.ModeOverride)
+	})
+	t.Run("ok/streaming", func(t *testing.T) {
+		inHeaders := &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{{Key: ":status", Value: "200"}, {Key: "dog", RawValue: []byte("cat")}},
+		}
+		expHeaders := map[string]string{":status": "200", "dog": "cat"}
+		mm := &mockChatCompletionMetrics{}
+		mt := &mockTranslator{t: t, expHeaders: expHeaders}
+		p := &chatCompletionProcessor{translator: mt, metrics: mm, stream: true}
+		res, err := p.ProcessResponseHeaders(t.Context(), inHeaders)
+		require.NoError(t, err)
+		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseHeaders).ResponseHeaders.Response
+		require.Equal(t, mt.retHeaderMutation, commonRes.HeaderMutation)
+		require.Equal(t, &extprocv3http.ProcessingMode{ResponseBodyMode: extprocv3http.ProcessingMode_STREAMED}, res.ModeOverride)
+	})
+	t.Run("error/streaming", func(t *testing.T) {
+		inHeaders := &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{{Key: ":status", Value: "500"}, {Key: "dog", RawValue: []byte("cat")}},
+		}
+		expHeaders := map[string]string{":status": "500", "dog": "cat"}
+		mm := &mockChatCompletionMetrics{}
+		mt := &mockTranslator{t: t, expHeaders: expHeaders}
+		p := &chatCompletionProcessor{translator: mt, metrics: mm, stream: true}
+		res, err := p.ProcessResponseHeaders(t.Context(), inHeaders)
+		require.NoError(t, err)
+		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseHeaders).ResponseHeaders.Response
+		require.Equal(t, mt.retHeaderMutation, commonRes.HeaderMutation)
+		require.Nil(t, res.ModeOverride)
 	})
 }
 
@@ -173,148 +204,159 @@ func TestChatCompletion_ProcessResponseBody(t *testing.T) {
 }
 
 func TestChatCompletion_ProcessRequestBody(t *testing.T) {
-	bodyFromModel := func(t *testing.T, model string) []byte {
-		var openAIReq openai.ChatCompletionRequest
-		openAIReq.Model = model
-		bytes, err := json.Marshal(openAIReq)
-		require.NoError(t, err)
-		return bytes
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream%v", stream), func(t *testing.T) {
+			bodyFromModel := func(t *testing.T, model string) []byte {
+				var openAIReq openai.ChatCompletionRequest
+				openAIReq.Model = model
+				openAIReq.Stream = stream
+				bytes, err := json.Marshal(openAIReq)
+				require.NoError(t, err)
+				return bytes
+			}
+			t.Run("body parser error", func(t *testing.T) {
+				mm := &mockChatCompletionMetrics{}
+				p := &chatCompletionProcessor{
+					metrics: mm,
+				}
+				_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: []byte("nonjson")})
+				require.ErrorContains(t, err, "invalid character 'o' in literal null")
+				mm.RequireRequestFailure(t)
+				mm.RequireTokensRecorded(t, 0)
+				mm.RequireSelected(t, "", "")
+				require.False(t, p.stream) // On error, stream should be false regardless of the input.
+			})
+			t.Run("router error", func(t *testing.T) {
+				headers := map[string]string{":path": "/foo"}
+				rt := mockRouter{t: t, expHeaders: headers, retErr: errors.New("test error")}
+				mm := &mockChatCompletionMetrics{}
+				p := &chatCompletionProcessor{
+					config:         &processorConfig{router: rt},
+					requestHeaders: headers,
+					logger:         slog.Default(),
+					metrics:        mm,
+				}
+				_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
+				require.ErrorContains(t, err, "failed to calculate route: test error")
+				mm.RequireRequestFailure(t)
+				mm.RequireTokensRecorded(t, 0)
+				mm.RequireSelected(t, "some-model", "")
+				require.False(t, p.stream) // On error, stream should be false regardless of the input.
+			})
+			t.Run("router error 404", func(t *testing.T) {
+				headers := map[string]string{":path": "/foo"}
+				rt := mockRouter{t: t, expHeaders: headers, retErr: x.ErrNoMatchingRule}
+				mm := &mockChatCompletionMetrics{}
+				p := &chatCompletionProcessor{
+					config:         &processorConfig{router: rt},
+					requestHeaders: headers,
+					logger:         slog.Default(),
+					metrics:        mm,
+				}
+				resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				ir := resp.GetImmediateResponse()
+				require.NotNil(t, ir)
+				require.Equal(t, typev3.StatusCode_NotFound, ir.GetStatus().GetCode())
+				require.Equal(t, x.ErrNoMatchingRule.Error(), string(ir.GetBody()))
+				mm.RequireRequestFailure(t)
+				mm.RequireTokensRecorded(t, 0)
+				mm.RequireSelected(t, "some-model", "")
+				require.False(t, p.stream) // On error, stream should be false regardless of the input.
+			})
+			t.Run("translator not found", func(t *testing.T) {
+				headers := map[string]string{":path": "/foo"}
+				rt := mockRouter{
+					t: t, expHeaders: headers, retBackendName: "some-backend",
+					retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
+				}
+				mm := &mockChatCompletionMetrics{}
+				p := &chatCompletionProcessor{
+					config:         &processorConfig{router: rt},
+					requestHeaders: headers,
+					logger:         slog.Default(),
+					metrics:        mm,
+				}
+				_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
+				require.ErrorContains(t, err, "unsupported API schema: backend={some-schema v10.0}")
+				mm.RequireRequestFailure(t)
+				mm.RequireTokensRecorded(t, 0)
+				mm.RequireSelected(t, "some-model", "some-backend")
+				require.False(t, p.stream) // On error, stream should be false regardless of the input.
+			})
+			t.Run("translator error", func(t *testing.T) {
+				headers := map[string]string{":path": "/foo"}
+				someBody := bodyFromModel(t, "some-model")
+				rt := mockRouter{
+					t: t, expHeaders: headers, retBackendName: "some-backend",
+					retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
+				}
+				var body openai.ChatCompletionRequest
+				require.NoError(t, json.Unmarshal(someBody, &body))
+				tr := mockTranslator{t: t, retErr: errors.New("test error"), expRequestBody: &body}
+				mm := &mockChatCompletionMetrics{}
+				p := &chatCompletionProcessor{
+					config:         &processorConfig{router: rt},
+					requestHeaders: headers,
+					logger:         slog.Default(),
+					metrics:        mm,
+					translator:     tr,
+				}
+				_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: someBody})
+				require.ErrorContains(t, err, "failed to transform request: test error")
+				mm.RequireRequestFailure(t)
+				mm.RequireTokensRecorded(t, 0)
+				mm.RequireSelected(t, "some-model", "some-backend")
+				require.False(t, p.stream) // On error, stream should be false regardless of the input.
+			})
+			t.Run("ok", func(t *testing.T) {
+				someBody := bodyFromModel(t, "some-model")
+				headers := map[string]string{":path": "/foo"}
+				rt := mockRouter{
+					t: t, expHeaders: headers, retBackendName: "some-backend",
+					retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
+				}
+				headerMut := &extprocv3.HeaderMutation{}
+				bodyMut := &extprocv3.BodyMutation{}
+
+				var expBody openai.ChatCompletionRequest
+				require.NoError(t, json.Unmarshal(someBody, &expBody))
+				mt := mockTranslator{t: t, expRequestBody: &expBody, retHeaderMutation: headerMut, retBodyMutation: bodyMut}
+				mm := &mockChatCompletionMetrics{}
+				p := &chatCompletionProcessor{
+					config: &processorConfig{
+						router:                   rt,
+						selectedBackendHeaderKey: "x-ai-gateway-backend-key",
+						modelNameHeaderKey:       "x-ai-gateway-model-key",
+					},
+					requestHeaders: headers,
+					logger:         slog.Default(),
+					metrics:        mm,
+					translator:     mt,
+				}
+				resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: someBody})
+				require.NoError(t, err)
+				require.Equal(t, mt, p.translator)
+				require.NotNil(t, resp)
+				commonRes := resp.Response.(*extprocv3.ProcessingResponse_RequestBody).RequestBody.Response
+				require.Equal(t, headerMut, commonRes.HeaderMutation)
+				require.Equal(t, bodyMut, commonRes.BodyMutation)
+
+				mm.RequireRequestNotCompleted(t)
+				mm.RequireSelected(t, "some-model", "some-backend")
+
+				// Check the model and backend headers are set in headerMut.
+				hdrs := headerMut.SetHeaders
+				require.Len(t, hdrs, 2)
+				require.Equal(t, "x-ai-gateway-model-key", hdrs[0].Header.Key)
+				require.Equal(t, "some-model", string(hdrs[0].Header.RawValue))
+				require.Equal(t, "x-ai-gateway-backend-key", hdrs[1].Header.Key)
+				require.Equal(t, "some-backend", string(hdrs[1].Header.RawValue))
+				require.Equal(t, stream, p.stream)
+			})
+		})
 	}
-	t.Run("body parser error", func(t *testing.T) {
-		mm := &mockChatCompletionMetrics{}
-		p := &chatCompletionProcessor{
-			metrics: mm,
-		}
-		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: []byte("nonjson")})
-		require.ErrorContains(t, err, "invalid character 'o' in literal null")
-		mm.RequireRequestFailure(t)
-		mm.RequireTokensRecorded(t, 0)
-		mm.RequireSelected(t, "", "")
-	})
-	t.Run("router error", func(t *testing.T) {
-		headers := map[string]string{":path": "/foo"}
-		rt := mockRouter{t: t, expHeaders: headers, retErr: errors.New("test error")}
-		mm := &mockChatCompletionMetrics{}
-		p := &chatCompletionProcessor{
-			config:         &processorConfig{router: rt},
-			requestHeaders: headers,
-			logger:         slog.Default(),
-			metrics:        mm,
-		}
-		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
-		require.ErrorContains(t, err, "failed to calculate route: test error")
-		mm.RequireRequestFailure(t)
-		mm.RequireTokensRecorded(t, 0)
-		mm.RequireSelected(t, "some-model", "")
-	})
-	t.Run("router error 404", func(t *testing.T) {
-		headers := map[string]string{":path": "/foo"}
-		rt := mockRouter{t: t, expHeaders: headers, retErr: x.ErrNoMatchingRule}
-		mm := &mockChatCompletionMetrics{}
-		p := &chatCompletionProcessor{
-			config:         &processorConfig{router: rt},
-			requestHeaders: headers,
-			logger:         slog.Default(),
-			metrics:        mm,
-		}
-		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		ir := resp.GetImmediateResponse()
-		require.NotNil(t, ir)
-		require.Equal(t, typev3.StatusCode_NotFound, ir.GetStatus().GetCode())
-		require.Equal(t, x.ErrNoMatchingRule.Error(), string(ir.GetBody()))
-		mm.RequireRequestFailure(t)
-		mm.RequireTokensRecorded(t, 0)
-		mm.RequireSelected(t, "some-model", "")
-	})
-	t.Run("translator not found", func(t *testing.T) {
-		headers := map[string]string{":path": "/foo"}
-		rt := mockRouter{
-			t: t, expHeaders: headers, retBackendName: "some-backend",
-			retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
-		}
-		mm := &mockChatCompletionMetrics{}
-		p := &chatCompletionProcessor{
-			config:         &processorConfig{router: rt},
-			requestHeaders: headers,
-			logger:         slog.Default(),
-			metrics:        mm,
-		}
-		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model")})
-		require.ErrorContains(t, err, "unsupported API schema: backend={some-schema v10.0}")
-		mm.RequireRequestFailure(t)
-		mm.RequireTokensRecorded(t, 0)
-		mm.RequireSelected(t, "some-model", "some-backend")
-	})
-	t.Run("translator error", func(t *testing.T) {
-		headers := map[string]string{":path": "/foo"}
-		someBody := bodyFromModel(t, "some-model")
-		rt := mockRouter{
-			t: t, expHeaders: headers, retBackendName: "some-backend",
-			retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
-		}
-		var body openai.ChatCompletionRequest
-		require.NoError(t, json.Unmarshal(someBody, &body))
-		tr := mockTranslator{t: t, retErr: errors.New("test error"), expRequestBody: &body}
-		mm := &mockChatCompletionMetrics{}
-		p := &chatCompletionProcessor{
-			config:         &processorConfig{router: rt},
-			requestHeaders: headers,
-			logger:         slog.Default(),
-			metrics:        mm,
-			translator:     tr,
-		}
-		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: someBody})
-		require.ErrorContains(t, err, "failed to transform request: test error")
-		mm.RequireRequestFailure(t)
-		mm.RequireTokensRecorded(t, 0)
-		mm.RequireSelected(t, "some-model", "some-backend")
-	})
-	t.Run("ok", func(t *testing.T) {
-		someBody := bodyFromModel(t, "some-model")
-		headers := map[string]string{":path": "/foo"}
-		rt := mockRouter{
-			t: t, expHeaders: headers, retBackendName: "some-backend",
-			retVersionedAPISchema: filterapi.VersionedAPISchema{Name: "some-schema", Version: "v10.0"},
-		}
-		headerMut := &extprocv3.HeaderMutation{}
-		bodyMut := &extprocv3.BodyMutation{}
-
-		var expBody openai.ChatCompletionRequest
-		require.NoError(t, json.Unmarshal(someBody, &expBody))
-		mt := mockTranslator{t: t, expRequestBody: &expBody, retHeaderMutation: headerMut, retBodyMutation: bodyMut}
-		mm := &mockChatCompletionMetrics{}
-		p := &chatCompletionProcessor{
-			config: &processorConfig{
-				router:                   rt,
-				selectedBackendHeaderKey: "x-ai-gateway-backend-key",
-				modelNameHeaderKey:       "x-ai-gateway-model-key",
-			},
-			requestHeaders: headers,
-			logger:         slog.Default(),
-			metrics:        mm,
-			translator:     mt,
-		}
-		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: someBody})
-		require.NoError(t, err)
-		require.Equal(t, mt, p.translator)
-		require.NotNil(t, resp)
-		commonRes := resp.Response.(*extprocv3.ProcessingResponse_RequestBody).RequestBody.Response
-		require.Equal(t, headerMut, commonRes.HeaderMutation)
-		require.Equal(t, bodyMut, commonRes.BodyMutation)
-
-		mm.RequireRequestNotCompleted(t)
-		mm.RequireSelected(t, "some-model", "some-backend")
-
-		// Check the model and backend headers are set in headerMut.
-		hdrs := headerMut.SetHeaders
-		require.Len(t, hdrs, 2)
-		require.Equal(t, "x-ai-gateway-model-key", hdrs[0].Header.Key)
-		require.Equal(t, "some-model", string(hdrs[0].Header.RawValue))
-		require.Equal(t, "x-ai-gateway-backend-key", hdrs[1].Header.Key)
-		require.Equal(t, "some-backend", string(hdrs[1].Header.RawValue))
-	})
 }
 
 func TestChatCompletion_ParseBody(t *testing.T) {

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
@@ -76,15 +75,14 @@ type mockTranslator struct {
 	expResponseBody   *extprocv3.HttpBody
 	retHeaderMutation *extprocv3.HeaderMutation
 	retBodyMutation   *extprocv3.BodyMutation
-	retOverride       *extprocv3http.ProcessingMode
 	retUsedToken      translator.LLMTokenUsage
 	retErr            error
 }
 
 // RequestBody implements [translator.OpenAIChatCompletionTranslator].
-func (m mockTranslator) RequestBody(body *openai.ChatCompletionRequest) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, override *extprocv3http.ProcessingMode, err error) {
+func (m mockTranslator) RequestBody(body *openai.ChatCompletionRequest) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
 	require.Equal(m.t, m.expRequestBody, body)
-	return m.retHeaderMutation, m.retBodyMutation, m.retOverride, m.retErr
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
 }
 
 // ResponseHeaders implements [translator.OpenAIChatCompletionTranslator].

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
-	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -683,18 +682,13 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			o := &openAIToAWSBedrockTranslatorV1ChatCompletion{}
 			originalReq := tt.input
-			hm, bm, mode, err := o.RequestBody(&originalReq)
+			hm, bm, err := o.RequestBody(&originalReq)
 			var expPath string
+			require.Equal(t, tt.input.Stream, o.stream)
 			if tt.input.Stream {
 				expPath = fmt.Sprintf("/model/%s/converse-stream", tt.input.Model)
-				require.True(t, o.stream)
-				require.NotNil(t, mode)
-				require.Equal(t, extprocv3http.ProcessingMode_STREAMED, mode.ResponseBodyMode)
-				require.Equal(t, extprocv3http.ProcessingMode_SEND, mode.ResponseHeaderMode)
 			} else {
 				expPath = fmt.Sprintf("/model/%s/converse", tt.input.Model)
-				require.False(t, o.stream)
-				require.Nil(t, mode)
 			}
 			require.NoError(t, err)
 			require.NotNil(t, hm)

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"strconv"
 
-	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
@@ -32,18 +31,12 @@ type openAIToOpenAITranslatorV1ChatCompletion struct {
 
 // RequestBody implements [Translator.RequestBody].
 func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(req *openai.ChatCompletionRequest) (
-	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, override *extprocv3http.ProcessingMode, err error,
+	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error,
 ) {
 	if req.Stream {
 		o.stream = true
-		override = &extprocv3http.ProcessingMode{
-			// TODO: We can delete this explicit setting of ResponseHeaderMode below as it is the default value we use
-			// 	after https://github.com/envoyproxy/envoy/pull/38254 this is released.
-			ResponseHeaderMode: extprocv3http.ProcessingMode_SEND,
-			ResponseBodyMode:   extprocv3http.ProcessingMode_STREAMED,
-		}
 	}
-	return nil, nil, override, nil
+	return nil, nil, nil
 }
 
 // ResponseError implements [Translator.ResponseError]

--- a/internal/extproc/translator/openai_openai_test.go
+++ b/internal/extproc/translator/openai_openai_test.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"testing"
 
-	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -29,17 +28,10 @@ func TestOpenAIToOpenAITranslatorV1ChatCompletionRequestBody(t *testing.T) {
 				originalReq := &openai.ChatCompletionRequest{Model: "foo-bar-ai", Stream: stream}
 
 				o := &openAIToOpenAITranslatorV1ChatCompletion{}
-				hm, bm, mode, err := o.RequestBody(originalReq)
+				hm, bm, err := o.RequestBody(originalReq)
 				require.Nil(t, bm)
 				require.NoError(t, err)
 				require.Equal(t, stream, o.stream)
-				if stream {
-					require.NotNil(t, mode)
-					require.Equal(t, extprocv3http.ProcessingMode_SEND, mode.ResponseHeaderMode)
-					require.Equal(t, extprocv3http.ProcessingMode_STREAMED, mode.ResponseBodyMode)
-				} else {
-					require.Nil(t, mode)
-				}
 
 				require.Nil(t, hm)
 			})

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -42,7 +42,7 @@ func requireExtProc(t *testing.T, stdout io.Writer, executable, configPath strin
 	cmd := exec.CommandContext(t.Context(), executable)
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
-	cmd.Args = append(cmd.Args, "-configPath", configPath)
+	cmd.Args = append(cmd.Args, "-configPath", configPath, "-logLevel", "debug")
 	cmd.Env = append(os.Environ(), envs...)
 	require.NoError(t, cmd.Start())
 }
@@ -69,6 +69,7 @@ func requireRunEnvoy(t *testing.T, accessLogPath string) {
 	cmd := exec.CommandContext(t.Context(), "envoy",
 		"-c", envoyYamlPath,
 		"--log-level", "warn",
+		"--component-log-level", "ext_proc:debug",
 		"--concurrency", strconv.Itoa(max(runtime.NumCPU(), 2)),
 	)
 	cmd.Stdout = os.Stdout

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -323,23 +323,19 @@ data: [DONE]
 			_ = stream.Close()
 		}()
 
-		acc := openaigo.ChatCompletionAccumulator{}
+		asserted := false
 		for stream.Next() {
 			chunk := stream.Current()
-			if len(chunk.Choices) == 0 {
-				continue
-			}
-			if !acc.AddChunk(chunk) {
-				t.Fatalf("failed to add chunk")
-			}
-			if chunk.Choices[0].Delta.Content == "" {
+			if len(chunk.Choices) == 0 || chunk.Choices[0].Delta.Content == "" {
 				continue
 			}
 			t.Logf("%v: %v", time.Now(), chunk.Choices[0].Delta.Content)
-			// Check each event is received less than half a second after the previous one.
-			require.Less(t, time.Since(start), time.Millisecond*500)
+			// Check each event is received less than a second after the previous one.
+			require.Less(t, time.Since(start), time.Second)
 			start = time.Now()
+			asserted = true
 		}
+		require.True(t, asserted)
 		require.NoError(t, stream.Err())
 	})
 }

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
-	openai "github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/tests/internal/testupstreamlib"
 )
 

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -324,7 +324,6 @@ data: [DONE]
 		}()
 
 		acc := openaigo.ChatCompletionAccumulator{}
-		first := true
 		for stream.Next() {
 			chunk := stream.Current()
 			if len(chunk.Choices) == 0 {
@@ -337,12 +336,9 @@ data: [DONE]
 				continue
 			}
 			t.Logf("%v: %v", time.Now(), chunk.Choices[0].Delta.Content)
-			if first {
-				// Check the first event received less than half a second.
-				require.Less(t, time.Since(start), time.Millisecond*500)
-				first = false
-				continue
-			}
+			// Check each event is received less than half a second after the previous one.
+			require.Less(t, time.Since(start), time.Millisecond*500)
+			start = time.Now()
 		}
 		require.NoError(t, stream.Err())
 	})

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	openaigo "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
-	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	openai "github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/tests/internal/testupstreamlib"
 )
 
@@ -272,6 +274,78 @@ data: [DONE]
 			}, 10*time.Second, 500*time.Millisecond)
 		})
 	}
+
+	t.Run("stream non blocking", func(t *testing.T) {
+		// This receives a stream of 20 event messages. The testuptream server sleeps 200 ms between each message.
+		// Therefore, if envoy fails to process the response in a streaming manner, the test will fail taking more than 4 seconds.
+		client := openaigo.NewClient(
+			option.WithBaseURL(listenerAddress+"/v1/"),
+			option.WithHeader("x-test-backend", "openai"),
+			option.WithHeader(testupstreamlib.ResponseTypeKey, "sse"),
+			option.WithHeader(testupstreamlib.ResponseBodyHeaderKey,
+				base64.StdEncoding.EncodeToString([]byte(
+					`
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" This"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" test"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" This"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" test"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" This"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" test"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" This"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":" test"},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-B8ZKlXBoEXZVTtv3YBmewxuCpNW7b","object":"chat.completion.chunk","created":1741382147,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_06737a9306","choices":[],"usage":{"prompt_tokens":25,"completion_tokens":61,"total_tokens":86,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+[DONE]
+`,
+				))),
+		)
+
+		// NewStreaming below will block until the first event is received, so take the time before calling it.
+		start := time.Now()
+		stream := client.Chat.Completions.NewStreaming(t.Context(), openaigo.ChatCompletionNewParams{
+			Messages: openaigo.F([]openaigo.ChatCompletionMessageParamUnion{
+				openaigo.UserMessage("Say this is a test"),
+			}),
+			Model: openaigo.F("something"),
+		})
+		defer func() {
+			_ = stream.Close()
+		}()
+
+		acc := openaigo.ChatCompletionAccumulator{}
+		first := true
+		for stream.Next() {
+			chunk := stream.Current()
+			if len(chunk.Choices) == 0 {
+				continue
+			}
+			if !acc.AddChunk(chunk) {
+				t.Fatalf("failed to add chunk")
+			}
+			if chunk.Choices[0].Delta.Content == "" {
+				continue
+			}
+			t.Logf("%v: %v", time.Now(), chunk.Choices[0].Delta.Content)
+			if first {
+				// Check the first event received less than half a second.
+				require.Less(t, time.Since(start), time.Millisecond*500)
+				first = false
+				continue
+			}
+		}
+		require.NoError(t, stream.Err())
+	})
 }
 
 func checkModelsIgnoringTimestamps(want openai.ModelList) func(t require.TestingT, body []byte) {


### PR DESCRIPTION
**Commit Message**

This fixes a bug in the extproc when handling stream=true requests. Previously, mode_override was set at the request body handling phase, and it was not set in the response headers phase. That resulted in buffering the entire response body which is clearly not ideal as from clients point of view, they will receive the entire streaming vs line by line. This refactors around the mode override and properly handle it. 