### PR TITLE
extproc: token latency stat only when stream=true

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -240,7 +240,11 @@ func (c *chatCompletionProcessor) ProcessResponseBody(ctx context.Context, body 
 
 	// Update metrics with token usage.
 	c.metrics.RecordTokenUsage(ctx, tokenUsage.InputTokens, tokenUsage.OutputTokens, tokenUsage.TotalTokens)
-	c.metrics.RecordTokenLatency(ctx, tokenUsage.OutputTokens)
+	if c.stream {
+		// Token latency is only recorded for streaming responses, otherwise it doesn't make sense since
+		// these metrics are defined as a difference between the two output events.
+		c.metrics.RecordTokenLatency(ctx, tokenUsage.OutputTokens)
+	}
 
 	if body.EndOfStream && len(c.config.requestCosts) > 0 {
 		resp.DynamicMetadata, err = c.maybeBuildDynamicMetadata()

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -166,6 +166,7 @@ func TestChatCompletion_ProcessResponseBody(t *testing.T) {
 			translator: mt,
 			logger:     slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
 			metrics:    mm,
+			stream:     true,
 			config: &processorConfig{
 				metadataNamespace: "ai_gateway_llm_ns",
 				requestCosts: []processorConfigRequestCost{


### PR DESCRIPTION
**Commit Message**

This changes the stat collection behavior so that token latency metrics are only recorded on stream=true requests. This was brought up in an offline discussion and otherwise the metrics doesn't make sense.

**Related Issues/PRs (if applicable)**

#459 