### PR TITLE
ci: ignore Envoy Gateway CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,4 @@
 # Ignore Envoy Gateway CVEs. We are using the latest EG main branch, which appears as a weird "0.5.0-rc1.0-*" convention in go.mod.
-# In other words, these CVEs are false positives, so we ignore them.
+# So, these CVEs are false positives.
 CVE-2025-24030
 CVE-2025-25294

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,4 @@
 # Ignore Envoy Gateway CVEs. We are using the latest EG main branch, which appears as a weird "0.5.0-rc1.0-*" convention in go.mod.
-# So, these CVEs are false positives, so we ignore them.
+# In other words, these CVEs are false positives, so we ignore them.
 CVE-2025-24030
 CVE-2025-25294

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,4 @@
+# Ignore Envoy Gateway CVEs. We are using the latest EG main branch, which appears as a weird "0.5.0-rc1.0-*" convention in go.mod.
+# So, these CVEs are false positives, so we ignore them.
 CVE-2025-24030
+CVE-2025-25294


### PR DESCRIPTION
**Commit Message**

We always use the latest main branch Envoy Gateway, so these CVEs detected by Trivy are false positives. Unfortunately, this is due to the fact that the main branch EG appears as `0.5.0-rc.1-*` in go.mod and there's no way to fix it.