### PR TITLE
extproc: do not panic when immediate response in debug mode

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -99,7 +99,7 @@ func (c *chatCompletionProcessor) ProcessRequestBody(ctx context.Context, rawBod
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse request body: %w", err)
 	}
-	c.logger.Info("Processing request", "path", c.requestHeaders[":path"], "model", model)
+	c.logger.Info("processing request body", "path", c.requestHeaders[":path"], "model", model)
 
 	c.metrics.SetModel(model)
 	c.requestHeaders[c.config.modelNameHeaderKey] = model

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -276,7 +276,11 @@ func filterSensitiveBodyForLogging(resp *extprocv3.ProcessingResponse, logger *s
 	if resp == nil {
 		return &extprocv3.ProcessingResponse{}
 	}
-	original := resp.Response.(*extprocv3.ProcessingResponse_RequestBody)
+	original, ok := resp.Response.(*extprocv3.ProcessingResponse_RequestBody)
+	if !ok {
+		// Meaning this is the immediate response, that doesn't need to be filtered.
+		return resp
+	}
 	originalHeaderMutation := original.RequestBody.Response.GetHeaderMutation()
 	redactedHeaderMutation := &extprocv3.HeaderMutation{
 		RemoveHeaders: originalHeaderMutation.GetRemoveHeaders(),

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -380,6 +380,17 @@ func Test_filterSensitiveBodyForLogging(t *testing.T) {
 		{Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte("sensitive")}},
 	}, originalMutation.GetSetHeaders())
 	require.Contains(t, buf.String(), "filtering sensitive header")
+
+	t.Run("do nothing for immediate response", func(t *testing.T) {
+		resp := &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ImmediateResponse{
+				ImmediateResponse: &extprocv3.ImmediateResponse{},
+			},
+		}
+		filtered := filterSensitiveBodyForLogging(resp, logger, []string{"authorization"})
+		require.NotNil(t, filtered)
+		require.Equal(t, resp, filtered)
+	})
 }
 
 func Test_headersToMap(t *testing.T) {


### PR DESCRIPTION
**Commit Message**

Previously, `filterSensitiveBodyForLogging` resulted in panic when the response was immediate response due to, for example, the matching route was not found. 
