### PR TITLE
extproc: make Main function accept args, stderr

### DIFF
--- a/cmd/extproc/main.go
+++ b/cmd/extproc/main.go
@@ -5,6 +5,22 @@
 
 package main
 
-import "github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
 
-func main() { mainlib.Main() }
+	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	signalsChan := make(chan os.Signal, 1)
+	signal.Notify(signalsChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-signalsChan
+		cancel()
+	}()
+	mainlib.Main(ctx, os.Args[1:], os.Stderr)
+}

--- a/examples/extproc_custom_router/main.go
+++ b/examples/extproc_custom_router/main.go
@@ -6,7 +6,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
 	"github.com/envoyproxy/ai-gateway/filterapi"
@@ -42,5 +46,12 @@ func main() {
 	// Initializes the custom router.
 	x.NewCustomRouter = newCustomRouter
 	// Executes the main function of the external processor.
-	mainlib.Main()
+	ctx, cancel := context.WithCancel(context.Background())
+	signalsChan := make(chan os.Signal, 1)
+	signal.Notify(signalsChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-signalsChan
+		cancel()
+	}()
+	mainlib.Main(ctx, os.Args[1:], os.Stderr)
 }


### PR DESCRIPTION
**Commit Message**

This makes changes to Main function of the extproc so that it will accept context as well as args, etc to allow the callsite to fine tune the behavior of extproc.

**Related Issues/PRs (if applicable)**

Extracted from #458 

