### PR TITLE
extproc: allow extra attributes in the chat completion metrics interface

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -41,7 +41,7 @@ type extProcFlags struct {
 	metricsAddr string     // HTTP address for the metrics server.
 }
 
-// parseAndValidateFlags parses and validates the flas passed to the external processor.
+// parseAndValidateFlags parses and validates the flags passed to the external processor.
 func parseAndValidateFlags(args []string) (extProcFlags, error) {
 	var (
 		flags extProcFlags

--- a/examples/extproc_custom_metrics/main.go
+++ b/examples/extproc_custom_metrics/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
@@ -61,14 +62,14 @@ func (m *myCustomChatCompletionMetrics) SetBackend(backend filterapi.Backend) {
 	m.logger.Info("SetBackend", "backend", backend.Name)
 }
 
-func (m *myCustomChatCompletionMetrics) RecordTokenUsage(_ context.Context, inputTokens, outputTokens, totalTokens uint32) {
+func (m *myCustomChatCompletionMetrics) RecordTokenUsage(_ context.Context, inputTokens, outputTokens, totalTokens uint32, _ ...attribute.KeyValue) {
 	m.logger.Info("RecordTokenUsage", "inputTokens", inputTokens, "outputTokens", outputTokens, "totalTokens", totalTokens)
 }
 
-func (m *myCustomChatCompletionMetrics) RecordRequestCompletion(_ context.Context, success bool) {
+func (m *myCustomChatCompletionMetrics) RecordRequestCompletion(_ context.Context, success bool, _ ...attribute.KeyValue) {
 	m.logger.Info("RecordRequestCompletion", "success", success)
 }
 
-func (m *myCustomChatCompletionMetrics) RecordTokenLatency(_ context.Context, tokens uint32) {
+func (m *myCustomChatCompletionMetrics) RecordTokenLatency(_ context.Context, tokens uint32, _ ...attribute.KeyValue) {
 	m.logger.Info("RecordTokenLatency", "tokens", tokens)
 }

--- a/filterapi/x/x.go
+++ b/filterapi/x/x.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
@@ -61,9 +62,9 @@ type ChatCompletionMetrics interface {
 	SetBackend(backend filterapi.Backend)
 
 	// RecordTokenUsage records token usage metrics.
-	RecordTokenUsage(ctx context.Context, inputTokens, outputTokens, totalTokens uint32)
+	RecordTokenUsage(ctx context.Context, inputTokens, outputTokens, totalTokens uint32, extraAttrs ...attribute.KeyValue)
 	// RecordRequestCompletion records latency metrics for the entire request
-	RecordRequestCompletion(ctx context.Context, success bool)
+	RecordRequestCompletion(ctx context.Context, success bool, extraAttrs ...attribute.KeyValue)
 	// RecordTokenLatency records latency metrics for token generation.
-	RecordTokenLatency(ctx context.Context, tokens uint32)
+	RecordTokenLatency(ctx context.Context, tokens uint32, extraAttrs ...attribute.KeyValue)
 }

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -15,6 +15,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
@@ -189,17 +190,17 @@ func (m *mockChatCompletionMetrics) SetModel(model string) { m.model = model }
 func (m *mockChatCompletionMetrics) SetBackend(backend filterapi.Backend) { m.backend = backend.Name }
 
 // RecordTokenUsage implements [metrics.ChatCompletion].
-func (m *mockChatCompletionMetrics) RecordTokenUsage(_ context.Context, _, _, _ uint32) {
+func (m *mockChatCompletionMetrics) RecordTokenUsage(_ context.Context, _, _, _ uint32, _ ...attribute.KeyValue) {
 	m.tokenUsageCount++
 }
 
 // RecordTokenLatency implements [metrics.ChatCompletion].
-func (m *mockChatCompletionMetrics) RecordTokenLatency(_ context.Context, _ uint32) {
+func (m *mockChatCompletionMetrics) RecordTokenLatency(_ context.Context, _ uint32, _ ...attribute.KeyValue) {
 	m.tokenLatencyCount++
 }
 
 // RecordRequestCompletion implements [metrics.ChatCompletion].
-func (m *mockChatCompletionMetrics) RecordRequestCompletion(_ context.Context, success bool) {
+func (m *mockChatCompletionMetrics) RecordRequestCompletion(_ context.Context, success bool, _ ...attribute.KeyValue) {
 	if success {
 		m.requestSuccessCount++
 	} else {

--- a/internal/metrics/chat_completion_metrics.go
+++ b/internal/metrics/chat_completion_metrics.go
@@ -68,12 +68,12 @@ func (c *chatCompletion) SetBackend(backend filterapi.Backend) {
 }
 
 // RecordTokenUsage implements [ChatCompletion.RecordTokenUsage].
-func (c *chatCompletion) RecordTokenUsage(ctx context.Context, inputTokens, outputTokens, totalTokens uint32) {
-	attrs := []attribute.KeyValue{
+func (c *chatCompletion) RecordTokenUsage(ctx context.Context, inputTokens, outputTokens, totalTokens uint32, extraAttrs ...attribute.KeyValue) {
+	attrs := append([]attribute.KeyValue{
 		attribute.Key(genaiAttributeOperationName).String(genaiOperationChat),
 		attribute.Key(genaiAttributeSystemName).String(c.backend),
 		attribute.Key(genaiAttributeRequestModel).String(c.model),
-	}
+	}, extraAttrs...)
 
 	c.metrics.tokenUsage.Record(ctx, float64(inputTokens),
 		metric.WithAttributes(attrs...),
@@ -90,12 +90,12 @@ func (c *chatCompletion) RecordTokenUsage(ctx context.Context, inputTokens, outp
 }
 
 // RecordRequestCompletion implements [ChatCompletion.RecordRequestCompletion].
-func (c *chatCompletion) RecordRequestCompletion(ctx context.Context, success bool) {
-	attrs := []attribute.KeyValue{
+func (c *chatCompletion) RecordRequestCompletion(ctx context.Context, success bool, extraAttrs ...attribute.KeyValue) {
+	attrs := append([]attribute.KeyValue{
 		attribute.Key(genaiAttributeOperationName).String(genaiOperationChat),
 		attribute.Key(genaiAttributeSystemName).String(c.backend),
 		attribute.Key(genaiAttributeRequestModel).String(c.model),
-	}
+	}, extraAttrs...)
 
 	if success {
 		// According to the semantic conventions, the error attribute should not be added for successful operations
@@ -111,12 +111,12 @@ func (c *chatCompletion) RecordRequestCompletion(ctx context.Context, success bo
 }
 
 // RecordTokenLatency implements [ChatCompletion.RecordTokenLatency].
-func (c *chatCompletion) RecordTokenLatency(ctx context.Context, tokens uint32) {
-	attrs := []attribute.KeyValue{
+func (c *chatCompletion) RecordTokenLatency(ctx context.Context, tokens uint32, extraAttrs ...attribute.KeyValue) {
+	attrs := append([]attribute.KeyValue{
 		attribute.Key(genaiAttributeOperationName).String(genaiOperationChat),
 		attribute.Key(genaiAttributeSystemName).String(c.backend),
 		attribute.Key(genaiAttributeRequestModel).String(c.model),
-	}
+	}, extraAttrs...)
 
 	if !c.firstTokenSent {
 		c.firstTokenSent = true

--- a/internal/metrics/chat_completion_metrics_test.go
+++ b/internal/metrics/chat_completion_metrics_test.go
@@ -51,10 +51,12 @@ func TestRecordTokenUsage(t *testing.T) {
 		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
 		pm    = DefaultChatCompletion(meter).(*chatCompletion)
 
+		extra = attribute.Key("extra").String("value")
 		attrs = []attribute.KeyValue{
 			attribute.Key(genaiAttributeOperationName).String(genaiOperationChat),
 			attribute.Key(genaiAttributeSystemName).String(genaiSystemOpenAI),
 			attribute.Key(genaiAttributeRequestModel).String("test-model"),
+			extra,
 		}
 		inputAttrs  = attribute.NewSet(append(attrs, attribute.Key(genaiAttributeTokenType).String(genaiTokenTypeInput))...)
 		outputAttrs = attribute.NewSet(append(attrs, attribute.Key(genaiAttributeTokenType).String(genaiTokenTypeOutput))...)
@@ -63,7 +65,7 @@ func TestRecordTokenUsage(t *testing.T) {
 
 	pm.SetModel("test-model")
 	pm.SetBackend(filterapi.Backend{Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}})
-	pm.RecordTokenUsage(t.Context(), 10, 5, 15)
+	pm.RecordTokenUsage(t.Context(), 10, 5, 15, extra)
 
 	count, sum := getHistogramValues(t, mr, genaiMetricClientTokenUsage, inputAttrs)
 	assert.Equal(t, uint64(1), count)
@@ -84,10 +86,12 @@ func TestRecordTokenLatency(t *testing.T) {
 		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
 		pm    = DefaultChatCompletion(meter).(*chatCompletion)
 
+		extra = attribute.Key("extra").String("value")
 		attrs = attribute.NewSet(
 			attribute.Key(genaiAttributeOperationName).String(genaiOperationChat),
 			attribute.Key(genaiAttributeSystemName).String(genAISystemAWSBedrock),
 			attribute.Key(genaiAttributeRequestModel).String("test-model"),
+			extra,
 		)
 	)
 
@@ -97,7 +101,7 @@ func TestRecordTokenLatency(t *testing.T) {
 
 	// Test first token.
 	time.Sleep(10 * time.Millisecond)
-	pm.RecordTokenLatency(t.Context(), 1)
+	pm.RecordTokenLatency(t.Context(), 1, extra)
 	assert.True(t, pm.firstTokenSent)
 	count, sum := getHistogramValues(t, mr, genaiMetricServerTimeToFirstToken, attrs)
 	assert.Equal(t, uint64(1), count)
@@ -105,14 +109,14 @@ func TestRecordTokenLatency(t *testing.T) {
 
 	// Test subsequent tokens.
 	time.Sleep(10 * time.Millisecond)
-	pm.RecordTokenLatency(t.Context(), 5)
+	pm.RecordTokenLatency(t.Context(), 5, extra)
 	count, sum = getHistogramValues(t, mr, genaiMetricServerTimePerOutputToken, attrs)
 	assert.Equal(t, uint64(1), count)
 	assert.Greater(t, sum, 0.0)
 
 	// Test zero tokens case.
 	time.Sleep(10 * time.Millisecond)
-	pm.RecordTokenLatency(t.Context(), 0)
+	pm.RecordTokenLatency(t.Context(), 0, extra)
 	count, sum = getHistogramValues(t, mr, genaiMetricServerTimePerOutputToken, attrs)
 	assert.Equal(t, uint64(1), count)
 	assert.Greater(t, sum, 0.0)
@@ -124,10 +128,12 @@ func TestRecordRequestCompletion(t *testing.T) {
 		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
 		pm    = DefaultChatCompletion(meter).(*chatCompletion)
 
+		extra = attribute.Key("extra").String("value")
 		attrs = []attribute.KeyValue{
 			attribute.Key(genaiAttributeOperationName).String(genaiOperationChat),
 			attribute.Key(genaiAttributeSystemName).String("custom"),
 			attribute.Key(genaiAttributeRequestModel).String("test-model"),
+			extra,
 		}
 		attrsSuccess = attribute.NewSet(attrs...)
 		attrsFailure = attribute.NewSet(append(attrs, attribute.Key(genaiAttributeErrorType).String(genaiErrorTypeFallback))...)
@@ -138,14 +144,14 @@ func TestRecordRequestCompletion(t *testing.T) {
 	pm.SetBackend(filterapi.Backend{Name: "custom"})
 
 	time.Sleep(10 * time.Millisecond)
-	pm.RecordRequestCompletion(t.Context(), true)
+	pm.RecordRequestCompletion(t.Context(), true, extra)
 	count, sum := getHistogramValues(t, mr, genaiMetricServerRequestDuration, attrsSuccess)
 	assert.Equal(t, uint64(1), count)
 	assert.Greater(t, sum, 0.0)
 
 	// Test some failed requests.
-	pm.RecordRequestCompletion(t.Context(), false)
-	pm.RecordRequestCompletion(t.Context(), false)
+	pm.RecordRequestCompletion(t.Context(), false, extra)
+	pm.RecordRequestCompletion(t.Context(), false, extra)
 	count, sum = getHistogramValues(t, mr, genaiMetricServerRequestDuration, attrsFailure)
 	assert.Equal(t, uint64(2), count)
 	assert.Greater(t, sum, 0.0)


### PR DESCRIPTION
**Commit Message**

extproc: allow extra attributes in the chat completion metrics interface

**Related Issues/PRs (if applicable)**

Follow-up of: https://github.com/envoyproxy/ai-gateway/pull/483

**Special notes for reviewers (if applicable)**

This complements the previous pull request by making the ChatCompletionMetrics capable of receiving additional attributes to be added to the generated metrics. This will facilitate custom builds of the completion metrics to enrich metrics with custom attributes.

Note that this would not be immediately leverageable by the default build of extprox, as the chat completion Processor will call the methods with no extra attirbtues, but it facilitates writing cleaner code when building a custom implementation of the metrics. In addition, we will have an interface that already makes sense and is better suited for extension (and if we eventually allow users to customizer metrics via the filter API config, etc, the metrics interface would already be able to nicely accommodate that).