### PR TITLE
test: adds huge number of events in a stream

### DIFF
--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -63,6 +63,8 @@ static_resources:
                                   exact: testupstream
                           route:
                             cluster: testupstream
+                            # Huge event tests take a long time to complete.
+                            timeout: 600s
                 http_filters:
                   - name: envoy.filters.http.ext_proc
                     typed_config:

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -350,7 +350,8 @@ data: [DONE]
 		)
 		stream := client.Chat.Completions.NewStreaming(t.Context(), openaigo.ChatCompletionNewParams{
 			Messages: openaigo.F([]openaigo.ChatCompletionMessageParamUnion{
-				openaigo.UserMessage("Say this is a test")}),
+				openaigo.UserMessage("Say this is a test"),
+			}),
 			Model: openaigo.F("something"),
 		})
 		defer func() {
@@ -368,7 +369,7 @@ data: [DONE]
 			bytes += len(chunk.Choices[0].Delta.Content)
 		}
 		require.Equal(t, 3000001, eventCount)
-		require.Equal(t, bytes, 1095000001) // 1GB+.
+		require.Equal(t, 1095000001, bytes) // 1GB+.
 		require.NoError(t, stream.Err())
 	})
 }


### PR DESCRIPTION
**Commit Message**

This adds a new test case in extproc+testupstream where the upstream server sends huge number of events. This at least ensures that the AI Gateway extproc can handle such case at least with the raw Envoy configuration given in the tests/extproc case.

**Related Issues/PRs (if applicable)**

Related to #494 
