### PR TITLE
translator: skip adding content if assistant content string is empty

### DIFF
--- a/internal/extproc/translator/openai_awsbedrock.go
+++ b/internal/extproc/translator/openai_awsbedrock.go
@@ -245,7 +245,7 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) openAIMessageToBedrockMes
 ) (*awsbedrock.Message, error) {
 	var bedrockMessage *awsbedrock.Message
 	contentBlocks := make([]*awsbedrock.ContentBlock, 0)
-	if v, ok := openAiMessage.Content.Value.(string); ok {
+	if v, ok := openAiMessage.Content.Value.(string); ok && len(v) > 0 {
 		contentBlocks = append(contentBlocks, &awsbedrock.ContentBlock{Text: &v})
 	} else if content, ok := openAiMessage.Content.Value.(openai.ChatCompletionAssistantMessageParamContent); ok {
 		if content.Type == openai.ChatCompletionAssistantMessageParamContentTypeRefusal {

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -107,6 +107,13 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 							},
 						}, Type: openai.ChatMessageRoleAssistant,
 					},
+					{
+						Value: openai.ChatCompletionAssistantMessageParam{
+							Content: openai.StringOrAssistantRoleContentUnion{
+								Value: "",
+							},
+						}, Type: openai.ChatMessageRoleAssistant,
+					},
 				},
 			},
 			output: awsbedrock.ConverseInput{
@@ -181,6 +188,10 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 								Text: ptr.To("I also dunno"),
 							},
 						},
+					},
+					{
+						Role:    openai.ChatMessageRoleAssistant,
+						Content: []*awsbedrock.ContentBlock{},
 					},
 				},
 			},


### PR DESCRIPTION
**Commit Message**

AWS Claude 3.5 v1 has cases when assistant returns empty content. Sending that back to AWS will result in a validation error. Will skip adding empty content if string is empty.

```
openai.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/', 'code': '400', 'message': 'The text field in the ContentBlock object at messages.3.content.0 is blank. Add text to the text field, and try again.'}}
```


**Related Issues/PRs (if applicable)**
#486
