### PR TITLE
extproc: fixes router to make the first match win

### DIFF
--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -32,6 +32,7 @@ func New(config *filterapi.Config, newCustomFn x.NewCustomRouterFn) (x.Router, e
 // Calculate implements [x.Router.Calculate].
 func (r *router) Calculate(headers map[string]string) (backend *filterapi.Backend, err error) {
 	var rule *filterapi.RouteRule
+outer:
 	for i := range r.rules {
 		_rule := &r.rules[i]
 		for _, hdr := range _rule.Headers {
@@ -39,7 +40,7 @@ func (r *router) Calculate(headers map[string]string) (backend *filterapi.Backen
 			// Currently, we only do the exact matching.
 			if ok && v == hdr.Value {
 				rule = _rule
-				break
+				break outer
 			}
 		}
 	}

--- a/internal/extproc/router/router.go
+++ b/internal/extproc/router/router.go
@@ -35,7 +35,8 @@ func (r *router) Calculate(headers map[string]string) (backend *filterapi.Backen
 outer:
 	for i := range r.rules {
 		_rule := &r.rules[i]
-		for _, hdr := range _rule.Headers {
+		for j := range _rule.Headers {
+			hdr := &_rule.Headers[j]
 			v, ok := headers[string(hdr.Name)]
 			// Currently, we only do the exact matching.
 			if ok && v == hdr.Value {

--- a/internal/extproc/router/router_test.go
+++ b/internal/extproc/router/router_test.go
@@ -46,6 +46,14 @@ func TestRouter_Calculate(t *testing.T) {
 		Rules: []filterapi.RouteRule{
 			{
 				Backends: []filterapi.Backend{
+					{Name: "cat", Schema: outSchema},
+				},
+				Headers: []filterapi.HeaderMatch{
+					{Name: "x-some-random-non-model-header", Value: "dog"},
+				},
+			},
+			{
+				Backends: []filterapi.Backend{
 					{Name: "foo", Schema: outSchema, Weight: 1},
 					{Name: "bar", Schema: outSchema, Weight: 3},
 				},
@@ -111,6 +119,12 @@ func TestRouter_Calculate(t *testing.T) {
 		require.Greater(t, chosenNames["bar"], chosenNames["foo"])
 		require.Greater(t, chosenNames["bar"], 700)
 		require.Greater(t, chosenNames["foo"], 200)
+	})
+
+	t.Run("first match win", func(t *testing.T) {
+		b, err := r.Calculate(map[string]string{"x-some-random-non-model-header": "dog", "x-model-name": "llama3.3333"})
+		require.NoError(t, err)
+		require.Equal(t, "cat", b.Name)
 	})
 
 	t.Run("concurrent access", func(t *testing.T) {


### PR DESCRIPTION
**Commit Message**

Previously, there was a bug in router's code where the matching rule search doesn't break and it iterated over all rules even when there's a matching rule found in the middle. That was a bug in the sense that it is not only an inefficient but also semantically wrong since the last match wins as opposed to the specification of GW API [1] which specifies "If ties still exist within an HTTPRoute, matching precedence MUST be granted to the FIRST matching rule (in list order) with a match meeting the above criteria.".

1: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule