### PR TITLE
extproc: do not list non model header values on /models

### DIFF
--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"io"
 	"log/slog"
 	"slices"
@@ -24,6 +23,7 @@ import (
 	"google.golang.org/grpc/status"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/filterapi/x"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc/status"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/filterapi/x"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
@@ -81,7 +80,7 @@ func (s *Server) LoadConfig(ctx context.Context, config *filterapi.Config) error
 			// If not set, we assume it's an exact match.
 			//
 			// Also, we only care about the AIModel header to declare models.
-			if (h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact) || h.Name != aigv1a1.AIModelHeaderKey {
+			if (h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact) || string(h.Name) != config.ModelNameHeaderKey {
 				continue
 			}
 			declaredModels = append(declaredModels, h.Value)

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"io"
 	"log/slog"
 	"slices"
@@ -78,7 +79,9 @@ func (s *Server) LoadConfig(ctx context.Context, config *filterapi.Config) error
 		for _, h := range r.Headers {
 			// If explicitly set to something that is not an exact match, skip.
 			// If not set, we assume it's an exact match.
-			if h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact {
+			//
+			// Also, we only care about the AIModel header to declare models.
+			if (h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact) || h.Name != aigv1a1.AIModelHeaderKey {
 				continue
 			}
 			declaredModels = append(declaredModels, h.Value)

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -8,7 +8,6 @@ package extproc
 import (
 	"context"
 	"errors"
-	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"io"
 	"log/slog"
 	"testing"
@@ -21,6 +20,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
-	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"github.com/envoyproxy/ai-gateway/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )
@@ -56,7 +55,7 @@ func TestServer_LoadConfig(t *testing.T) {
 					},
 					Headers: []filterapi.HeaderMatch{
 						{
-							Name:  aigv1a1.AIModelHeaderKey,
+							Name:  "x-model-name",
 							Value: "llama3.3333",
 						},
 					},
@@ -67,7 +66,7 @@ func TestServer_LoadConfig(t *testing.T) {
 					},
 					Headers: []filterapi.HeaderMatch{
 						{
-							Name:  aigv1a1.AIModelHeaderKey,
+							Name:  "x-model-name",
 							Value: "gpt4.4444",
 						},
 						{

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -8,6 +8,7 @@ package extproc
 import (
 	"context"
 	"errors"
+	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	"io"
 	"log/slog"
 	"testing"
@@ -55,7 +56,7 @@ func TestServer_LoadConfig(t *testing.T) {
 					},
 					Headers: []filterapi.HeaderMatch{
 						{
-							Name:  "x-model-name",
+							Name:  aigv1a1.AIModelHeaderKey,
 							Value: "llama3.3333",
 						},
 					},
@@ -66,8 +67,12 @@ func TestServer_LoadConfig(t *testing.T) {
 					},
 					Headers: []filterapi.HeaderMatch{
 						{
-							Name:  "x-model-name",
+							Name:  aigv1a1.AIModelHeaderKey,
 							Value: "gpt4.4444",
+						},
+						{
+							Name:  "some-random-header",
+							Value: "some-random-value",
 						},
 					},
 				},
@@ -94,6 +99,7 @@ func TestServer_LoadConfig(t *testing.T) {
 		val, err := llmcostcel.EvaluateProgram(prog, "", "", 1, 1, 1)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), val)
+		require.Equal(t, []string{"llama3.3333", "gpt4.4444"}, s.config.declaredModels)
 	})
 }
 

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -60,15 +60,23 @@ func TestWithTestUpstream(t *testing.T) {
 				Backends: []filterapi.Backend{{Name: "testupstream", Schema: azureOpenAISchema}},
 				Headers:  []filterapi.HeaderMatch{{Name: "x-test-backend", Value: "azure-openai"}},
 			},
+			{
+				Backends: []filterapi.Backend{{Name: "testupstream", Schema: azureOpenAISchema}},
+				Headers: []filterapi.HeaderMatch{
+					{Name: "x-model-name", Value: "some-model1"},
+					{Name: "x-model-name", Value: "some-model2"},
+					{Name: "x-model-name", Value: "some-model3"},
+				},
+			},
 		},
 	})
 
 	expectedModels := openai.ModelList{
 		Object: "list",
 		Data: []openai.Model{
-			{ID: "openai", Object: "model", OwnedBy: "Envoy AI Gateway"},
-			{ID: "aws-bedrock", Object: "model", OwnedBy: "Envoy AI Gateway"},
-			{ID: "azure-openai", Object: "model", OwnedBy: "Envoy AI Gateway"},
+			{ID: "some-model1", Object: "model", OwnedBy: "Envoy AI Gateway"},
+			{ID: "some-model2", Object: "model", OwnedBy: "Envoy AI Gateway"},
+			{ID: "some-model3", Object: "model", OwnedBy: "Envoy AI Gateway"},
 		},
 	}
 


### PR DESCRIPTION
**Commit Message**

Previously, /v1/models endpoint returned all header matching values, not limited to the special "x-ai-eg-model" header. This fixes it, and only lists the values from the matching rules using that header.

**Related Issues/PRs (if applicable)**

Follow up on #325 
