### PR TITLE
backport: set extProcImage before potentially returning #515

### DIFF
--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -180,6 +180,7 @@ func extProcName(route *aigv1a1.AIGatewayRoute) string {
 }
 
 func (c *AIGatewayRouteController) applyExtProcDeploymentConfigUpdate(d *appsv1.DeploymentSpec, filterConfig *aigv1a1.AIGatewayFilterConfig) {
+	d.Template.Spec.Containers[0].Image = c.extProcImage
 	if filterConfig == nil || filterConfig.ExternalProcessor == nil {
 		d.Replicas = nil
 		d.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
@@ -191,7 +192,6 @@ func (c *AIGatewayRouteController) applyExtProcDeploymentConfigUpdate(d *appsv1.
 	} else {
 		d.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
 	}
-	d.Template.Spec.Containers[0].Image = c.extProcImage
 	d.Replicas = extProc.Replicas
 }
 

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -165,7 +165,9 @@ func Test_applyExtProcDeploymentConfigUpdate(t *testing.T) {
 	dep := &appsv1.DeploymentSpec{
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{}},
+				Containers: []corev1.Container{{
+					Image: "placeholderExtProc",
+				}},
 			},
 		},
 	}
@@ -173,10 +175,13 @@ func Test_applyExtProcDeploymentConfigUpdate(t *testing.T) {
 	c := &AIGatewayRouteController{client: fake.NewClientBuilder().WithScheme(scheme).Build(), extProcImage: extProcImage}
 	t.Run("not panic", func(_ *testing.T) {
 		c.applyExtProcDeploymentConfigUpdate(dep, nil)
+		require.Equal(t, dep.Template.Spec.Containers[0].Image, extProcImage)
 		c.applyExtProcDeploymentConfigUpdate(dep, &aigv1a1.AIGatewayFilterConfig{})
+		require.Equal(t, dep.Template.Spec.Containers[0].Image, extProcImage)
 		c.applyExtProcDeploymentConfigUpdate(dep, &aigv1a1.AIGatewayFilterConfig{
 			ExternalProcessor: &aigv1a1.AIGatewayFilterConfigExternalProcessor{},
 		})
+		require.Equal(t, dep.Template.Spec.Containers[0].Image, extProcImage)
 	})
 	t.Run("update", func(t *testing.T) {
 		req := corev1.ResourceRequirements{


### PR DESCRIPTION
**Commit Message**

The scenario where `filterConfig` is nil will result in skipping the code: `d.Template.Spec.Containers[0].Image = c.extProcImage`. The container image should be updated regardless of filterConfig, so moving the logic up.

**Related Issues/PRs (if applicable)**

https://github.com/envoyproxy/ai-gateway/pull/447
