### PR TITLE
test: adds metrics endpoint check in extproc e2e

### DIFF
--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -362,6 +362,17 @@ data: [DONE]
 		require.True(t, asserted)
 		require.NoError(t, stream.Err())
 	})
+	t.Run("metrics", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9190/metrics", nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), `gen_ai_server_time_per_output_token_seconds_bucket{gen_ai_operation_name="chat",gen_ai_request_model="something",gen_ai_system_name="aws.bedrock",otel_scope_name="envoyproxy/ai-gateway",otel_scope_version="",le="0.01"} 1`)
+	})
 }
 
 func checkModelsIgnoringTimestamps(want openai.ModelList) func(t require.TestingT, body []byte) {


### PR DESCRIPTION
**Commit Message**

Previously, we did not have any test that checks if the prometheus /metrics endpoint works correctly in the e2e test. This adds an additional test case in tests/extproc.
