### PR TITLE
examples: adds prometheus scraping setup

### DIFF
--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -178,6 +178,10 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        "prometheus.io/path": "/metrics"
+        "prometheus.io/port": "9190"
+        "prometheus.io/scrape": "true"
       labels:
         app: ai-eg-route-extproc-envoy-ai-gateway-basic
         app.kubernetes.io/managed-by: envoy-ai-gateway
@@ -194,6 +198,8 @@ spec:
           ports:
             - containerPort: 1063
               name: grpc
+            - containerPort: 9190
+              name: metrics
           resources: {}
           volumeMounts:
             - mountPath: /etc/ai-gateway/extproc

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,2 +1,2 @@
 This `monitoring.yaml` file is a Kubernetes manifest file that deploys a Prometheus server that scrapes metrics from pods with the standard annotations.
-More specifically, Envoy AI Gateway produced metrics can be collected by `prometheus.io/scrape: 'true'` annotation.
+More specifically, Envoy AI Gateway produced metrics can be collected by `prometheus.io/scrape: 'true'` annotation. so there's nothing Envoy AI Gateway specific in this file.

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,0 +1,2 @@
+This `monitoring.yaml` file is a Kubernetes manifest file that deploys a Prometheus server that scrapes metrics from pods with the standard annotations.
+More specifically, Envoy AI Gateway produced metrics can be collected by `prometheus.io/scrape: 'true'` annotation.

--- a/examples/monitoring/monitoring.yaml
+++ b/examples/monitoring/monitoring.yaml
@@ -1,0 +1,131 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 3s
+    scrape_configs:
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.47.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus/
+          ports:
+            - containerPort: 9090
+              name: web
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090
+      name: web

--- a/examples/monitoring/monitoring.yaml
+++ b/examples/monitoring/monitoring.yaml
@@ -101,20 +101,20 @@ spec:
     spec:
       serviceAccountName: prometheus
       containers:
-        - name: prometheus
-          image: prom/prometheus:v2.47.0
-          args:
-            - "--config.file=/etc/prometheus/prometheus.yml"
-          volumeMounts:
-            - name: prometheus-config
-              mountPath: /etc/prometheus/
-          ports:
-            - containerPort: 9090
-              name: web
-      volumes:
+      - name: prometheus
+        image: prom/prometheus:v2.47.0
+        args:
+        - "--config.file=/etc/prometheus/prometheus.yml"
+        volumeMounts:
         - name: prometheus-config
-          configMap:
-            name: prometheus-config
+          mountPath: /etc/prometheus/
+        ports:
+        - containerPort: 9090
+          name: web
+      volumes:
+      - name: prometheus-config
+        configMap:
+          name: prometheus-config
 ---
 apiVersion: v1
 kind: Service
@@ -125,7 +125,7 @@ spec:
   selector:
     app: prometheus
   ports:
-    - protocol: TCP
-      port: 9090
-      targetPort: 9090
-      name: web
+  - protocol: TCP
+    port: 9090
+    targetPort: 9090
+    name: web

--- a/examples/token_ratelimit/token_ratelimit.yaml
+++ b/examples/token_ratelimit/token_ratelimit.yaml
@@ -39,7 +39,7 @@ spec:
         - headers:
             - type: Exact
               name: x-ai-eg-model
-              value: gpt-4o-mini
+              value: rate-limit-funky-model
       backendRefs:
         - name: envoy-ai-gateway-token-ratelimit-testupstream
   # The following metadata keys are used to store the costs from the LLM request.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -87,6 +87,11 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	if err := initPrometheus(ctx); err != nil {
+		cancel()
+		panic(err)
+	}
+
 	code := m.Run()
 	cancel()
 
@@ -224,6 +229,21 @@ func initTestupstream(ctx context.Context) (err error) {
 	}
 	initLog("\twaiting for deployment")
 	return kubectlWaitForDeploymentReady("default", "testupstream")
+}
+
+func initPrometheus(ctx context.Context) (err error) {
+	initLog("Installing Prometheus")
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		initLog(fmt.Sprintf("\tdone (took %.2fs in total)\n", elapsed.Seconds()))
+	}()
+	initLog("\tapplying manifests")
+	if err = kubectlApplyManifest(ctx, "../../examples/monitoring/monitoring.yaml"); err != nil {
+		return
+	}
+	initLog("\twaiting for deployment")
+	return kubectlWaitForDeploymentReady("monitoring", "prometheus")
 }
 
 func kubectl(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
**Commit Message**

This adds an example prometheus setup to scrape LLM metrics from extproc deployments and the case in tests/e2e to verify it's working.

**Related Issues/PRs (if applicable)**

Contributes to #245 