### PR TITLE
controller: create HTTPRoute for each backend

### DIFF
--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -6,7 +6,46 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: envoy-ai-gateway-basic
+  name: envoy-ai-gateway-basic-aws
+  namespace: default
+  ownerReferences:
+    - apiVersion: aigateway.envoyproxy.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: AIGatewayRoute
+      name: envoy-ai-gateway-basic
+      uid: ""
+spec:
+  parentRefs:
+    - name: envoy-ai-gateway-basic
+      namespace: default
+  rules:
+    - backendRefs:
+        - group: gateway.envoyproxy.io
+          kind: Backend
+          name: envoy-ai-gateway-basic-aws
+      filters:
+        - extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: ai-eg-host-rewrite
+          type: ExtensionRef
+      matches:
+        - headers:
+            - name: x-ai-eg-selected-backend
+              value: envoy-ai-gateway-basic-aws.default
+    - backendRefs:
+        - group: gateway.envoyproxy.io
+          kind: Backend
+          name: envoy-ai-gateway-basic-aws
+      matches:
+        - path:
+            value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: envoy-ai-gateway-basic-openai
   namespace: default
   ownerReferences:
     - apiVersion: aigateway.envoyproxy.io/v1alpha1
@@ -38,16 +77,27 @@ spec:
         - group: gateway.envoyproxy.io
           kind: Backend
           name: envoy-ai-gateway-basic-aws
-      filters:
-        - extensionRef:
-            group: gateway.envoyproxy.io
-            kind: HTTPRouteFilter
-            name: ai-eg-host-rewrite
-          type: ExtensionRef
       matches:
-        - headers:
-            - name: x-ai-eg-selected-backend
-              value: envoy-ai-gateway-basic-aws.default
+        - path:
+            value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: envoy-ai-gateway-basic-testupstream
+  namespace: default
+  ownerReferences:
+    - apiVersion: aigateway.envoyproxy.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: AIGatewayRoute
+      name: envoy-ai-gateway-basic
+      uid: ""
+spec:
+  parentRefs:
+    - name: envoy-ai-gateway-basic
+      namespace: default
+  rules:
     - backendRefs:
         - kind: Service
           name: envoy-ai-gateway-basic-testupstream
@@ -65,7 +115,7 @@ spec:
     - backendRefs:
         - group: gateway.envoyproxy.io
           kind: Backend
-          name: envoy-ai-gateway-basic-openai
+          name: envoy-ai-gateway-basic-aws
       matches:
         - path:
             value: /

--- a/cmd/aigw/translate_test.go
+++ b/cmd/aigw/translate_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"sort"
 	"testing"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -53,6 +54,11 @@ func Test_translate(t *testing.T) {
 			expHTTPRoutes, expEnvoyExtensionPolicy, expHTTPRouteFilter,
 				expConfigMaps, expSecrets, expDeployments, expServices,
 				expBackends, expBackendTLSPolicy, expGatewayClass, expGateway := requireCollectTranslatedObjects(t, string(outBuf))
+
+			sort.Slice(outHTTPRoutes, func(i, j int) bool {
+				return outHTTPRoutes[i].Name < outHTTPRoutes[j].Name
+			})
+
 			assert.Equal(t, expHTTPRoutes, outHTTPRoutes)
 			assert.Equal(t, expEnvoyExtensionPolicy, outEnvoyExtensionPolicy)
 			assert.Equal(t, expHTTPRouteFilter, outHTTPRouteFilter)

--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -211,41 +211,115 @@ func (c *AIGatewayRouteController) syncAIGatewayRoute(ctx context.Context, aiGat
 		return fmt.Errorf("failed to reconcile extension policy: %w", err)
 	}
 
-	// Check if the HTTPRoute exists.
 	c.logger.Info("syncing AIGatewayRoute", "namespace", aiGatewayRoute.Namespace, "name", aiGatewayRoute.Name)
-	var httpRoute gwapiv1.HTTPRoute
-	err = c.client.Get(ctx, client.ObjectKey{Name: aiGatewayRoute.Name, Namespace: aiGatewayRoute.Namespace}, &httpRoute)
-	existingRoute := err == nil
-	if apierrors.IsNotFound(err) {
-		// This means that this AIGatewayRoute is a new one.
-		httpRoute = gwapiv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      aiGatewayRoute.Name,
-				Namespace: aiGatewayRoute.Namespace,
-			},
-			Spec: gwapiv1.HTTPRouteSpec{},
+	// List all HTTPRoutes in the same namespace as this aiGatewayRoute.
+	var existingHTTPRoutList gwapiv1.HTTPRouteList
+	err = c.client.List(ctx, &existingHTTPRoutList, client.InNamespace(aiGatewayRoute.Namespace))
+	if err != nil {
+		return fmt.Errorf("failed to list HTTPRoutes in %s namespace: %w", aiGatewayRoute.Namespace, err)
+	}
+	// Filter HTTPRoute owned by this aiGatewayRoute.
+	existingHTTPRoutes := make(map[string]*gwapiv1.HTTPRoute)
+	for _, httpRoute := range existingHTTPRoutList.Items {
+		for _, ownerRef := range httpRoute.OwnerReferences {
+			if ownerRef.UID == aiGatewayRoute.UID {
+				key := fmt.Sprintf("%s.%s", httpRoute.Name, aiGatewayRoute.Namespace)
+				existingHTTPRoutes[key] = &httpRoute
+			}
 		}
-		if err = ctrlutil.SetControllerReference(aiGatewayRoute, &httpRoute, c.client.Scheme()); err != nil {
-			panic(fmt.Errorf("BUG: failed to set controller reference for HTTPRoute: %w", err))
+	}
+	// Find all deduplicated AIServiceBackends of this aiGatewayRoute.
+	backends := make(map[string]*aigv1a1.AIServiceBackend)
+	var defaultBackend *aigv1a1.AIServiceBackend
+	for _, rule := range aiGatewayRoute.Spec.Rules {
+		for _, br := range rule.BackendRefs {
+			key := fmt.Sprintf("%s.%s", br.Name, aiGatewayRoute.Namespace)
+			if _, ok := backends[key]; ok {
+				continue
+			}
+			var backend *aigv1a1.AIServiceBackend
+			backend, err = c.backend(ctx, aiGatewayRoute.Namespace, br.Name)
+			if err != nil {
+				return fmt.Errorf("AIServiceBackend %s not found", key)
+			}
+			backends[key] = backend
+			// Choose default backend whose name is alphabetically smallest.
+			if defaultBackend == nil || defaultBackend.Name > backend.Name {
+				defaultBackend = backend
+			}
 		}
-	} else if err != nil {
-		return fmt.Errorf("failed to get HTTPRoute: %w", err)
 	}
 
-	// Update the HTTPRoute with the new AIGatewayRoute.
-	if err = c.newHTTPRoute(ctx, &httpRoute, aiGatewayRoute); err != nil {
-		return fmt.Errorf("failed to construct a new HTTPRoute: %w", err)
+	// The naming convention is that HTTPRoute and AIServiceBackend have same name as the backend name.
+	deletedHTTPRoutes := make([]*gwapiv1.HTTPRoute, 0)
+	removedOwnerHTTPRoutes := make([]*gwapiv1.HTTPRoute, 0)
+	for _, httpRoute := range existingHTTPRoutes {
+		key := fmt.Sprintf("%s.%s", httpRoute.Name, aiGatewayRoute.Namespace)
+		if _, ok := backends[key]; !ok {
+			// If the existing HTTPRoute does not in the new Backend map, we check its owner references.
+			// If this HTTRoute only belongs to this aigGatewayRoute, we delete them.
+			// Otherwise, we remove aiGatewayRoute from this HTTPRoute's owner references.
+			if len(httpRoute.OwnerReferences) == 1 {
+				deletedHTTPRoutes = append(deletedHTTPRoutes, httpRoute)
+			} else {
+				removedOwnerHTTPRoutes = append(removedOwnerHTTPRoutes, httpRoute)
+			}
+		}
 	}
 
-	if existingRoute {
-		c.logger.Info("updating HTTPRoute", "namespace", httpRoute.Namespace, "name", httpRoute.Name)
-		if err = c.client.Update(ctx, &httpRoute); err != nil {
-			return fmt.Errorf("failed to update HTTPRoute: %w", err)
+	// Create/Update HTTPRoute for each AIServiceBackend
+	for _, backend := range backends {
+		var httpRoute gwapiv1.HTTPRoute
+		err = c.client.Get(ctx, client.ObjectKey{Name: backend.Name, Namespace: aiGatewayRoute.Namespace}, &httpRoute)
+		existingRoute := err == nil
+		if apierrors.IsNotFound(err) {
+			// This means that this AIGatewayRoute is a new one.
+			httpRoute = gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      backend.Name,
+					Namespace: aiGatewayRoute.Namespace,
+				},
+				Spec: gwapiv1.HTTPRouteSpec{},
+			}
+			if err = ctrlutil.SetControllerReference(aiGatewayRoute, &httpRoute, c.client.Scheme()); err != nil {
+				panic(fmt.Errorf("BUG: failed to set controller reference for HTTPRoute %s: %w", backend.Name, err))
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to get HTTPRoute %s: %w", backend.Name, err)
 		}
-	} else {
-		c.logger.Info("creating HTTPRoute", "namespace", httpRoute.Namespace, "name", httpRoute.Name)
-		if err = c.client.Create(ctx, &httpRoute); err != nil {
-			return fmt.Errorf("failed to create HTTPRoute: %w", err)
+		// always pick the first backends as the default backend.
+		if err = c.newHTTPRoute(&httpRoute, backend, defaultBackend, aiGatewayRoute); err != nil {
+			return fmt.Errorf("failed to construct a new HTTPRoute %s: %w", backend.Name, err)
+		}
+		if existingRoute {
+			c.logger.Info("updating HTTPRoute", "namespace", httpRoute.Namespace, "name", httpRoute.Name)
+			if err = c.client.Update(ctx, &httpRoute); err != nil {
+				return fmt.Errorf("failed to update HTTPRoute %s: %w", backend.Name, err)
+			}
+		} else {
+			c.logger.Info("creating HTTPRoute", "namespace", httpRoute.Namespace, "name", httpRoute.Name)
+			if err = c.client.Create(ctx, &httpRoute); err != nil {
+				return fmt.Errorf("failed to create HTTPRoute %s: %w", backend.Name, err)
+			}
+		}
+	}
+	// Clean up old HTTPRoutes
+	for _, httpRoute := range deletedHTTPRoutes {
+		if err = c.client.Delete(ctx, httpRoute); err != nil {
+			return fmt.Errorf("failed to delete HTTPRoute %s: %w", httpRoute.Name, err)
+		}
+	}
+	// Update old HTTPRoutes' owner references
+	for _, httpRoute := range removedOwnerHTTPRoutes {
+		newOwners := make([]metav1.OwnerReference, 0)
+		for _, ownerRef := range httpRoute.OwnerReferences {
+			if ownerRef.UID != aiGatewayRoute.UID {
+				newOwners = append(newOwners, ownerRef)
+			}
+		}
+		httpRoute.OwnerReferences = newOwners
+		if err = c.client.Update(ctx, httpRoute); err != nil {
+			return fmt.Errorf("failed to remove owner %s for  HTTPRoute %s: %w", aiGatewayRoute.Name, httpRoute.Name, err)
 		}
 	}
 
@@ -401,25 +475,13 @@ func (c *AIGatewayRouteController) reconcileExtProcConfigMap(ctx context.Context
 	return nil
 }
 
-// newHTTPRoute updates the HTTPRoute with the new AIGatewayRoute.
-func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv1.HTTPRoute, aiGatewayRoute *aigv1a1.AIGatewayRoute) error {
-	var backends []*aigv1a1.AIServiceBackend
-	dedup := make(map[string]struct{})
-	for _, rule := range aiGatewayRoute.Spec.Rules {
-		for _, br := range rule.BackendRefs {
-			key := fmt.Sprintf("%s.%s", br.Name, aiGatewayRoute.Namespace)
-			if _, ok := dedup[key]; ok {
-				continue
-			}
-			dedup[key] = struct{}{}
-			backend, err := c.backend(ctx, aiGatewayRoute.Namespace, br.Name)
-			if err != nil {
-				return fmt.Errorf("AIServiceBackend %s not found", key)
-			}
-			backends = append(backends, backend)
-		}
-	}
-
+// newHTTPRoute updates the HTTPRoute for each AIServiceBackend with the new AIGatewayRoute.
+func (c *AIGatewayRouteController) newHTTPRoute(
+	dst *gwapiv1.HTTPRoute,
+	backend *aigv1a1.AIServiceBackend,
+	defaultBackend *aigv1a1.AIServiceBackend,
+	aiGatewayRoute *aigv1a1.AIGatewayRoute,
+) error {
 	rewriteFilters := []gwapiv1.HTTPRouteFilter{
 		{
 			Type: gwapiv1.HTTPRouteFilterExtensionRef,
@@ -430,22 +492,25 @@ func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv
 			},
 		},
 	}
-	rules := make([]gwapiv1.HTTPRouteRule, len(backends))
-	for i, b := range backends {
-		key := fmt.Sprintf("%s.%s", b.Name, b.Namespace)
-		rule := gwapiv1.HTTPRouteRule{
+	rules := []gwapiv1.HTTPRouteRule{
+		{
 			BackendRefs: []gwapiv1.HTTPBackendRef{
-				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: b.Spec.BackendRef}},
+				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: backend.Spec.BackendRef}},
 			},
 			Matches: []gwapiv1.HTTPRouteMatch{
-				{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: key}}},
+				{
+					Headers: []gwapiv1.HTTPHeaderMatch{
+						{
+							Name:  selectedBackendHeaderKey,
+							Value: fmt.Sprintf("%s.%s", backend.Name, backend.Namespace),
+						},
+					},
+				},
 			},
 			Filters:  rewriteFilters,
-			Timeouts: b.Spec.Timeouts,
-		}
-		rules[i] = rule
+			Timeouts: backend.Spec.Timeouts,
+		},
 	}
-
 	// Adds the default route rule with "/" path. This is necessary because Envoy's router selects the backend
 	// before entering the filters. So, all requests would result in a 404 if there is no default route. In practice,
 	// this default route is not used because our AI Gateway filters is the one who actually calculates the route based
@@ -459,11 +524,10 @@ func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv
 			Matches: []gwapiv1.HTTPRouteMatch{{Path: &gwapiv1.HTTPPathMatch{Value: ptr.To("/")}}},
 			BackendRefs: []gwapiv1.HTTPBackendRef{
 				// It can be any valid backend reference because it will not be used.
-				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: backends[0].Spec.BackendRef}},
+				{BackendRef: gwapiv1.BackendRef{BackendObjectReference: defaultBackend.Spec.BackendRef}},
 			},
 		})
 	}
-
 	dst.Spec.Rules = rules
 
 	targetRefs := aiGatewayRoute.Spec.TargetRefs

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -8,6 +8,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -241,21 +242,26 @@ func TestAIGatewayRouterController_syncAIGatewayRoute(t *testing.T) {
 	s := NewAIGatewayRouteController(fakeClient, kube, logr.Discard(), uuid2.NewUUID, "defaultExtProcImage", "debug")
 	require.NotNil(t, s)
 
-	for _, backend := range []*aigv1a1.AIServiceBackend{
+	backends := []*aigv1a1.AIServiceBackend{
 		{ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: "ns1"}, Spec: aigv1a1.AIServiceBackendSpec{
 			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 		}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: "ns1"}, Spec: aigv1a1.AIServiceBackendSpec{
 			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: ptr.To[gwapiv1.Namespace]("ns1")},
 		}},
-	} {
+	}
+	for _, backend := range backends {
 		err := fakeClient.Create(t.Context(), backend, &client.CreateOptions{})
 		require.NoError(t, err)
 	}
-
 	t.Run("existing", func(t *testing.T) {
+		fakeUID1 := types.UID("fake-uid-1234")
+		fakeUID2 := types.UID("fake-uid-5678")
 		route := &aigv1a1.AIGatewayRoute{
-			ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "route1", Namespace: "ns1",
+				UID: fakeUID1,
+			},
 			Spec: aigv1a1.AIGatewayRouteSpec{
 				Rules: []aigv1a1.AIGatewayRouteRule{
 					{
@@ -267,29 +273,100 @@ func TestAIGatewayRouterController_syncAIGatewayRoute(t *testing.T) {
 		}
 		err := fakeClient.Create(t.Context(), route, &client.CreateOptions{})
 		require.NoError(t, err)
-		httpRoute := &gwapiv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "ns1", Labels: map[string]string{managedByLabel: "envoy-ai-gateway"}},
-			Spec:       gwapiv1.HTTPRouteSpec{},
+		// create 3 HTTPRoutes.
+		// HTTPRoute apple belongs to AIGatewayRoute with fakeUID1.
+		// HTTPRoute foo belongs to AIGatewayRoute with fakeUID1 but not in the AIServiceBackends anymore.
+		// HTTPRoute bar belongs to both AIGatewayRoute fakeUID1 and fakeUID2 but not in fakeUID1 AIServiceBackends anymore.
+		for _, httpRoute := range []*gwapiv1.HTTPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "apple", Namespace: "ns1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "aigateway.envoyproxy.io/v1alpha1",
+							Kind:       "AIGatewayRoute",
+							UID:        fakeUID1,
+						},
+					},
+				},
+				Spec: gwapiv1.HTTPRouteSpec{},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo", Namespace: "ns1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "aigateway.envoyproxy.io/v1alpha1",
+							Kind:       "AIGatewayRoute",
+							UID:        fakeUID1,
+						},
+					},
+				},
+				Spec: gwapiv1.HTTPRouteSpec{},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar", Namespace: "ns1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "aigateway.envoyproxy.io/v1alpha1",
+							Kind:       "AIGatewayRoute",
+							UID:        fakeUID1,
+						},
+						{
+							APIVersion: "aigateway.envoyproxy.io/v1alpha1",
+							Kind:       "AIGatewayRoute",
+							UID:        fakeUID2,
+						},
+					},
+				},
+				Spec: gwapiv1.HTTPRouteSpec{},
+			},
+		} {
+			err = fakeClient.Create(t.Context(), httpRoute, &client.CreateOptions{})
+			require.NoError(t, err)
 		}
-		err = fakeClient.Create(t.Context(), httpRoute, &client.CreateOptions{})
-		require.NoError(t, err)
 
-		// Then sync, which should update the HTTPRoute.
+		// Then sync, which should create/update/clean-up the HTTPRoutes.
 		require.NoError(t, s.syncAIGatewayRoute(t.Context(), route))
-		var updatedHTTPRoute gwapiv1.HTTPRoute
-		err = fakeClient.Get(t.Context(), client.ObjectKey{Name: "route1", Namespace: "ns1"}, &updatedHTTPRoute)
+		var updatedHTTPRouteList gwapiv1.HTTPRouteList
+		err = fakeClient.List(t.Context(), &updatedHTTPRouteList, &client.ListOptions{Namespace: "ns1"})
 		require.NoError(t, err)
-		require.Len(t, updatedHTTPRoute.Spec.Rules, 3) // 2 backends + 1 for the default rule.
-		require.Len(t, updatedHTTPRoute.Spec.Rules[0].BackendRefs, 1)
-		require.Equal(t, "some-backend1", string(updatedHTTPRoute.Spec.Rules[0].BackendRefs[0].BackendRef.Name))
-		require.Equal(t, "apple.ns1", updatedHTTPRoute.Spec.Rules[0].Matches[0].Headers[0].Value)
-		require.Equal(t, "some-backend2", string(updatedHTTPRoute.Spec.Rules[1].BackendRefs[0].BackendRef.Name))
-		require.Equal(t, "orange.ns1", updatedHTTPRoute.Spec.Rules[1].Matches[0].Headers[0].Value)
-		// Defaulting to the first backend.
-		require.Equal(t, "some-backend1", string(updatedHTTPRoute.Spec.Rules[2].BackendRefs[0].BackendRef.Name))
-		require.Equal(t, "/", *updatedHTTPRoute.Spec.Rules[2].Matches[0].Path.Value)
-	})
+		// 1 existing HTTPRoute apple + 1 existing HTTPRout bar + 1 new HTTRoute orange
+		require.Len(t, updatedHTTPRouteList.Items, 3)
+		httpRoutesBelongToFakeUID1 := make([]*gwapiv1.HTTPRoute, 0)
+		httpRoutesNotBelongToFakeUID1 := make([]*gwapiv1.HTTPRoute, 0)
+		for _, httpRoute := range updatedHTTPRouteList.Items {
+			ownByFakeUID1 := false
+			for _, owner := range httpRoute.OwnerReferences {
+				if owner.UID == fakeUID1 {
+					ownByFakeUID1 = true
+					httpRoutesBelongToFakeUID1 = append(httpRoutesBelongToFakeUID1, &httpRoute)
+				}
+			}
+			if !ownByFakeUID1 {
+				httpRoutesNotBelongToFakeUID1 = append(httpRoutesNotBelongToFakeUID1, &httpRoute)
+			}
+		}
+		require.Len(t, httpRoutesBelongToFakeUID1, 2)
+		require.Len(t, httpRoutesNotBelongToFakeUID1, 1)
 
+		sort.Slice(httpRoutesBelongToFakeUID1, func(i, j int) bool {
+			return httpRoutesBelongToFakeUID1[i].Name < httpRoutesBelongToFakeUID1[j].Name
+		})
+		for i, updatedHTTPRoute := range httpRoutesBelongToFakeUID1 {
+			require.Len(t, updatedHTTPRoute.Spec.Rules, 2) // 1 backend + 1 for the default rule.
+			require.Len(t, updatedHTTPRoute.Spec.Rules[0].BackendRefs, 1)
+			require.Equal(t, string(backends[i].Spec.BackendRef.Name), string(updatedHTTPRoute.Spec.Rules[0].BackendRefs[0].BackendRef.Name))
+			require.Equal(t, fmt.Sprintf("%s.%s", backends[i].Name, backends[i].Namespace), updatedHTTPRoute.Spec.Rules[0].Matches[0].Headers[0].Value)
+			// Defaulting to the first backend.
+			require.Equal(t, "some-backend1", string(updatedHTTPRoute.Spec.Rules[1].BackendRefs[0].BackendRef.Name))
+			require.Equal(t, "/", *updatedHTTPRoute.Spec.Rules[1].Matches[0].Path.Value)
+		}
+		// Check fakeUID is removed from HTTPRoute bar's owner references
+		require.Len(t, httpRoutesNotBelongToFakeUID1[0].OwnerReferences, 1)
+		require.Equal(t, httpRoutesNotBelongToFakeUID1[0].OwnerReferences[0].UID, fakeUID2)
+	})
 	// Check the namespace has the default host rewrite filter.
 	var f egv1a1.HTTPRouteFilter
 	err := s.client.Get(t.Context(), client.ObjectKey{Name: hostRewriteHTTPFilterName, Namespace: "ns1"}, &f)
@@ -307,10 +384,7 @@ func Test_newHTTPRoute(t *testing.T) {
 
 			fakeClient := requireNewFakeClientWithIndexes(t)
 			s := NewAIGatewayRouteController(fakeClient, nil, logr.Discard(), uuid2.NewUUID, "defaultExtProcImage", "debug")
-			httpRoute := &gwapiv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: ns},
-				Spec:       gwapiv1.HTTPRouteSpec{},
-			}
+
 			aiGatewayRoute := &aigv1a1.AIGatewayRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: ns},
 				Spec: aigv1a1.AIGatewayRouteSpec{
@@ -343,7 +417,8 @@ func Test_newHTTPRoute(t *testing.T) {
 				timeout2 gwapiv1.Duration = "60s"
 				timeout3 gwapiv1.Duration = "90s"
 			)
-			for _, backend := range []*aigv1a1.AIServiceBackend{
+
+			backends := []*aigv1a1.AIServiceBackend{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: ns},
 					Spec: aigv1a1.AIServiceBackendSpec{
@@ -372,36 +447,45 @@ func Test_newHTTPRoute(t *testing.T) {
 						Timeouts:   &gwapiv1.HTTPRouteTimeouts{Request: &timeout1, BackendRequest: &timeout2},
 					},
 				},
-			} {
+			}
+
+			httpRoutes := make(map[string]*gwapiv1.HTTPRoute)
+			for _, backend := range backends {
 				err := s.client.Create(t.Context(), backend, &client.CreateOptions{})
 				require.NoError(t, err)
-			}
-			err := s.newHTTPRoute(t.Context(), httpRoute, aiGatewayRoute)
-			require.NoError(t, err)
 
-			expRules := []gwapiv1.HTTPRouteRule{
-				{
+				httpRoute := &gwapiv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{Name: backend.Name, Namespace: ns},
+					Spec:       gwapiv1.HTTPRouteSpec{},
+				}
+				err = s.newHTTPRoute(httpRoute, backend, backends[0], aiGatewayRoute)
+				require.NoError(t, err)
+				httpRoutes[backend.Name] = httpRoute
+			}
+
+			expRules := map[string]gwapiv1.HTTPRouteRule{
+				"apple": {
 					Matches: []gwapiv1.HTTPRouteMatch{
 						{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "apple." + ns}}},
 					},
 					BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: refNs}}}},
 					Timeouts:    &gwapiv1.HTTPRouteTimeouts{Request: &timeout1, BackendRequest: &timeout2},
 				},
-				{
+				"orange": {
 					Matches: []gwapiv1.HTTPRouteMatch{
 						{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "orange." + ns}}},
 					},
 					BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend2", Namespace: refNs}}}},
 					Timeouts:    &gwapiv1.HTTPRouteTimeouts{Request: &timeout2, BackendRequest: &timeout3},
 				},
-				{
+				"pineapple": {
 					Matches: []gwapiv1.HTTPRouteMatch{
 						{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "pineapple." + ns}}},
 					},
 					BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "some-backend3", Namespace: refNs}}}},
 					Timeouts:    &gwapiv1.HTTPRouteTimeouts{Request: &timeout1, BackendRequest: &timeout3},
 				},
-				{
+				"foo": {
 					Matches: []gwapiv1.HTTPRouteMatch{
 						{Headers: []gwapiv1.HTTPHeaderMatch{{Name: selectedBackendHeaderKey, Value: "foo." + ns}}},
 					},
@@ -409,24 +493,29 @@ func Test_newHTTPRoute(t *testing.T) {
 					Timeouts:    &gwapiv1.HTTPRouteTimeouts{Request: &timeout1, BackendRequest: &timeout2},
 				},
 			}
-			require.Len(t, httpRoute.Spec.Rules, 5) // 4 backends + 1 for the default rule.
-			for i, r := range httpRoute.Spec.Rules {
-				t.Run(fmt.Sprintf("rule-%d", i), func(t *testing.T) {
-					if i == 4 {
-						require.Equal(t, expRules[0].BackendRefs, r.BackendRefs)
-						require.NotNil(t, r.Matches[0].Path)
-						require.Equal(t, "/", *r.Matches[0].Path.Value)
-					} else {
-						require.Equal(t, expRules[i].Matches, r.Matches)
-						require.Equal(t, expRules[i].BackendRefs, r.BackendRefs)
-						require.Equal(t, expRules[i].Timeouts, r.Timeouts)
-						// Each rule should have a host rewrite filter by default.
-						require.Len(t, r.Filters, 1)
-						require.Equal(t, gwapiv1.HTTPRouteFilterExtensionRef, r.Filters[0].Type)
-						require.NotNil(t, r.Filters[0].ExtensionRef)
-						require.Equal(t, hostRewriteHTTPFilterName, string(r.Filters[0].ExtensionRef.Name))
-					}
-				})
+			require.Len(t, httpRoutes, 4) // 4 backends.
+			for name, h := range httpRoutes {
+				expRule, ok := expRules[name]
+				require.True(t, ok)
+				require.Len(t, h.Spec.Rules, 2) // 1 backend + 1 default rule.
+				for i, rule := range h.Spec.Rules {
+					t.Run(fmt.Sprintf("%s-rule-%d", name, i), func(t *testing.T) {
+						if i == 1 {
+							require.Equal(t, expRules["apple"].BackendRefs, rule.BackendRefs)
+							require.NotNil(t, rule.Matches[0].Path)
+							require.Equal(t, "/", *rule.Matches[0].Path.Value)
+						} else {
+							require.Equal(t, expRule.Matches, rule.Matches)
+							require.Equal(t, expRule.BackendRefs, rule.BackendRefs)
+							require.Equal(t, expRule.Timeouts, rule.Timeouts)
+							// Each rule should have a host rewrite filter by default.
+							require.Len(t, rule.Filters, 1)
+							require.Equal(t, gwapiv1.HTTPRouteFilterExtensionRef, rule.Filters[0].Type)
+							require.NotNil(t, rule.Filters[0].ExtensionRef)
+							require.Equal(t, hostRewriteHTTPFilterName, string(rule.Filters[0].ExtensionRef.Name))
+						}
+					})
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**Commit Message**
In this PR, I create HTTPRoute for each backend in the AIServiceBackend rules. When `AIGatewayRouteController` reconciles a AIGatewayRoute, it lists all the HTTPRoutes belongs to that AIGatewayRoute. It also constructs a de-duplicated backends from the rules of that AIGatewayRoute. 

The controller creates new HTTRoutes for each backend if they do not exist before, and updates the HTTRoutes if they are already existed. 

For clean up, we delete HTTPRoutes if they are not in the backends and only belong to that AIGatewayRoute. For HTTRoute which does not in the backend list but belong to multiple AIGatewayRoutes, we remove that AIGatewayRoute from the owner references.

**Related Issues/PRs (if applicable)**

This PR is to fix issue #509 

**Special notes for reviewers (if applicable)**
N.A.