### PR TITLE
controller: surface IsNotFound error in GetPreRotationTime

### DIFF
--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -153,7 +153,7 @@ func (c *BackendSecurityPolicyController) executeRotation(ctx context.Context, r
 	requeue := time.Minute
 	var rotationTime time.Time
 	rotationTime, err = rotator.GetPreRotationTime(ctx)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		c.logger.Error(err, "failed to get rotation time, retry in one minute")
 	} else {
 		if rotator.IsExpired(rotationTime) {

--- a/internal/controller/rotators/aws_oidc_rotator.go
+++ b/internal/controller/rotators/aws_oidc_rotator.go
@@ -109,7 +109,7 @@ func (r *AWSOIDCRotator) GetPreRotationTime(ctx context.Context) (time.Time, err
 	if err != nil {
 		// return zero value for time if secret has not been created.
 		if apierrors.IsNotFound(err) {
-			return time.Time{}, nil
+			return time.Time{}, err
 		}
 		return time.Time{}, err
 	}

--- a/internal/controller/rotators/aws_oidc_rotator_test.go
+++ b/internal/controller/rotators/aws_oidc_rotator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -301,7 +302,8 @@ func TestAWS_GetPreRotationTime(t *testing.T) {
 		backendSecurityPolicyName:      policyName,
 	}
 
-	preRotateTime, _ := awsOidcRotator.GetPreRotationTime(t.Context())
+	preRotateTime, err := awsOidcRotator.GetPreRotationTime(t.Context())
+	require.True(t, apierrors.IsNotFound(err))
 	require.Equal(t, 0, preRotateTime.Minute())
 
 	createTestAwsSecret(t, fakeClient, policyName, oldAwsAccessKey, oldAwsSecretKey, oldAwsSessionToken, awsProfileName, awsRegion)


### PR DESCRIPTION
**Commit Message**

This commit ensures that an `apierrors.IsNotFound` is not discarded in the `GetPreRotationTime` method.
Instead, the error is returned to the caller. This commit also updates the `executeRotation` method to
maintain the preexisting behavior by allowing the `apierrors.IsNotFound` case trigger the token rotation.

**Related Issues/PRs (if applicable)**

Fixes #466 

**Special notes for reviewers (if applicable)**

This commit does not add a new test for the `executeRotation` method as the `TestBackendSecurityPolicyController_ReconcileOIDC_Fail` already depends on this behavior.
