### PR TITLE
test: fix extproc TestWithRealProviders

### DIFF
--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -260,8 +260,9 @@ func TestWithRealProviders(t *testing.T) {
 							}
 							// Simulate getting weather data
 							weatherData := "Sunny, 25°C"
-							params.Messages = append(params.Messages, openai.ToolMessage(toolCall.ID, weatherData))
-							t.Logf("Appended tool message: %v", openai.ToolMessage(toolCall.ID, weatherData)) // Debug log
+							toolMessage := openai.ToolMessage(weatherData, toolCall.ID)
+							params.Messages = append(params.Messages, toolMessage)
+							t.Logf("Appended tool message: %+v", *toolMessage.OfTool) // Debug log
 						}
 					}
 					if getWeatherCalled == false {


### PR DESCRIPTION
**Commit Message**

The test broke after upgrading github.com/openai/openai-go to 0.1.0-beta.6. from 0.1.0-alpha.65 because OpenAI swapped `openai.ToolMessage()`'s two string arguments. :weary:

This change swaps the arguments to use the right order.

compare

https://github.com/openai/openai-go/blob/v0.1.0-alpha.65/chatcompletion.go#L66

and

https://github.com/openai/openai-go/blob/v0.1.0-beta.6/chatcompletion.go#L1420