### PR TITLE
ci: use EG v1.4.0 on e2e test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -158,8 +158,8 @@ jobs:
         include:
           - name: latest
             envoy_gateway_version: v0.0.0-latest
-          - name: 1.4.0-rc.2
-            envoy_gateway_version: 1.4.0-rc.2
+          - name: 1.4.0
+            envoy_gateway_version: 1.4.0
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	egLatest      = "v0.0.0-latest" // This defaults to the latest dev version.
-	egNamespace   = "envoy-gateway-system"
-	egDefaultPort = 10080
+	egDefaultVersion = "v1.4.0"
+	egNamespace      = "envoy-gateway-system"
+	egDefaultPort    = 10080
 
 	kindClusterName = "envoy-ai-gateway"
 	kindLogDir      = "./logs"
@@ -34,7 +34,7 @@ var egVersion = func() string {
 	if v, ok := os.LookupEnv("EG_VERSION"); ok {
 		return v
 	} else {
-		return egLatest
+		return egDefaultVersion
 	}
 }()
 


### PR DESCRIPTION
**Commit Message**

EG v1.4.0 has just been released.