### PR TITLE
feat: move Backends back to RouteRule

### DIFF
--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -347,24 +347,28 @@ func (runCtx *runCmdContext) writeExtensionPolicy(
 		dirMapping[volume.MountPath] = dir
 	}
 
-	for i := range filterCfg.Backends {
-		be := filterCfg.Backends[i]
-		if auth := be.Auth; auth != nil {
-			if auth.AWSAuth != nil {
-				newDir, ok := dirMapping[path.Dir(auth.AWSAuth.CredentialFileName)]
-				if !ok {
-					panic(fmt.Sprintf("BUG: dir %s not found in dirMapping", path.Dir(auth.AWSAuth.CredentialFileName)))
+	for i := range filterCfg.Rules {
+		rule := &filterCfg.Rules[i]
+		for j := range rule.Backends {
+			be := &rule.Backends[j]
+			if auth := be.Auth; auth != nil {
+				if auth.AWSAuth != nil {
+					newDir, ok := dirMapping[path.Dir(auth.AWSAuth.CredentialFileName)]
+					if !ok {
+						panic(fmt.Sprintf("BUG: dir %s not found in dirMapping", path.Dir(auth.AWSAuth.CredentialFileName)))
+					}
+					auth.AWSAuth.CredentialFileName = filepath.Join(newDir, path.Base(auth.AWSAuth.CredentialFileName))
+				} else if auth.APIKey != nil {
+					newDir, ok := dirMapping[path.Dir(auth.APIKey.Filename)]
+					if !ok {
+						panic(fmt.Sprintf("BUG: dir %s not found in dirMapping", path.Dir(auth.APIKey.Filename)))
+					}
+					auth.APIKey.Filename = filepath.Join(newDir, path.Base(auth.APIKey.Filename))
 				}
-				auth.AWSAuth.CredentialFileName = filepath.Join(newDir, path.Base(auth.AWSAuth.CredentialFileName))
-			} else if auth.APIKey != nil {
-				newDir, ok := dirMapping[path.Dir(auth.APIKey.Filename)]
-				if !ok {
-					panic(fmt.Sprintf("BUG: dir %s not found in dirMapping", path.Dir(auth.APIKey.Filename)))
-				}
-				auth.APIKey.Filename = filepath.Join(newDir, path.Base(auth.APIKey.Filename))
 			}
 		}
 	}
+
 	runCtx.mustClearSetOwnerReferencesAndStatusAndWriteObj(&ep.TypeMeta, ep)
 	return
 }

--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -97,35 +97,37 @@ spec:
 apiVersion: v1
 data:
   extproc-config.yaml: |
-    backends:
-    - auth:
-        aws:
-          credentialFileName: /etc/backend_security_policy/rule1-backref0-envoy-ai-gateway-basic-aws-credentials/credentials
-          region: us-east-1
-      name: envoy-ai-gateway-basic-aws.default
-      schema:
-        name: AWSBedrock
-    - auth:
-        apiKey:
-          filename: /etc/backend_security_policy/rule0-backref0-envoy-ai-gateway-basic-openai-apikey/apiKey
-      name: envoy-ai-gateway-basic-openai.default
-      schema:
-        name: OpenAI
-    - name: envoy-ai-gateway-basic-testupstream.default
-      schema:
-        name: OpenAI
     metadataNamespace: io.envoy.ai_gateway
     modelNameHeaderKey: x-ai-eg-model
     rules:
-    - headers:
+    - backends:
+      - auth:
+          apiKey:
+            filename: /etc/backend_security_policy/rule0-backref0-envoy-ai-gateway-basic-openai-apikey/apiKey
+        name: envoy-ai-gateway-basic-openai.default
+        schema:
+          name: OpenAI
+      headers:
       - name: x-ai-eg-model
         value: gpt-4o-mini
       name: envoy-ai-gateway-basic-rule-0
-    - headers:
+    - backends:
+      - auth:
+          aws:
+            credentialFileName: /etc/backend_security_policy/rule1-backref0-envoy-ai-gateway-basic-aws-credentials/credentials
+            region: us-east-1
+        name: envoy-ai-gateway-basic-aws.default
+        schema:
+          name: AWSBedrock
+      headers:
       - name: x-ai-eg-model
         value: us.meta.llama3-2-1b-instruct-v1:0
       name: envoy-ai-gateway-basic-rule-1
-    - headers:
+    - backends:
+      - name: envoy-ai-gateway-basic-testupstream.default
+        schema:
+          name: OpenAI
+      headers:
       - name: x-ai-eg-model
         value: some-cool-self-hosted-model
       name: envoy-ai-gateway-basic-rule-2

--- a/filterapi/filterconfig.go
+++ b/filterapi/filterconfig.go
@@ -41,22 +41,27 @@ modelNameHeaderKey: x-ai-eg-model
 //	llmRequestCosts:
 //	- metadataKey: token_usage_key
 //	  type: OutputToken
-//	backends:
-//	- name: openai-backend.mynamespace
-//	  schema:
-//	    name: OpenAI
-//	- name: aws-bedrock-backend.mynamespace
-//	  schema:
-//	    name: AWSBedrock
 //	rules:
 //	- name: llama3-route
 //	  headers:
 //	  - name: x-ai-eg-model
 //	    value: llama3.3333
+//	  backends:
+//	  - name: openai-backend.mynamespace
+//	    schema:
+//	      name: OpenAI
+//	  - name: awsbedrock
+//	    weight: 10
+//	    schema:
+//	      name: AWSBedrock
 //	- name: gpt4-route
 //	  headers:
 //	  - name: x-ai-eg-model
 //	    value: gpt4.4444
+//	  backends:
+//	  - name: openai
+//	    schema:
+//	      name: OpenAI
 //
 // where the input of the Gateway is in the OpenAI schema, the model name is populated in the header x-ai-eg-model,
 // The model name header `x-ai-eg-model` is used in the header matching to make the routing decision. **After** the routing decision is made,
@@ -84,8 +89,6 @@ type Config struct {
 	// Rules is the routing rules to be used by the filter to make the routing decision.
 	// Inside the routing rules, the header ModelNameHeaderKey may be used to make the routing decision.
 	Rules []RouteRule `json:"rules"`
-	// Backends is the list of backends to which the request should be routed to when the headers match.
-	Backends []*Backend `json:"backends"`
 }
 
 // LLMRequestCost specifies "where" the request cost is stored in the filter metadata as well as
@@ -148,6 +151,8 @@ type RouteRule struct {
 	// Headers is the list of headers to match for the routing decision.
 	// Currently, only exact match is supported.
 	Headers []HeaderMatch `json:"headers"`
+	// Backends is the list of backends to which the request should be routed to when the headers match.
+	Backends []Backend `json:"backends"`
 }
 
 // RouteRuleName is the name of the route rule.

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -626,55 +626,76 @@ func TestAIGatewayRouteController_reconcileExtProcConfigMap(t *testing.T) {
 					{
 						Name:    "myroute-rule-0",
 						Headers: []filterapi.HeaderMatch{{Name: aigv1a1.AIModelHeaderKey, Value: "some-ai"}},
+						Backends: []filterapi.Backend{
+							{
+								Name:   "apple.ns",
+								Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAWSBedrock},
+								Auth: &filterapi.BackendAuth{
+									APIKey: &filterapi.APIKeyAuth{
+										Filename: "/etc/backend_security_policy/rule0-backref0-some-backend-security-policy-1/apiKey",
+									},
+								},
+							},
+							{Name: "pineapple.ns"},
+						},
 					},
 					{
 						Name:    "myroute-rule-1",
 						Headers: []filterapi.HeaderMatch{{Name: aigv1a1.AIModelHeaderKey, Value: "another-ai"}},
+						Backends: []filterapi.Backend{
+							{
+								Name: "cat.ns",
+								Auth: &filterapi.BackendAuth{
+									APIKey: &filterapi.APIKeyAuth{
+										Filename: "/etc/backend_security_policy/rule1-backref0-some-backend-security-policy-1/apiKey",
+									},
+								},
+							},
+						},
 					},
 					{
 						Name:    "myroute-rule-2",
 						Headers: []filterapi.HeaderMatch{{Name: aigv1a1.AIModelHeaderKey, Value: "another-ai-2"}},
+						Backends: []filterapi.Backend{
+							{
+								Name: "pen.ns",
+								Auth: &filterapi.BackendAuth{
+									AWSAuth: &filterapi.AWSAuth{
+										CredentialFileName: "/etc/backend_security_policy/rule2-backref0-some-backend-security-policy-2/credentials",
+										Region:             "us-east-1",
+									},
+								},
+							},
+						},
 					},
 					{
 						Name:    "myroute-rule-3",
 						Headers: []filterapi.HeaderMatch{{Name: aigv1a1.AIModelHeaderKey, Value: "another-ai-3"}},
+						Backends: []filterapi.Backend{
+							{
+								Name: "dog.ns",
+								Auth: &filterapi.BackendAuth{
+									AWSAuth: &filterapi.AWSAuth{
+										CredentialFileName: "/etc/backend_security_policy/rule3-backref0-some-backend-security-policy-3/credentials",
+										Region:             "us-east-1",
+									},
+								},
+							},
+						},
 					},
 					{
 						Name:    "myroute-rule-4",
 						Headers: []filterapi.HeaderMatch{{Name: aigv1a1.AIModelHeaderKey, Value: "another-ai-4"}},
-					},
-				},
-				Backends: []*filterapi.Backend{
-					{Name: "apple.ns", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAWSBedrock}, Auth: &filterapi.BackendAuth{
-						APIKey: &filterapi.APIKeyAuth{
-							Filename: "/etc/backend_security_policy/rule0-backref0-some-backend-security-policy-1/apiKey",
-						},
-					}},
-					{Name: "cat.ns", Auth: &filterapi.BackendAuth{
-						APIKey: &filterapi.APIKeyAuth{
-							Filename: "/etc/backend_security_policy/rule1-backref0-some-backend-security-policy-1/apiKey",
-						},
-					}},
-					{Name: "dog.ns", Auth: &filterapi.BackendAuth{
-						AWSAuth: &filterapi.AWSAuth{
-							CredentialFileName: "/etc/backend_security_policy/rule3-backref0-some-backend-security-policy-3/credentials",
-							Region:             "us-east-1",
-						},
-					}},
-					{
-						Name: "dragon.ns", Auth: &filterapi.BackendAuth{
-							AzureAuth: &filterapi.AzureAuth{
-								Filename: "/etc/backend_security_policy/rule4-backref0-some-backend-security-policy-4/azureAccessToken",
+						Backends: []filterapi.Backend{{
+							Name: "dragon.ns",
+							Auth: &filterapi.BackendAuth{
+								AzureAuth: &filterapi.AzureAuth{
+									Filename: "/etc/backend_security_policy/rule4-backref0-some-backend-security-policy-4/azureAccessToken",
+								},
 							},
-						}, Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAzureOpenAI, Version: "version1"},
+							Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAzureOpenAI, Version: "version1"},
+						}},
 					},
-					{Name: "pen.ns", Auth: &filterapi.BackendAuth{
-						AWSAuth: &filterapi.AWSAuth{
-							CredentialFileName: "/etc/backend_security_policy/rule2-backref0-some-backend-security-policy-2/credentials",
-							Region:             "us-east-1",
-						},
-					}},
-					{Name: "pineapple.ns"},
 				},
 				LLMRequestCosts: []filterapi.LLMRequestCost{
 					{Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "output-token"},

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -83,9 +83,7 @@ func (s *Server) LoadConfig(ctx context.Context, config *filterapi.Config) error
 			}
 			declaredModels = append(declaredModels, h.Value)
 		}
-	}
 
-	for _, r := range config.Rules {
 		for _, backend := range r.Backends {
 			b := backend
 			var h backendauth.Handler

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -49,11 +49,6 @@ func TestServer_LoadConfig(t *testing.T) {
 			Schema:                 filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
 			SelectedRouteHeaderKey: "x-ai-eg-selected-route",
 			ModelNameHeaderKey:     "x-model-name",
-			Backends: []*filterapi.Backend{
-				{Name: "kserve", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}},
-				{Name: "awsbedrock", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAWSBedrock}},
-				{Name: "openai", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}},
-			},
 			Rules: []filterapi.RouteRule{
 				{
 					Headers: []filterapi.HeaderMatch{
@@ -61,6 +56,10 @@ func TestServer_LoadConfig(t *testing.T) {
 							Name:  "x-model-name",
 							Value: "llama3.3333",
 						},
+					},
+					Backends: []filterapi.Backend{
+						{Name: "kserve", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}},
+						{Name: "awsbedrock", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAWSBedrock}},
 					},
 				},
 				{
@@ -73,6 +72,9 @@ func TestServer_LoadConfig(t *testing.T) {
 							Name:  "some-random-header",
 							Value: "some-random-value",
 						},
+					},
+					Backends: []filterapi.Backend{
+						{Name: "openai", Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}},
 					},
 				},
 			},

--- a/tests/extproc/custom_extproc_test.go
+++ b/tests/extproc/custom_extproc_test.go
@@ -35,11 +35,11 @@ func TestExtProcCustomRouter(t *testing.T) {
 		ModelNameHeaderKey:     "x-model-name",
 		Rules: []filterapi.RouteRule{
 			{
-				Name:    "testupstream-openai-route",
-				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "something-cool"}},
+				Name:     "testupstream-openai-route",
+				Headers:  []filterapi.HeaderMatch{{Name: "x-model-name", Value: "something-cool"}},
+				Backends: fakeBackends,
 			},
 		},
-		Backends: fakeBackends,
 	})
 	stdoutPath := t.TempDir() + "/extproc-stdout.log"
 	f, err := os.Create(stdoutPath)
@@ -95,11 +95,11 @@ func TestExtProcCustomMetrics(t *testing.T) {
 		ModelNameHeaderKey:     "x-model-name",
 		Rules: []filterapi.RouteRule{
 			{
-				Name:    "testupstream-openai-route",
-				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "something-cool"}},
+				Name:     "testupstream-openai-route",
+				Headers:  []filterapi.HeaderMatch{{Name: "x-model-name", Value: "something-cool"}},
+				Backends: fakeBackends,
 			},
 		},
-		Backends: fakeBackends,
 	})
 	stdoutPath := t.TempDir() + "/extproc-stdout.log"
 	f, err := os.Create(stdoutPath)

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -68,7 +68,7 @@ var (
 	azureOpenAISchema = filterapi.VersionedAPISchema{Name: filterapi.APISchemaAzureOpenAI, Version: "2025-01-01-preview"}
 )
 
-var fakeBackends = []*filterapi.Backend{
+var fakeBackends = []filterapi.Backend{
 	{Name: "testupstream-openai", Schema: openAISchema},
 	{Name: "testupstream-aws", Schema: awsBedrockSchema},
 	{Name: "testupstream-azure", Schema: azureOpenAISchema},

--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -48,6 +48,11 @@ func TestWithRealProviders(t *testing.T) {
 			{
 				Name:    "openai-route",
 				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "gpt-4o-mini"}},
+				Backends: []filterapi.Backend{
+					{Name: "openai", Schema: openAISchema, Auth: &filterapi.BackendAuth{
+						APIKey: &filterapi.APIKeyAuth{Filename: cc.OpenAIAPIKeyFilePath},
+					}},
+				},
 			},
 			{
 				Name: "aws-bedrock-route",
@@ -55,24 +60,23 @@ func TestWithRealProviders(t *testing.T) {
 					{Name: "x-model-name", Value: "us.meta.llama3-2-1b-instruct-v1:0"},
 					{Name: "x-model-name", Value: "us.anthropic.claude-3-5-sonnet-20240620-v1:0"},
 				},
+				Backends: []filterapi.Backend{
+					{Name: "aws-bedrock", Schema: awsBedrockSchema, Auth: &filterapi.BackendAuth{AWSAuth: &filterapi.AWSAuth{
+						CredentialFileName: cc.AWSFilePath,
+						Region:             "us-east-1",
+					}}},
+				},
 			},
 			{
 				Name:    "azure-openai-route",
 				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "o1"}},
+				Backends: []filterapi.Backend{
+					{Name: "azure-openai", Schema: azureOpenAISchema, Auth: &filterapi.BackendAuth{
+						AzureAuth: &filterapi.AzureAuth{Filename: cc.AzureAccessTokenFilePath},
+					}},
+				},
 			},
 		},
-		Backends: append(fakeBackends, []*filterapi.Backend{
-			{Name: "openai", Schema: openAISchema, Auth: &filterapi.BackendAuth{
-				APIKey: &filterapi.APIKeyAuth{Filename: cc.OpenAIAPIKeyFilePath},
-			}},
-			{Name: "aws-bedrock", Schema: awsBedrockSchema, Auth: &filterapi.BackendAuth{AWSAuth: &filterapi.AWSAuth{
-				CredentialFileName: cc.AWSFilePath,
-				Region:             "us-east-1",
-			}}},
-			{Name: "azure-openai", Schema: azureOpenAISchema, Auth: &filterapi.BackendAuth{
-				AzureAuth: &filterapi.AzureAuth{Filename: cc.AzureAccessTokenFilePath},
-			}},
-		}...),
 	})
 
 	requireExtProc(t, os.Stdout, extProcExecutablePath(), configPath)

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -51,6 +51,9 @@ func TestWithTestUpstream(t *testing.T) {
 			{
 				Name:    "testupstream-openai-route",
 				Headers: []filterapi.HeaderMatch{{Name: "x-test-backend", Value: "openai"}},
+				Backends: []filterapi.Backend{
+					{Name: "testupstream-openai", Schema: openAISchema},
+				},
 			},
 			{
 				Name:    "testupstream-aws-route",
@@ -67,9 +70,9 @@ func TestWithTestUpstream(t *testing.T) {
 					{Name: "x-model-name", Value: "some-model2"},
 					{Name: "x-model-name", Value: "some-model3"},
 				},
+				Backends: fakeBackends,
 			},
 		},
-		Backends: fakeBackends,
 	})
 
 	expectedModels := openai.ModelList{


### PR DESCRIPTION
**Commit Message**

The backends and headers in filter config are M:N, with https://github.com/envoyproxy/ai-gateway/pull/599, we swapped out the backend from the config.rules, leading to the lost mapping relationship between them. With this PR, we'll move the backends back to the config.rules which is more straightforward.

**Related Issues/PRs (if applicable)**


Related PR: https://github.com/envoyproxy/ai-gateway/pull/620,  https://github.com/envoyproxy/ai-gateway/pull/599

**Special notes for reviewers (if applicable)**

None