### PR TITLE
test: adds additional logging for flake

### DIFF
--- a/tests/e2e/provider_fallback_test.go
+++ b/tests/e2e/provider_fallback_test.go
@@ -96,6 +96,7 @@ func Test_Examples_ProviderFallback(t *testing.T) {
 		defer resp.Body.Close()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
+		t.Logf("Response headers: %v", resp.Header)
 		t.Logf("Response body: %s", string(respBody))
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 			// This means that the fallback configuration is not working as expected.

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -62,6 +62,8 @@ func Test_Examples_TokenRateLimit(t *testing.T) {
 			require.Equal(t, int64(output), oaiBody.Usage.CompletionTokens)
 			require.Equal(t, int64(total), oaiBody.Usage.TotalTokens)
 		}
+		t.Logf("Response headers: %v", resp.Header)
+		t.Logf("Response body: %s", string(body))
 		require.Equal(t, expStatus, resp.StatusCode)
 	}
 


### PR DESCRIPTION
**Commit Message**

To debug the flake in e2e #647, this commit adds additional logging to help debug it especially because headers might contain the reason of the status code by Envoy