### PR TITLE
test: deflake e2e by forwarding to svc, not pod

### DIFF
--- a/examples/monitoring/monitoring.yaml
+++ b/examples/monitoring/monitoring.yaml
@@ -136,6 +136,8 @@ kind: Service
 metadata:
   name: prometheus
   namespace: monitoring
+  labels:
+    app: prometheus
 spec:
   selector:
     app: prometheus

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -72,7 +72,7 @@ func (tc examplesBasicTestCase) run(t *testing.T, egNamespace, egSelector string
 			t.Skip("skipped due to missing credentials")
 		}
 		require.Eventually(t, func() bool {
-			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultServicePort)
 			defer fwd.kill()
 
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	egDefaultVersion = "v1.4.0"
-	egNamespace      = "envoy-gateway-system"
-	egDefaultPort    = 10080
+	egDefaultVersion     = "v1.4.0"
+	egNamespace          = "envoy-gateway-system"
+	egDefaultServicePort = 80
 
 	kindClusterName = "envoy-ai-gateway"
 	kindLogDir      = "./logs"
@@ -339,10 +339,8 @@ func requireWaitForGatewayPodReady(t *testing.T, selector string) {
 }
 
 // requireNewHTTPPortForwarder creates a new port forwarder for the given namespace and selector.
-//
-// If gatewayPod is true, it will check and wait until the pod has the extproc container.
 func requireNewHTTPPortForwarder(t *testing.T, namespace string, selector string, port int) portForwarder {
-	f, err := newPodPortForwarder(t.Context(), namespace, selector, port)
+	f, err := newServicePortForwarder(t.Context(), namespace, selector, port)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		res, err := http.Get(f.address())
@@ -356,8 +354,8 @@ func requireNewHTTPPortForwarder(t *testing.T, namespace string, selector string
 	return f
 }
 
-// newPodPortForwarder creates a new local port forwarder for the namespace and selector.
-func newPodPortForwarder(ctx context.Context, namespace, selector string, podPort int) (f portForwarder, err error) {
+// newServicePortForwarder creates a new local port forwarder for the namespace and selector.
+func newServicePortForwarder(ctx context.Context, namespace, selector string, podPort int) (f portForwarder, err error) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return portForwarder{}, fmt.Errorf("failed to get a local available port for Pod %q: %w", selector, err)
@@ -368,7 +366,7 @@ func newPodPortForwarder(ctx context.Context, namespace, selector string, podPor
 	}
 	f.localPort = l.Addr().(*net.TCPAddr).Port
 
-	cmd := kubectl(ctx, "get", "pod", "-n", namespace,
+	cmd := kubectl(ctx, "get", "svc", "-n", namespace,
 		"--selector="+selector, "-o", "jsonpath='{.items[0].metadata.name}'")
 	cmd.Stdout = nil // To ensure that we can capture the output by Output().
 	out, err := cmd.Output()
@@ -378,7 +376,7 @@ func newPodPortForwarder(ctx context.Context, namespace, selector string, podPor
 	serviceName := string(out[1 : len(out)-1]) // Remove the quotes.
 
 	cmd = kubectl(ctx, "port-forward",
-		"-n", namespace, "pod/"+serviceName,
+		"-n", namespace, "svc/"+serviceName,
 		fmt.Sprintf("%d:%d", f.localPort, podPort),
 	)
 	if err := cmd.Start(); err != nil {

--- a/tests/e2e/provider_fallback_test.go
+++ b/tests/e2e/provider_fallback_test.go
@@ -54,7 +54,7 @@ func Test_Examples_ProviderFallback(t *testing.T) {
 	// So, no matter how many times we try, we should always get a 503 error.
 	for i := range 5 {
 		t.Run("no-fallback/"+strconv.Itoa(i), func(t *testing.T) {
-			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultServicePort)
 			defer fwd.kill()
 
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -82,7 +82,7 @@ func Test_Examples_ProviderFallback(t *testing.T) {
 	// At this point, the fallback configuration should be applied. So the request must be either
 	// successful or return a 401 error due to the secret key not being propagated yet.
 	require.Eventually(t, func() bool {
-		fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+		fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultServicePort)
 		defer fwd.kill()
 
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -108,7 +108,7 @@ func Test_Examples_ProviderFallback(t *testing.T) {
 	// Now we should be able to get a response from the fallback provider (AWS) without dropping any requests.
 	for i := range 5 {
 		t.Run("with-fallback/"+strconv.Itoa(i), func(t *testing.T) {
-			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+			fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultServicePort)
 			defer fwd.kill()
 
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -34,7 +34,7 @@ func Test_Examples_TokenRateLimit(t *testing.T) {
 
 	const modelName = "rate-limit-funky-model"
 	makeRequest := func(usedID string, input, output, total int, expStatus int) {
-		fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+		fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultServicePort)
 		defer fwd.kill()
 
 		requestBody := fmt.Sprintf(`{"messages":[{"role":"user","content":"Say this is a test"}],"model":"%s"}`, modelName)

--- a/tests/e2e/translation_testupstream_test.go
+++ b/tests/e2e/translation_testupstream_test.go
@@ -56,7 +56,7 @@ func TestTranslationWithTestUpstream(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				require.Eventually(t, func() bool {
-					fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultPort)
+					fwd := requireNewHTTPPortForwarder(t, egNamespace, egSelector, egDefaultServicePort)
 					defer fwd.kill()
 
 					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)


### PR DESCRIPTION
**Commit Message**

Previously, the pod was the target for port-forwarding. However, that can be fragile since the pod may be rolled out even after the gateway itself becomes healthy after the side car injection. This will deflake the tests by using the service as a target which allows us to avoid choosing the pod that is in the middle of termination/rollout.

**Related Issues/PRs (if applicable)**

Closes #647 