### PR TITLE
ci: removes unnecessary line in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,5 @@ jobs:
         if: ${{ !contains(github.ref, '-rc') }}
         run: |
           gh release create $TAG --draft --title $TAG --notes "To be written by the release manager" ./out/ai-gateway-crds-helm-${TAG}.tgz ./out/ai-gateway-helm-${TAG}.tgz
-          gh release upload $TAG ./out/ai-gateway-crds-helm-${TAG}.tgz ./out/ai-gateway-helm-${TAG}.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Commit Message**

This removes the redundant upload in release.yaml which resulted in uploading the same artifacts twice. 
The CI failed in https://github.com/envoyproxy/ai-gateway/actions/runs/15404045295/job/43343173369
while we can see the artifacts already uploaded correctly at `gh release create`.

**Related Issues/PRs (if applicable)**

Follow up on #513 