### PR TITLE
extproc: hotfix for gzip header

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -271,8 +271,8 @@ func (c *chatCompletionProcessorUpstreamFilter) ProcessResponseBody(ctx context.
 		c.metrics.RecordRequestCompletion(ctx, err == nil)
 	}()
 	var br io.Reader
-	switch c.responseEncoding {
 	var removeHeaders []string
+	switch c.responseEncoding {
 	case "gzip":
 		br, err = gzip.NewReader(bytes.NewReader(body.Body))
 		if err != nil {

--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -272,11 +272,15 @@ func (c *chatCompletionProcessorUpstreamFilter) ProcessResponseBody(ctx context.
 	}()
 	var br io.Reader
 	switch c.responseEncoding {
+	var removeHeaders []string
 	case "gzip":
 		br, err = gzip.NewReader(bytes.NewReader(body.Body))
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode gzip: %w", err)
 		}
+		// TODO: this is a hotfix, we should update this to recompress since its in the header
+		// If the response was gzipped, ensure we remove the content-encoding header
+		removeHeaders = append(removeHeaders, "content-encoding")
 	default:
 		br = bytes.NewReader(body.Body)
 	}
@@ -285,6 +289,10 @@ func (c *chatCompletionProcessorUpstreamFilter) ProcessResponseBody(ctx context.
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform response: %w", err)
 	}
+	if headerMutation == nil {
+		headerMutation = &extprocv3.HeaderMutation{}
+	}
+	headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, removeHeaders...)
 
 	resp := &extprocv3.ProcessingResponse{
 		Response: &extprocv3.ProcessingResponse_ResponseBody{


### PR DESCRIPTION
**Commit Message**

This is a hotfix for a bug where if the gzip header is present, we decompress and leave the header. This results in the client throwing an error trying to decompress based on the header, but it has already been decompressed. This hot fix removes the header. In the future we probably want to return it compressed with the header intact. 

for example - the error I encountered was ```io.netty.handler.codec.compression.DecompressionException: Input is not in the GZIP format```

Co-authored-by: Sukumar Gaonkar <sgaonkar4@bloomberg.net>

