### PR TITLE
backport: do not sign content-length for AWS (#694)

### DIFF
--- a/internal/extproc/backendauth/aws.go
+++ b/internal/extproc/backendauth/aws.go
@@ -106,6 +106,14 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, h
 	if err != nil {
 		return fmt.Errorf("cannot create request: %w", err)
 	}
+	// By setting the content length to -1, we can avoid the inclusion of the `Content-Length` header in the signature.
+	// https://github.com/aws/aws-sdk-go-v2/blob/755839b2eebb246c7eec79b65404aee105196d5b/aws/signer/v4/v4.go#L427-L431
+	//
+	// The reason why we want to avoid this is that the ExtProc filter will remove the content-length header
+	// from the request currently. Envoy will instead do "transfer-encoding: chunked" for the request body,
+	// which should be acceptable for AWS Bedrock or any modern HTTP service.
+	// https://github.com/envoyproxy/envoy/blob/60b2b5187cf99db79ecfc54675354997af4765ea/source/extensions/filters/http/ext_proc/processor_state.cc#L180-L183
+	req.ContentLength = -1
 
 	err = a.signer.SignHTTP(ctx, a.credentials, req,
 		hex.EncodeToString(payloadHash[:]), "bedrock", a.region, time.Now())


### PR DESCRIPTION
**Commit Message**

Previously, AWS signing has included the "content-length" header. However, Envoy's extproc filter strips it from the request as we are using CONTINUE_AND_REPLACE option to reduce the memory overhead. While we have still no clue as to why AWS doesn't complain when the request body is small, excluding content-length from the signing target headers will make the tests with both small and large bodies pass.

**Related Issues/PRs (if applicable)**

CONTINUE_AND_REPLACE was introduced in #636 to avoid sending a request body twice between Envoy and the ExtProc.

