### PR TITLE
cli: add default admin port

### DIFF
--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -60,6 +60,14 @@ spec:
   logging:
     level:
       default: error
+  bootstrap:
+    jsonPatches:
+      - op: replace
+        path: /admin/address/socket_address/address
+        value: "127.0.0.1"
+      - op: replace
+        path: /admin/address/socket_address/port_value
+        value: 9901
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute

--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -61,13 +61,13 @@ spec:
     level:
       default: error
   bootstrap:
-    jsonPatches:
-      - op: replace
-        path: /admin/address/socket_address/address
-        value: "127.0.0.1"
-      - op: replace
-        path: /admin/address/socket_address/port_value
-        value: 9901
+    type: Merge
+    value: |-
+      admin:
+        address:
+          socket_address:
+            address: 127.0.0.1
+            port_value: 9901
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -55,6 +55,29 @@ func TestRun(t *testing.T) {
 		<-done
 	}()
 
+	// This is the health checking to see the envoy admin is working as expected.
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:9901/ready",
+			strings.NewReader(""))
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Logf("error: %v", err)
+			return false
+		}
+		defer func() {
+			require.NoError(t, resp.Body.Close())
+		}()
+		raw, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		body := string(raw)
+		t.Logf("status=%d, response: %s", resp.StatusCode, body)
+		if resp.StatusCode != http.StatusOK && body != "live" {
+			return false
+		}
+		return true
+	}, 120*time.Second, 1*time.Second)
+
 	// This is the health checking to see the extproc is working as expected.
 	require.Eventually(t, func() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost:1975/v1/chat/completions",


### PR DESCRIPTION
**Description**

Add default admin port for CLI, users can edit by following the example config.

**Related Issues/PRs (if applicable)**

Fixes #686

**Special notes for reviewers (if applicable)**

