### PR TITLE
cli: use fixed prometheus port with aigw run

### DIFF
--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -279,7 +279,6 @@ func (runCtx *runCmdContext) mustStartExtProc(
 	args := []string{
 		"--configPath", configPath,
 		"--extProcAddr", fmt.Sprintf("unix://%s", runCtx.udsPath),
-		"--metricsPort", fmt.Sprintf("%d", mustGetAvailablePort()),
 	}
 	if runCtx.isDebug {
 		args = append(args, "--logLevel", "debug")
@@ -291,20 +290,6 @@ func (runCtx *runCmdContext) mustStartExtProc(
 			runCtx.stderrLogger.Error("Failed to run external processor", "error", err)
 		}
 	}()
-}
-
-// This function panics if it fails to find an available port. This should not happen in practice.
-func mustGetAvailablePort() int32 {
-	l, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		panic(fmt.Errorf("failed to lookup an available local port: %w", err))
-	}
-	port := l.Addr().(*net.TCPAddr).Port
-	err = l.Close()
-	if err != nil {
-		panic(fmt.Errorf("failed to close listener: %w", err))
-	}
-	return int32(port) // nolint:gosec
 }
 
 // mustClearSetOwnerReferencesAndStatusAndWriteObj clears the owner references and status of the given object, marshals it

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -132,6 +132,7 @@ func TestRun(t *testing.T) {
 			}
 			defer func() { _ = resp.Body.Close() }()
 			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
 			t.Logf("Response: status=%d, body=%s", resp.StatusCode, string(body))
 			return resp.StatusCode == http.StatusOK
 		}, 2*time.Minute, 1*time.Second)

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -8,12 +8,9 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,8 +123,7 @@ func TestRun(t *testing.T) {
 
 	t.Run("access metrics", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			const query = `sum(gen_ai_client_token_usage_sum{gateway_envoyproxy_io_owning_gateway_name = "envoy-ai-gateway-token-ratelimit"}) by (gen_ai_request_model, gen_ai_token_type)`
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:1064/api/v1/query?query=%s", url.QueryEscape(query)), nil)
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:1064/metrics", nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
@@ -137,24 +133,7 @@ func TestRun(t *testing.T) {
 			defer func() { _ = resp.Body.Close() }()
 			body, err := io.ReadAll(resp.Body)
 			t.Logf("Response: status=%d, body=%s", resp.StatusCode, string(body))
-			if resp.StatusCode != http.StatusOK {
-				t.Logf("Failed to query Prometheus: status=%s", resp.Status)
-				return false
-			}
-			type prometheusResponse struct {
-				Status string `json:"status"`
-				Data   struct {
-					ResultType string `json:"resultType"`
-					Result     []struct {
-						Metric map[string]string `json:"metric"`
-						Value  []interface{}     `json:"value"`
-					}
-				}
-			}
-			var pr prometheusResponse
-			require.NoError(t, json.Unmarshal(body, &pr))
-			t.Log(pr.Status)
-			return true
+			return resp.StatusCode == http.StatusOK
 		}, 2*time.Minute, 1*time.Second)
 	})
 }

--- a/site/docs/cli/run.md
+++ b/site/docs/cli/run.md
@@ -12,6 +12,10 @@ This command runs the Envoy AI Gateway locally as a standalone proxy with a give
 Since the project is primarily focused on the Kubernetes environment, this command is useful for testing the configuration locally before deploying it to a Kubernetes cluster.
 Not only does it help in testing the configuration, but it is also useful in a local development environment of the provider-agnostic AI applications.
 
+:::warning
+Currently, `aigw run` only properly works on Linux. macOS support is pending due to the Envoy v1.34+ binary not available for macOS yet. That will be resolved with https://github.com/Homebrew/homebrew-core/pull/223051.
+:::
+
 ## Default Proxy
 
 By default, `aigw run` runs the AI Gateway with a default configuration that includes a proxy that listens on port `1975`.
@@ -106,3 +110,7 @@ Now, the AI Gateway is running locally with the custom configuration serving at 
 curl -H "Content-Type: application/json" -XPOST http://localhost:1975/v1/chat/completions \
     -d '{"model": "deepseek-r1:1.5b","messages": [{"role": "user", "content": "Say this is a test!"}]}'
 ```
+
+### Note
+
+* The ExtProc will serve the prometheus metrics at `localhost:1064` by default where you can scrape the [metrics](../capabilities/metrics.md).

--- a/site/docs/cli/run.md
+++ b/site/docs/cli/run.md
@@ -113,4 +113,4 @@ curl -H "Content-Type: application/json" -XPOST http://localhost:1975/v1/chat/co
 
 ### Note
 
-* The ExtProc will serve the prometheus metrics at `localhost:1064` by default where you can scrape the [metrics](../capabilities/metrics.md).
+* The ExtProc will serve the prometheus metrics at `localhost:1064/metrics` by default where you can scrape the [LLM/AI metrics](../capabilities/metrics.md).


### PR DESCRIPTION
**Commit Message**

Previously, the prometheus metrics port was chosen randomly, hence it was impossible to scrape metrics when using `aigw run` command. This fixes it by using the default port 1064 used by the extproc. Note that there won't be a conflict as `aigw run` doesn't support multiple gateways.
