### PR TITLE
extproc: cleans up <v1.34 specific code path

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: v1.34
+          - name: v1.34  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
             envoy_version: envoyproxy/envoy:v1.34-latest
           - name: latest
             envoy_version: envoyproxy/envoy-dev:latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ For example,
 * The latest `kubectl` binary for running `make test-e2e`.
   * See: https://kubernetes.io/docs/tasks/tools/
 * The latest `envoy` binary for running `make test-extproc`.
-  * On Linux, you can download the latest Envoy binary as described in https://www.envoyproxy.io/docs/envoy/latest/start/install. 
+  * On Linux, you can download the latest Envoy binary as described in https://www.envoyproxy.io/docs/envoy/latest/start/install.
     Alternatively, you can use `func-e` on Linux as well like on macOS below.
   * On macOS, since `brew envoy` tends to behind the latest version, it is recommended use `func-e` to run the latest Envoy. See https://func-e.io/.
   * `alias envoy='func-e run'` is a convenient way to run the latest Envoy binary via `func-e` on both macOS and Linux.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,11 @@ For example,
 * The latest `kubectl` binary for running `make test-e2e`.
   * See: https://kubernetes.io/docs/tasks/tools/
 * The latest `envoy` binary for running `make test-extproc`.
-  * See: https://www.envoyproxy.io/docs/envoy/latest/start/install
+  * On Linux, you can download the latest Envoy binary as described in https://www.envoyproxy.io/docs/envoy/latest/start/install. 
+    Alternatively, you can use `func-e` on Linux as well like on macOS below.
+  * On macOS, since `brew envoy` tends to behind the latest version, it is recommended use `func-e` to run the latest Envoy. See https://func-e.io/.
+  * `alias envoy='func-e run'` is a convenient way to run the latest Envoy binary via `func-e` on both macOS and Linux.
+    For example, `func-e use 1.34` can be used to switch to a specific version of Envoy to be run with `func-e run`.
 
 Other than that, everything will be automatically managed and installed via `make` targets,
 and you should not need to worry about the dependencies (tell us if you do).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ For example,
 
 * The latest `kubectl` binary for running `make test-e2e`.
   * See: https://kubernetes.io/docs/tasks/tools/
-* The latest `envoy` binary for running `make test-extproc`.
+* The latest `envoy` binary for running `make test-extproc`. The current required version is v1.34 or later.
   * On Linux, you can download the latest Envoy binary as described in https://www.envoyproxy.io/docs/envoy/latest/start/install.
     Alternatively, you can use `func-e` on Linux as well like on macOS below.
   * On macOS, since `brew envoy` tends to behind the latest version, it is recommended use `func-e` to run the latest Envoy. See https://func-e.io/.

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -211,20 +210,9 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 				return status.Error(codes.NotFound, err.Error())
 			}
 			if isUpstreamFilter {
-				var resp *extprocv3.ProcessingResponse
-				resp, err = s.setBackend(ctx, p, reqID, req)
-				if err != nil {
+				if err = s.setBackend(ctx, p, reqID, req); err != nil {
 					s.logger.Error("error processing request message", slog.String("error", err.Error()))
 					return status.Errorf(codes.Unknown, "error processing request message: %v", err)
-				}
-				if resp != nil { // coverage-ignore
-					// This only happens runtime.GOOS == "darwin" when the attributes are not set.
-					if err = stream.Send(resp); err != nil {
-						s.logger.Error("cannot send response", slog.String("error", err.Error()))
-						return status.Errorf(codes.Unknown, "cannot send response: %v", err)
-					}
-					p = passThroughProcessor{}
-					continue
 				}
 			} else {
 				s.routerProcessorsPerReqIDMutex.Lock()
@@ -301,31 +289,16 @@ func (s *Server) processMsg(ctx context.Context, l *slog.Logger, p Processor, re
 
 // setBackend retrieves the backend from the request attributes and sets it in the processor. This is only called
 // if the processor is an upstream filter.
-func (s *Server) setBackend(ctx context.Context, p Processor, reqID string, req *extprocv3.ProcessingRequest) (*extprocv3.ProcessingResponse, error) {
+func (s *Server) setBackend(ctx context.Context, p Processor, reqID string, req *extprocv3.ProcessingRequest) error {
 	attributes := req.GetAttributes()["envoy.filters.http.ext_proc"]
 	if attributes == nil || len(attributes.Fields) == 0 { // coverage-ignore
-		if runtime.GOOS == "darwin" {
-			// TODO: this feels like a bug of Envoy v1.33 or earlier, not the darwin specific code.
-			//
-			// For some reason that I _suspect_ stems from macOS specific event loop peculiarities,
-			// the first request to a specific endpoint may not have the attributes set. Assuming
-			// the retry is configured, we simply do nothing and let the retry happen.
-			return &extprocv3.ProcessingResponse{
-				Response: &extprocv3.ProcessingResponse_RequestHeaders{
-					RequestHeaders: &extprocv3.HeadersResponse{
-						Response: &extprocv3.CommonResponse{},
-					},
-				},
-			}, nil
-		}
-		// Otherwise, this is a bug of either Envoy or control plane.
-		return nil, status.Error(codes.Internal, "missing attributes in request")
+		return status.Error(codes.Internal, "missing attributes in request")
 	}
 
 	// This should contain the endpoint metadata.
 	hostMetadata, ok := attributes.Fields["xds.upstream_host_metadata"]
 	if !ok {
-		return nil, status.Error(codes.Internal, "missing xds.upstream_host_metadata in request")
+		return status.Error(codes.Internal, "missing xds.upstream_host_metadata in request")
 	}
 
 	// Unmarshal the text into the struct since the metadata is encoded as a proto string.
@@ -337,29 +310,29 @@ func (s *Server) setBackend(ctx context.Context, p Processor, reqID string, req 
 
 	aiGatewayEndpointMetadata, ok := metadata.FilterMetadata["aigateway.envoy.io"]
 	if !ok {
-		return nil, status.Error(codes.Internal, "missing aigateway.envoy.io metadata")
+		return status.Error(codes.Internal, "missing aigateway.envoy.io metadata")
 	}
 	backendName, ok := aiGatewayEndpointMetadata.Fields["backend_name"]
 	if !ok {
-		return nil, status.Error(codes.Internal, "missing backend_name in endpoint metadata")
+		return status.Error(codes.Internal, "missing backend_name in endpoint metadata")
 	}
 	backend, ok := s.config.backends[backendName.GetStringValue()]
 	if !ok {
-		return nil, status.Errorf(codes.Internal, "unknown backend: %s", backendName.GetStringValue())
+		return status.Errorf(codes.Internal, "unknown backend: %s", backendName.GetStringValue())
 	}
 
 	s.routerProcessorsPerReqIDMutex.RLock()
 	defer s.routerProcessorsPerReqIDMutex.RUnlock()
 	routerProcessor, ok := s.routerProcessorsPerReqID[reqID]
 	if !ok {
-		return nil, status.Errorf(codes.Internal, "no router processor found, request_id=%s, backend=%s",
+		return status.Errorf(codes.Internal, "no router processor found, request_id=%s, backend=%s",
 			reqID, backendName.GetStringValue())
 	}
 
 	if err := p.SetBackend(ctx, backend.b, backend.handler, routerProcessor); err != nil {
-		return nil, status.Errorf(codes.Internal, "cannot set backend: %v", err)
+		return status.Errorf(codes.Internal, "cannot set backend: %v", err)
 	}
-	return nil, nil
+	return nil
 }
 
 // Check implements [grpc_health_v1.HealthServer].

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -345,7 +345,7 @@ func TestServer_setBackend(t *testing.T) {
 			require.NoError(t, err)
 			s, _ := requireNewServerWithMockProcessor(t)
 			s.config.backends = map[string]*processorConfigBackend{"openai": {}}
-			_, err = s.setBackend(t.Context(), nil, "aaaaaaaaaaaa", &extprocv3.ProcessingRequest{
+			err = s.setBackend(t.Context(), nil, "aaaaaaaaaaaa", &extprocv3.ProcessingRequest{
 				Attributes: map[string]*structpb.Struct{
 					"envoy.filters.http.ext_proc": {Fields: map[string]*structpb.Value{
 						"xds.upstream_host_metadata": {Kind: &structpb.Value_StringValue{StringValue: string(str)}},


### PR DESCRIPTION
**Commit Message**

Until today, macOS binary for Envoy v1.34 was not existent out there, hence there was a workaround codepath for the development purpose. Now, the binary is available with func-e, more precisely hosted via archive-envoy[1] project, it is safe to delete the workaround code.

[1] https://archive.tetratelabs.io/envoy/envoy-versions.json