### PR TITLE
ci: run unit tests on macos

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -54,7 +54,7 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
             ~/go/bin
-          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}-${{ matrix.platform.arch }}
+          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}-${{ matrix.os }}
       - env:
           TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
           TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,8 +126,7 @@ jobs:
       - name: Install stable Envoy via func-e
         if: matrix.version != 'latest'
         run: |
-          go install github.com/tetratelabs/func-e@6a0f4e4780761107295d186eb434823d69a61897
-          func-e use ${{ matrix.version }}
+          go tool func-e use ${{ matrix.version }}
           echo $HOME/.func-e/versions/${{ matrix.version }}/bin >> $GITHUB_PATH
       - name: Install latest Envoy
         if: matrix.version == 'latest'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -128,7 +128,7 @@ jobs:
         run: |
           go install github.com/tetratelabs/func-e@6a0f4e4780761107295d186eb434823d69a61897
           func-e use ${{ matrix.version }}
-          echo $HOME/.func-e/versions/${{ matrix.envoy_version }}/bin >> $GITHUB_PATH
+          echo $HOME/.func-e/versions/${{ matrix.version }}/bin >> $GITHUB_PATH
       - name: Install latest Envoy
         if: matrix.version == 'latest'
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,8 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-latest
-        - macos-latest
+          - ubuntu-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -103,19 +103,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: v1.34  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
-            envoy_version: envoyproxy/envoy:v1.34-latest
-          - name: latest
-            envoy_version: envoyproxy/envoy-dev:latest
-    runs-on: ubuntu-latest
+          - version: v1.34  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
+            os: ubuntu-latest
+          - version: v1.34  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
+            os: macos-latest
+          - version: latest
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-        if: github.event_name == 'pull_request_target'
       - uses: actions/setup-go@v5
         with:
           cache: false
@@ -127,7 +123,14 @@ jobs:
             ~/go/pkg/mod
             ~/go/bin
           key: extproc-tests-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
-      - name: Install Envoy
+      - name: Install stable Envoy via func-e
+        if: matrix.version != 'latest'
+        run: |
+          go install github.com/tetratelabs/func-e@6a0f4e4780761107295d186eb434823d69a61897
+          func-e use ${{ matrix.version }}
+          echo $HOME/.func-e/versions/${{ matrix.envoy_version }}/bin >> $GITHUB_PATH
+      - name: Install latest Envoy
+        if: matrix.version == 'latest'
         run: |
           export ENVOY_BIN_DIR=$HOME/envoy/bin
           mkdir -p $ENVOY_BIN_DIR
@@ -155,12 +158,6 @@ jobs:
             envoy_gateway_version: 1.4.0
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-        if: github.event_name == 'pull_request_target'
       - uses: actions/setup-go@v5
         with:
           cache: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,13 @@ permissions:
 jobs:
   unittest:
     name: Unit Test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -48,7 +54,7 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
             ~/go/bin
-          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}
+          key: unittest-${{ hashFiles('**/go.mod', '**/go.sum', '**/Makefile') }}-${{ matrix.platform.arch }}
       - env:
           TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}
           TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,14 +98,14 @@ jobs:
       - run: make test-controller
 
   test_extproc:
-    name: External Processor Test (Envoy ${{ matrix.name }})
+    name: External Processor Test (Envoy v${{ matrix.version }} on ${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - version: v1.34  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
+          - version: 1.34.1  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
             os: ubuntu-latest
-          - version: v1.34  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
+          - version: 1.34.1  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
             os: macos-latest
           - version: latest
             os: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Note: we cannot run the latest Envoy version on macOS due to https://github.com/tetratelabs/archive-envoy/issues/12.
+        # Once it's supported, the following "binary installation" steps below can be just removed and
+        # we can simply exec.Cmd with "go tool func-e run" with the envoy version configured via ENVOY_VERSION env var.
         include:
           - version: 1.34.1  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
             os: ubuntu-latest
@@ -134,7 +137,7 @@ jobs:
           export ENVOY_BIN_DIR=$HOME/envoy/bin
           mkdir -p $ENVOY_BIN_DIR
           docker run -v $ENVOY_BIN_DIR:/tmp/ci -w /tmp/ci \
-          --entrypoint /bin/cp ${{ matrix.envoy_version }} /usr/local/bin/envoy .
+          --entrypoint /bin/cp envoyproxy/envoy-dev:latest /usr/local/bin/envoy .
           echo $ENVOY_BIN_DIR >> $GITHUB_PATH
       - env:
           TEST_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BEDROCK_USER_AWS_ACCESS_KEY_ID }}

--- a/go.mod
+++ b/go.mod
@@ -459,6 +459,7 @@ tool (
 	github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker
 	github.com/elastic/crd-ref-docs
 	github.com/golangci/golangci-lint/cmd/golangci-lint
+	github.com/tetratelabs/func-e
 	github.com/vladopajic/go-test-coverage/v2
 	helm.sh/helm/v3/cmd/helm
 	mvdan.cc/gofumpt

--- a/go.mod
+++ b/go.mod
@@ -357,7 +357,7 @@ require (
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/telepresenceio/watchable v0.0.0-20220726211108-9bb86f92afa7 // indirect
 	github.com/tetafro/godot v1.5.0 // indirect
-	github.com/tetratelabs/func-e v1.1.5-0.20250320201954-b46a029a6395 // indirect
+	github.com/tetratelabs/func-e v1.1.5-0.20250618051429-6a0f4e478076 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1128,8 +1128,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.5.0 h1:aNwfVI4I3+gdxjMgYPus9eHmoBeJIbnajOyqZYStzuw=
 github.com/tetafro/godot v1.5.0/go.mod h1:2oVxTBSftRTh4+MVfUaUXR6bn2GDXCaMcOG4Dk3rfio=
-github.com/tetratelabs/func-e v1.1.5-0.20250320201954-b46a029a6395 h1:7EHa+viJhUCb5VnvtxYZ8ZFjZGJrfpKFqAsBGTj9bGA=
-github.com/tetratelabs/func-e v1.1.5-0.20250320201954-b46a029a6395/go.mod h1:FDAoUIMZc6Jkc0oEsbd2aTWRQhWDVrKhKy+yAdMfZbg=
+github.com/tetratelabs/func-e v1.1.5-0.20250618051429-6a0f4e478076 h1:WhWdSJ8QinLKWKgr3aE4veeR+Mg0Qu+3LfD9oTyA9CM=
+github.com/tetratelabs/func-e v1.1.5-0.20250618051429-6a0f4e478076/go.mod h1:FDAoUIMZc6Jkc0oEsbd2aTWRQhWDVrKhKy+yAdMfZbg=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
**Commit Message**

Previously, we haven't run macOS CI since it was a de-facto platform for some maintainers hence it was virtually manually continuously tested. However, we are looking to provide more seamless experience for aigw CLI, it makes sense for us to do the automation of tests on macOS. 

Note that this only enables unit tests and extproc integration test job. The e2e as well as CEL validation tests are not feasible as the nested virtualization is not supported on GHA. 