### PR TITLE
extproc: reverts the use of REPLACE_AND_CONTINUE

### DIFF
--- a/internal/extensionserver/extensionserver.go
+++ b/internal/extensionserver/extensionserver.go
@@ -242,9 +242,7 @@ func (s *Server) maybeModifyCluster(cluster *clusterv3.Cluster) {
 	extProcConfig.RequestAttributes = []string{"xds.upstream_host_metadata"}
 	extProcConfig.ProcessingMode = &extprocv3http.ProcessingMode{
 		RequestHeaderMode: extprocv3http.ProcessingMode_SEND,
-		// At the upstream filter, it can access the original body in its memory, so it can perform the translation
-		// as well as the authentication at the request headers. Hence, there's no need to send the request body to the extproc.
-		RequestBodyMode: extprocv3http.ProcessingMode_NONE,
+		RequestBodyMode:   extprocv3http.ProcessingMode_BUFFERED,
 		// Response will be handled at the router filter level so that we could avoid the shenanigans around the retry+the upstream filter.
 		ResponseHeaderMode: extprocv3http.ProcessingMode_SKIP,
 		ResponseBodyMode:   extprocv3http.ProcessingMode_NONE,

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -189,7 +189,7 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
@@ -234,12 +234,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
@@ -279,12 +283,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
@@ -324,12 +332,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
@@ -380,12 +392,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
@@ -442,12 +458,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
@@ -504,12 +524,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
@@ -574,12 +598,16 @@ static_resources:
                   - xds.upstream_host_metadata
                 processing_mode:
                   request_header_mode: "SEND"
-                  request_body_mode: "NONE"
+                  request_body_mode: "BUFFERED"
                   response_header_mode: "SKIP"
                   response_body_mode: "NONE"
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extproc_cluster
+                metadataOptions:
+                  forwardingNamespaces:
+                    untyped:
+                      - ai_gateway_llm_ns
             - name: envoy.filters.http.upstream_codec
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec


### PR DESCRIPTION
**Commit Message**

This tries to revert 65ca02a4d9568ec588a0f7be38424aa20e702350.  That was introduced to avoid sending request bodies twice to the extrpco. However, the current implementation of extproc will ALWAYS remove content-length header hence result in forcing the chunked transfer-encoding. That causes some issue with some AI providers as described in #721 for example.

**Related Issues/PRs (if applicable)**

Reverts https://github.com/envoyproxy/ai-gateway/pull/636
Fixes #721 
