### PR TITLE
chore: update k8s versions used in envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ test-coverage: ## Run the unit tests for the codebase with coverage check.
 	@$(MAKE) test GO_TEST_ARGS="-coverprofile=$(OUTPUT_DIR)/go-test-coverage.out -covermode=atomic -coverpkg=github.com/envoyproxy/ai-gateway/... $(GO_TEST_ARGS)"
 	@go tool go-test-coverage --config=.testcoverage.yml
 
-ENVTEST_K8S_VERSIONS ?= 1.29.0 1.30.0 1.31.0
+ENVTEST_K8S_VERSIONS ?= 1.31.0 1.32.0 1.33.0
 
 # This runs the integration tests of CEL validation rules in CRD definitions.
 #

--- a/tests/internal/envtest.go
+++ b/tests/internal/envtest.go
@@ -24,7 +24,7 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/controller"
 )
 
-const defaultK8sVersion = "1.31.0"
+const defaultK8sVersion = "1.33.0"
 
 // NewEnvTest creates a new environment for testing the controller package.
 func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.Interface) {


### PR DESCRIPTION
**Description**

This commit updates the k8s versions used for CEL validation tests as well as the controller tests with envtest.
