### PR TITLE
ci: add codeql workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -26,9 +26,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language:
-        - go
 
     steps:
     - name: Checkout repository
@@ -43,7 +40,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
       with:
-        languages: ${{ matrix.language }}
+        languages: go
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
@@ -51,4 +48,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:go"


### PR DESCRIPTION
**Description**

This adds the codeql action, against a repository's source code to find security vulnerabilities. It automatically uploads the results to GitHub so they can be displayed on pull requests and in the repository's security tab. 

