### PR TITLE
ci: add retest action

### DIFF
--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -1,0 +1,27 @@
+name: Retest Action on PR Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  retest:
+    if: |
+      ${{
+         github.event.issue.pull_request
+         && github.repository == 'envoyproxy/gateway'
+         && github.actor != 'repokitteh-read-only[bot]'
+         && github.actor != 'dependabot[bot]'
+      }}
+    name: Retest
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: envoyproxy/toolshed/gh-actions/retest@effeefe9b275dc8056f77c0e7b1010c252167d3e  # actions-v0.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -12,7 +12,7 @@ jobs:
     if: |
       ${{
          github.event.issue.pull_request
-         && github.repository == 'envoyproxy/gateway'
+         && github.repository == 'envoyproxy/ai-gateway'
          && github.actor != 'repokitteh-read-only[bot]'
          && github.actor != 'dependabot[bot]'
       }}


### PR DESCRIPTION
**Commit Message**

This adds the `retest` action to workflow, we use that in eg repo, this is quite useful for contributors to run /retest in PR if action failed (for flaky issues)