### PR TITLE
ci: add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,6 @@ jobs:
       uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # Different amounts of days for issues/PRs are not currently supported but there is a PR
-        # open for it: https://github.com/actions/stale/issues/214
         days-before-stale: 30
         days-before-close: -1
         stale-issue-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 */4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  prune_stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    name: Prune Stale
+    runs-on: ubuntu-22.04
+    # do not run it in forked repos
+    if: github.repository == 'envoyproxy/ai-gateway'
+
+    steps:
+    - name: Prune Stale
+      uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Different amounts of days for issues/PRs are not currently supported but there is a PR
+        # open for it: https://github.com/actions/stale/issues/214
+        days-before-stale: 30
+        days-before-close: -1
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had activity in the
+          last 30 days.
+        stale-pr-message: >
+          This pull request has been automatically marked as stale because it has not had
+          activity in the last 30 days.
+          Please feel free to give a status update now, ping for review, when it's ready.
+          Thank you for your contributions!
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'no stalebot,help wanted'
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'no stalebot'
+        operations-per-run: 500
+        ascending: true


### PR DESCRIPTION
**Commit Message**

This adds the stale workflow to detect the issues/PRs which are inactivated.

We usually use it as a reminder for both maintainer and contributors, not a action to directly close the PR/issues. So we only enable the `days-before-stale` and disable `days-before-close`.