### PR TITLE
chore: clean up the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 **Description**
 
 <!--
-Please write the description here, which typically talks about the description / what this PR does / why we need it.
+Please provide a clear and concise summary of what this PR changes and why these changes are needed here.
 After the PR is merged, the message here will be included in the commit message after the PR title (which is in the format of "<tag>: add foo for bar").
 
 Example:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-**Commit Message**
+**Description**
 
 <!--
-Please write the commit message here, which typically talks about the description / what this PR does / why we need it.
-After the PR is merged, the message here will be included after the PR title (which is in the format of "<tag>: add foo for bar").
+Please write the description here, which typically talks about the description / what this PR does / why we need it.
+After the PR is merged, the message here will be included in the commit message after the PR title (which is in the format of "<tag>: add foo for bar").
 
 Example:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 **Commit Message**
 
 <!--
-Please write the commit message here, which
-typically talks about the description / what this commit does / why we need it
+Please write the commit message here, which typically talks about the description / what this PR does / why we need it.
+After the PR is merged, the message here will be included after the PR title (which is in the format of "<tag>: add foo for bar").
 
 Example:
 
@@ -32,27 +32,4 @@ Example:
 The changes in this PR are not yet complete. I am still working on the
 controller part of this feature, but I wanted to get feedback on the
 filter part first.
--->
-
-
-<!--
-⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
-Please make sure that at least `make precommit test` passes before submitting the PR as ready for review.
-If there's anything you're unsure about, please ensure the PR is marked as a draft. For example,
-draft PRs would be ideal for discussing the approach to a problem or the design of a feature.
-
-Also, please make sure that you can check off all the items on the checklist below.
-
-Otherwise, you might unnecessarily consume the time of the maintainers unless there's
-a specific reason for not doing so.
-
-**Checklist** (you don't need to keep in your PR description):
-- [ ] The PR title follows the same format as the merged PRs.
-- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) (for first-time contributors).
-- [ ] I have made sure that `make precommit test` passes locally.
-- [ ] I have written tests for any new line of code unless there's existing tests that cover the changes.
-- [ ] I have updated the documentation accordingly.
-- [ ] I am sure the coding style is consistent with the rest of the codebase.
-
-⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
 -->


### PR DESCRIPTION
**Commit Message**

This cleans up the PR template so that it explicitly says how the title as well as the description is used in the finale commit.
