### PR TITLE
extproc: pass model name override as part of dynamic metadata

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -29,6 +29,10 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
 )
 
+const (
+	ModelNameOverride = "model_name_override"
+)
+
 // ChatCompletionProcessorFactory returns a factory method to instantiate the chat completion processor.
 func ChatCompletionProcessorFactory(ccm x.ChatCompletionMetrics) ProcessorFactory {
 	return func(config *processorConfig, requestHeaders map[string]string, logger *slog.Logger, isUpstreamFilter bool) (Processor, error) {
@@ -397,6 +401,11 @@ func (c *chatCompletionProcessorUpstreamFilter) maybeBuildDynamicMetadata() (*st
 		c.logger.Info("Setting request cost metadata", "type", rc.Type, "cost", cost, "metadataKey", rc.MetadataKey)
 		metadata[rc.MetadataKey] = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(cost)}}
 	}
+
+	if c.modelNameOverride != "" {
+		metadata[ModelNameOverride] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: c.modelNameOverride}}
+	}
+
 	if len(metadata) == 0 {
 		return nil, nil
 	}

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -278,10 +278,15 @@ func Test_chatCompletionProcessorUpstreamFilter_SetBackend(t *testing.T) {
 	headers := map[string]string{":path": "/foo"}
 	mm := &mockChatCompletionMetrics{}
 	p := &chatCompletionProcessorUpstreamFilter{
-		config:         &processorConfig{},
-		requestHeaders: headers,
-		logger:         slog.Default(),
-		metrics:        mm,
+		config: &processorConfig{
+			requestCosts: []processorConfigRequestCost{
+				{LLMRequestCost: &filterapi.LLMRequestCost{Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "output_token_usage", CEL: "15"}},
+			},
+		},
+		requestHeaders:    headers,
+		logger:            slog.Default(),
+		metrics:           mm,
+		modelNameOverride: "ai_gateway_llm",
 	}
 	err := p.SetBackend(t.Context(), &filterapi.Backend{
 		Name:   "some-backend",
@@ -292,6 +297,12 @@ func Test_chatCompletionProcessorUpstreamFilter_SetBackend(t *testing.T) {
 	mm.RequireTokensRecorded(t, 0)
 	mm.RequireSelectedBackend(t, "some-backend")
 	require.False(t, p.stream) // On error, stream should be false regardless of the input.
+
+	// Check model name override after setting it in setBackend
+	md, err := p.maybeBuildDynamicMetadata()
+	require.NoError(t, err)
+	require.NotNil(t, md)
+	require.Equal(t, "", md.Fields["model_name_override"].GetStringValue())
 }
 
 func Test_chatCompletionProcessorUpstreamFilter_ProcessRequestHeaders(t *testing.T) {


### PR DESCRIPTION
The goal here is to give user access to the model override name used to query the inference provider.

