### PR TITLE
test: adds more AI providers

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -185,6 +185,10 @@ jobs:
           TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_USER_AWS_SECRET_ACCESS_KEY }}
           TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
           TEST_GEMINI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_GEMINI_API_KEY }}
+          TEST_GROQ_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_GROQ_API_KEY }}
+          TEST_GROK_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_GROK_API_KEY }}
+          TEST_SAMBANOVA_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_SAMBANOVA_API_KEY }}
+          TEST_DEEPINFRA_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_DEEPINFRA_API_KEY }}
         run: make test-extproc
 
   test_e2e:

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -32,8 +32,8 @@ func setupDefaultAIGatewayResourcesWithAvailableCredentials(t *testing.T) (strin
 	// Set up the credential substitution.
 	t.Setenv("OPENAI_API_KEY", credCtx.OpenAIAPIKey)
 	aiGatewayResourcesPath := filepath.Join(t.TempDir(), "ai-gateway-resources.yaml")
-	awsCredTmpFile := filepath.Join(t.TempDir(), credCtx.AWSFileLiteral)
-	err := os.WriteFile(awsCredTmpFile, []byte(aiGatewayDefaultResources), 0o600)
+	awsCredTmpFile := filepath.Join(t.TempDir(), "aws-credentials")
+	err := os.WriteFile(awsCredTmpFile, []byte(credCtx.AWSFileLiteral), 0o600)
 	require.NoError(t, err)
 	aiGatewayResources := strings.ReplaceAll(aiGatewayDefaultResources, "~/.aws/credentials", awsCredTmpFile)
 	err = os.WriteFile(aiGatewayResourcesPath, []byte(aiGatewayResources), 0o600)

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -28,12 +28,15 @@ import (
 // setupDefaultAIGatewayResourcesWithAvailableCredentials sets up the default AI Gateway resources with available
 // credentials and returns the path to the resources file and the credentials context.
 func setupDefaultAIGatewayResourcesWithAvailableCredentials(t *testing.T) (string, internaltesting.CredentialsContext) {
-	credCtx := internaltesting.RequireNewCredentialsContext(t)
+	credCtx := internaltesting.RequireNewCredentialsContext()
 	// Set up the credential substitution.
 	t.Setenv("OPENAI_API_KEY", credCtx.OpenAIAPIKey)
 	aiGatewayResourcesPath := filepath.Join(t.TempDir(), "ai-gateway-resources.yaml")
-	aiGatewayResources := strings.ReplaceAll(aiGatewayDefaultResources, "~/.aws/credentials", credCtx.AWSFilePath)
-	err := os.WriteFile(aiGatewayResourcesPath, []byte(aiGatewayResources), 0o600)
+	awsCredTmpFile := filepath.Join(t.TempDir(), credCtx.AWSFileLiteral)
+	err := os.WriteFile(awsCredTmpFile, []byte(aiGatewayDefaultResources), 0o600)
+	require.NoError(t, err)
+	aiGatewayResources := strings.ReplaceAll(aiGatewayDefaultResources, "~/.aws/credentials", awsCredTmpFile)
+	err = os.WriteFile(aiGatewayResourcesPath, []byte(aiGatewayResources), 0o600)
 	require.NoError(t, err)
 	return aiGatewayResourcesPath, credCtx
 }

--- a/internal/testing/credentials_context.go
+++ b/internal/testing/credentials_context.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // RequiredCredential is a bit flag for the required credentials.
@@ -26,26 +24,40 @@ const (
 	RequiredCredentialAzure
 	// RequiredCredentialGemini is the bit flag for the Gemini API key.
 	RequiredCredentialGemini
+	// RequiredCredentialGroq is the bit flag for the Groq API key.
+	// https://console.groq.com/docs/openai
+	RequiredCredentialGroq
+	// RequiredCredentialGrok is the bit flag for the Grok API key.
+	// https://console.groq.com/docs/openai
+	RequiredCredentialGrok
+	// RequiredCredentialSambaNova is the bit flag for the SambaNova API key.
+	// https://docs.sambanova.ai/cloud/api-reference/endpoints/chat
+	RequiredCredentialSambaNova
+	// RequiredCredentialDeepInfra is the bit flag for the DeepInfra API key.
+	// https://deepinfra.com/docs/openai_api
+	RequiredCredentialDeepInfra
 )
 
 // CredentialsContext holds the context for the credentials used in the tests.
 type CredentialsContext struct {
 	// OpenAIValid, AWSValid, AzureValid are true if the credentials are set and ready to use the real services.
-	OpenAIValid, AWSValid, AzureValid, GeminiValid bool
+	OpenAIValid, AWSValid, AzureValid, GeminiValid, GroqValid, GrokValid, SambaNovaValid, DeepInfraValid bool
 	// OpenAIAPIKey is the OpenAI API key. This defaults to "dummy-openai-api-key" if not set.
 	OpenAIAPIKey string
-	// OpenAIAPIKeyFilePath is the path to the temporary file containing the OpenAIAPIKey.
-	OpenAIAPIKeyFilePath string
 	// AWSFileLiteral contains the AWS credentials in the format of a file literal.
 	AWSFileLiteral string
-	// AWSFilePath is the path to the temporary file containing the AWS credentials (or dummy credentials).
-	AWSFilePath string
 	// AzureAccessToken is the Azure access token. This defaults to "dummy-azure-access-token" if not set.
 	AzureAccessToken string
-	// AzureAccessTokenFilePath is the path to the temporary file containing the Azure access token (or dummy token).
-	AzureAccessTokenFilePath string
 	// GeminiAPIKey is the API key for Gemini API. https://ai.google.dev/gemini-api/docs/openai
 	GeminiAPIKey string
+	// GroqAPIKey is the API key for Groq API. https://console.groq.com/docs/openai
+	GroqAPIKey string
+	// GrokAPIKey is the API key for Grok API. https://console.grok.com/docs/openai
+	GrokAPIKey string
+	// SambaNovaAPIKey is the API key for SambaNova API. https://docs.sambanova.ai/cloud/api-reference/endpoints/chat
+	SambaNovaAPIKey string
+	// DeepInfraAPIKey is the API key for DeepInfra API. https://deepinfra.com/docs/openai_api
+	DeepInfraAPIKey string
 }
 
 // MaybeSkip skips the test if the required credentials are not set.
@@ -62,63 +74,69 @@ func (c CredentialsContext) MaybeSkip(t *testing.T, required RequiredCredential)
 	if required&RequiredCredentialGemini != 0 && !c.GeminiValid {
 		t.Skip("skipping test as Gemini API key is not set in TEST_GEMINI_API_KEY")
 	}
+	if required&RequiredCredentialGroq != 0 {
+		t.Skip("skipping test as Groq API key is not set in TEST_GROQ_API_KEY")
+	}
+	if required&RequiredCredentialGrok != 0 {
+		t.Skip("skipping test as Grok API key is not set in TEST_GROK_API_KEY")
+	}
+	if required&RequiredCredentialSambaNova != 0 {
+		t.Skip("skipping test as SambaNova API key is not set in TEST_SAMBANOVA_API_KEY")
+	}
+	if required&RequiredCredentialDeepInfra != 0 {
+		t.Skip("skipping test as DeepInfra API key is not set in TEST_DEEPINFRA_API_KEY")
+	}
 }
 
 // RequireNewCredentialsContext creates a new credential context for the tests from the environment variables.
-func RequireNewCredentialsContext(t *testing.T) (ctx CredentialsContext) {
+func RequireNewCredentialsContext() (ctx CredentialsContext) {
 	// Set up credential file for OpenAI.
 	openAIAPIKeyEnv := os.Getenv("TEST_OPENAI_API_KEY")
-	openAIAPIKeyVal := cmp.Or(openAIAPIKeyEnv, "dummy-openai-api-key")
-
-	openAIAPIKeyFilePath := t.TempDir() + "/open-ai-api-key"
-	openaiFile, err := os.Create(openAIAPIKeyFilePath)
-	require.NoError(t, err)
-	_, err = openaiFile.WriteString(openAIAPIKeyVal)
-	require.NoError(t, err)
+	ctx.OpenAIValid = openAIAPIKeyEnv != ""
+	ctx.OpenAIAPIKey = cmp.Or(openAIAPIKeyEnv, "dummy-openai-api-key")
 
 	// Set up credential file for Gemini API.
 	geminiAPIKeyEnv := os.Getenv("TEST_GEMINI_API_KEY")
-	geminiAPIKey := cmp.Or(geminiAPIKeyEnv, "dummy-gemini-api-key")
+	ctx.GeminiValid = geminiAPIKeyEnv != ""
+	ctx.GeminiAPIKey = cmp.Or(geminiAPIKeyEnv, "dummy-gemini-api-key")
+
+	// Set up credential file for Groq API.
+	groqAPIKeyEnv := os.Getenv("TEST_GROQ_API_KEY")
+	ctx.GroqValid = groqAPIKeyEnv != ""
+	ctx.GroqAPIKey = cmp.Or(groqAPIKeyEnv, "dummy-groq-api-key")
+
+	// Set up credential file for Grok API.
+	grokAPIKeyEnv := os.Getenv("TEST_GROK_API_KEY")
+	ctx.GrokValid = grokAPIKeyEnv != ""
+	ctx.GrokAPIKey = cmp.Or(grokAPIKeyEnv, "dummy-grok-api-key")
+
+	// Set up credential file for SambaNova API.
+	sambaNovaAPIKeyEnv := os.Getenv("TEST_SAMBANOVA_API_KEY")
+	ctx.SambaNovaValid = sambaNovaAPIKeyEnv != ""
+	ctx.SambaNovaAPIKey = cmp.Or(sambaNovaAPIKeyEnv, "dummy-sambanova-api-key")
+
+	// Set up credential file for DeepInfra API.
+	deepInfraAPIKeyEnv := os.Getenv("TEST_DEEPINFRA_API_KEY")
+	ctx.DeepInfraValid = deepInfraAPIKeyEnv != ""
+	ctx.DeepInfraAPIKey = cmp.Or(deepInfraAPIKeyEnv, "dummy-deepinfra-api-key")
 
 	// Set up credential file for Azure.
 	azureAccessTokenEnv := os.Getenv("TEST_AZURE_ACCESS_TOKEN")
+	ctx.AzureValid = azureAccessTokenEnv != ""
 	azureAccessToken := cmp.Or(azureAccessTokenEnv, "dummy-azure-access-token")
-	azureAccessTokenFilePath := t.TempDir() + "/azureAccessToken"
-	azureFile, err := os.Create(azureAccessTokenFilePath)
-	require.NoError(t, err)
-	_, err = azureFile.WriteString(azureAccessToken)
-	require.NoError(t, err)
+	ctx.AzureAccessToken = azureAccessToken
 
 	// Set up credential file for AWS.
 	awsAccessKeyID := os.Getenv("TEST_AWS_ACCESS_KEY_ID")
 	awsSecretAccessKey := os.Getenv("TEST_AWS_SECRET_ACCESS_KEY")
 	awsSessionToken := os.Getenv("TEST_AWS_SESSION_TOKEN")
-	var awsCredentialsBody string
+	ctx.AWSValid = awsAccessKeyID != "" && awsSecretAccessKey != "" && awsSessionToken != ""
 	if awsSessionToken != "" {
-		awsCredentialsBody = fmt.Sprintf("[default]\nAWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nAWS_SESSION_TOKEN=%s\n",
+		ctx.AWSFileLiteral = fmt.Sprintf("[default]\nAWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nAWS_SESSION_TOKEN=%s\n",
 			cmp.Or(awsAccessKeyID, "dummy_access_key_id"), cmp.Or(awsSecretAccessKey, "dummy_secret_access_key"), awsSessionToken)
 	} else {
-		awsCredentialsBody = fmt.Sprintf("[default]\nAWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\n",
+		ctx.AWSFileLiteral = fmt.Sprintf("[default]\nAWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\n",
 			cmp.Or(awsAccessKeyID, "dummy_access_key_id"), cmp.Or(awsSecretAccessKey, "dummy_secret_access_key"))
 	}
-	awsFilePath := t.TempDir() + "/aws-credential-file"
-	awsFile, err := os.Create(awsFilePath)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, awsFile.Close()) }()
-	_, err = awsFile.WriteString(awsCredentialsBody)
-	require.NoError(t, err)
-
-	return CredentialsContext{
-		OpenAIValid:              openAIAPIKeyEnv != "",
-		AWSValid:                 awsAccessKeyID != "" && awsSecretAccessKey != "",
-		AzureValid:               azureAccessTokenEnv != "",
-		GeminiValid:              geminiAPIKeyEnv != "",
-		OpenAIAPIKey:             openAIAPIKeyVal,
-		OpenAIAPIKeyFilePath:     openAIAPIKeyFilePath,
-		AWSFileLiteral:           awsCredentialsBody,
-		AWSFilePath:              awsFilePath,
-		AzureAccessToken:         azureAccessToken,
-		AzureAccessTokenFilePath: azureAccessTokenFilePath,
-		GeminiAPIKey:             geminiAPIKey,
-	}
+	return
 }

--- a/internal/testing/credentials_context.go
+++ b/internal/testing/credentials_context.go
@@ -74,16 +74,16 @@ func (c CredentialsContext) MaybeSkip(t *testing.T, required RequiredCredential)
 	if required&RequiredCredentialGemini != 0 && !c.GeminiValid {
 		t.Skip("skipping test as Gemini API key is not set in TEST_GEMINI_API_KEY")
 	}
-	if required&RequiredCredentialGroq != 0 {
+	if required&RequiredCredentialGroq != 0 && !c.GroqValid {
 		t.Skip("skipping test as Groq API key is not set in TEST_GROQ_API_KEY")
 	}
-	if required&RequiredCredentialGrok != 0 {
+	if required&RequiredCredentialGrok != 0 && !c.GrokValid {
 		t.Skip("skipping test as Grok API key is not set in TEST_GROK_API_KEY")
 	}
-	if required&RequiredCredentialSambaNova != 0 {
+	if required&RequiredCredentialSambaNova != 0 && !c.SambaNovaValid {
 		t.Skip("skipping test as SambaNova API key is not set in TEST_SAMBANOVA_API_KEY")
 	}
-	if required&RequiredCredentialDeepInfra != 0 {
+	if required&RequiredCredentialDeepInfra != 0 && !c.DeepInfraValid {
 		t.Skip("skipping test as DeepInfra API key is not set in TEST_DEEPINFRA_API_KEY")
 	}
 }

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -86,6 +86,42 @@ static_resources:
                             headers:
                               - name: x-selected-route-name
                                 string_match:
+                                  exact: groq-route
+                          route:
+                            auto_host_rewrite: true
+                            cluster: groq
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-selected-route-name
+                                string_match:
+                                  exact: grok-route
+                          route:
+                            auto_host_rewrite: true
+                            cluster: grok
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-selected-route-name
+                                string_match:
+                                  exact: sambanova-route
+                          route:
+                            auto_host_rewrite: true
+                            cluster: sambanova
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-selected-route-name
+                                string_match:
+                                  exact: deepinfra-route
+                          route:
+                            auto_host_rewrite: true
+                            cluster: deepinfra
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-selected-route-name
+                                string_match:
                                   exact: testupstream-openai-route
                           route:
                             cluster: testupstream-openai
@@ -597,6 +633,210 @@ static_resources:
                   filter_metadata:
                     aigateway.envoy.io:
                       backend_name: "gemini"
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          auto_host_sni: true
+    - name: groq
+      connect_timeout: 30s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      outlier_detection:
+        consecutive_5xx: 1
+        interval: 1s
+        base_ejection_time: 2s  # Must be smaller than the require.Eventually's interval. Otherwise, the tests may pass without going through the fallback since the always-failing backend could be ejected by the time when require.Eventually retries due to the previous request IF the retry is not configured.
+        max_ejection_percent: 100
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http_protocol_options: {}
+          http_filters:
+            - name: upstream_extproc
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                allow_mode_override: true
+                request_attributes:
+                  - xds.upstream_host_metadata
+                processing_mode:
+                  request_header_mode: "SEND"
+                  request_body_mode: "NONE"
+                  response_header_mode: "SKIP"
+                  response_body_mode: "NONE"
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: extproc_cluster
+            - name: envoy.filters.http.upstream_codec
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+      load_assignment:
+        cluster_name: groq
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  hostname: api.groq.com
+                  address:
+                    socket_address:
+                      address: api.groq.com
+                      port_value: 443
+                metadata:
+                  filter_metadata:
+                    aigateway.envoy.io:
+                      backend_name: "groq"
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          auto_host_sni: true
+    - name: grok
+      connect_timeout: 30s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      outlier_detection:
+        consecutive_5xx: 1
+        interval: 1s
+        base_ejection_time: 2s  # Must be smaller than the require.Eventually's interval. Otherwise, the tests may pass without going through the fallback since the always-failing backend could be ejected by the time when require.Eventually retries due to the previous request IF the retry is not configured.
+        max_ejection_percent: 100
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http_protocol_options: {}
+          http_filters:
+            - name: upstream_extproc
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                allow_mode_override: true
+                request_attributes:
+                  - xds.upstream_host_metadata
+                processing_mode:
+                  request_header_mode: "SEND"
+                  request_body_mode: "NONE"
+                  response_header_mode: "SKIP"
+                  response_body_mode: "NONE"
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: extproc_cluster
+            - name: envoy.filters.http.upstream_codec
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+      load_assignment:
+        cluster_name: grok
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  hostname: api.x.ai
+                  address:
+                    socket_address:
+                      address: api.x.ai
+                      port_value: 443
+                metadata:
+                  filter_metadata:
+                    aigateway.envoy.io:
+                      backend_name: "grok"
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          auto_host_sni: true
+    - name: sambanova
+      connect_timeout: 30s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      outlier_detection:
+        consecutive_5xx: 1
+        interval: 1s
+        base_ejection_time: 2s  # Must be smaller than the require.Eventually's interval. Otherwise, the tests may pass without going through the fallback since the always-failing backend could be ejected by the time when require.Eventually retries due to the previous request IF the retry is not configured.
+        max_ejection_percent: 100
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http_protocol_options: {}
+          http_filters:
+            - name: upstream_extproc
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                allow_mode_override: true
+                request_attributes:
+                  - xds.upstream_host_metadata
+                processing_mode:
+                  request_header_mode: "SEND"
+                  request_body_mode: "NONE"
+                  response_header_mode: "SKIP"
+                  response_body_mode: "NONE"
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: extproc_cluster
+            - name: envoy.filters.http.upstream_codec
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+      load_assignment:
+        cluster_name: sambanova
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  hostname: api.sambanova.ai
+                  address:
+                    socket_address:
+                      address: api.sambanova.ai
+                      port_value: 443
+                metadata:
+                  filter_metadata:
+                    aigateway.envoy.io:
+                      backend_name: "sambanova"
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          auto_host_sni: true
+    - name: deepinfra
+      connect_timeout: 30s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      outlier_detection:
+        consecutive_5xx: 1
+        interval: 1s
+        base_ejection_time: 2s  # Must be smaller than the require.Eventually's interval. Otherwise, the tests may pass without going through the fallback since the always-failing backend could be ejected by the time when require.Eventually retries due to the previous request IF the retry is not configured.
+        max_ejection_percent: 100
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http_protocol_options: {}
+          http_filters:
+            - name: upstream_extproc
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                allow_mode_override: true
+                request_attributes:
+                  - xds.upstream_host_metadata
+                processing_mode:
+                  request_header_mode: "SEND"
+                  request_body_mode: "NONE"
+                  response_header_mode: "SKIP"
+                  response_body_mode: "NONE"
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: extproc_cluster
+            - name: envoy.filters.http.upstream_codec
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+      load_assignment:
+        cluster_name: deepinfra
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  hostname: api.deepinfra.com
+                  address:
+                    socket_address:
+                      address: api.deepinfra.com
+                      port_value: 443
+                metadata:
+                  filter_metadata:
+                    aigateway.envoy.io:
+                      backend_name: "deepinfra"
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:

--- a/tests/extproc/extproc_test.go
+++ b/tests/extproc/extproc_test.go
@@ -67,7 +67,11 @@ var (
 	openAISchema      = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"}
 	awsBedrockSchema  = filterapi.VersionedAPISchema{Name: filterapi.APISchemaAWSBedrock}
 	azureOpenAISchema = filterapi.VersionedAPISchema{Name: filterapi.APISchemaAzureOpenAI, Version: "2025-01-01-preview"}
-	geminiSchema      = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "/v1beta/openai"}
+	geminiSchema      = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1beta/openai"}
+	groqSchema        = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "openai/v1"}
+	grokSchema        = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"}
+	sambaNovaSchema   = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"}
+	deepInfraSchema   = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1/openai"}
 
 	testUpstreamOpenAIBackend     = filterapi.Backend{Name: "testupstream-openai", Schema: openAISchema}
 	testUpstreamModelNameOverride = filterapi.Backend{Name: "testupstream-modelname-override", ModelNameOverride: "override-model", Schema: openAISchema}
@@ -88,7 +92,7 @@ func requireExtProc(t *testing.T, stdout io.Writer, executable, configPath strin
 	cmd := exec.CommandContext(t.Context(), executable)
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
-	cmd.Args = append(cmd.Args, "-configPath", configPath)
+	cmd.Args = append(cmd.Args, "-configPath", configPath, "-logLevel", "warn")
 	cmd.Env = append(os.Environ(), envs...)
 	require.NoError(t, cmd.Start())
 }

--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -88,6 +88,42 @@ func TestWithRealProviders(t *testing.T) {
 					}},
 				},
 			},
+			{
+				Name:    "groq-route",
+				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "llama-3.1-8b-instant"}},
+				Backends: []filterapi.Backend{
+					{Name: "groq", Schema: groqSchema, Auth: &filterapi.BackendAuth{
+						APIKey: &filterapi.APIKeyAuth{Key: cc.GroqAPIKey},
+					}},
+				},
+			},
+			{
+				Name:    "grok-route",
+				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "grok-3"}},
+				Backends: []filterapi.Backend{
+					{Name: "grok", Schema: grokSchema, Auth: &filterapi.BackendAuth{
+						APIKey: &filterapi.APIKeyAuth{Key: cc.GrokAPIKey},
+					}},
+				},
+			},
+			{
+				Name:    "sambanova-route",
+				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "Meta-Llama-3.1-8B-Instruct"}},
+				Backends: []filterapi.Backend{
+					{Name: "sambanova", Schema: sambaNovaSchema, Auth: &filterapi.BackendAuth{
+						APIKey: &filterapi.APIKeyAuth{Key: cc.SambaNovaAPIKey},
+					}},
+				},
+			},
+			{
+				Name:    "deepinfra-route",
+				Headers: []filterapi.HeaderMatch{{Name: "x-model-name", Value: "meta-llama/Meta-Llama-3-8B-Instruct"}},
+				Backends: []filterapi.Backend{
+					{Name: "deepinfra", Schema: deepInfraSchema, Auth: &filterapi.BackendAuth{
+						APIKey: &filterapi.APIKeyAuth{Key: cc.DeepInfraAPIKey},
+					}},
+				},
+			},
 		},
 	})
 
@@ -99,8 +135,13 @@ func TestWithRealProviders(t *testing.T) {
 			{name: "aws-bedrock", modelName: "us.meta.llama3-2-1b-instruct-v1:0", required: internaltesting.RequiredCredentialAWS},
 			{name: "azure-openai", modelName: "o1", required: internaltesting.RequiredCredentialAzure},
 			{name: "gemini", modelName: "gemini-2.0-flash-lite", required: internaltesting.RequiredCredentialGemini},
+			{name: "groq", modelName: "llama-3.1-8b-instant", required: internaltesting.RequiredCredentialGroq},
+			{name: "grok", modelName: "grok-3", required: internaltesting.RequiredCredentialGrok},
+			{name: "sambanova", modelName: "Meta-Llama-3.1-8B-Instruct", required: internaltesting.RequiredCredentialSambaNova},
+			// TODO: enable after we confirm the payment info.
+			// {name: "deepinfra", modelName: "meta-llama/Meta-Llama-3-8B-Instruct", required: internaltesting.RequiredCredentialDeepInfra},
 		} {
-			t.Run(tc.modelName, func(t *testing.T) {
+			t.Run(tc.name, func(t *testing.T) {
 				cc.MaybeSkip(t, tc.required)
 				requireEventuallyNonStreamingRequestOK(t, tc.modelName, "Say this is a test")
 			})

--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -32,7 +32,7 @@ func TestWithRealProviders(t *testing.T) {
 	requireRunEnvoy(t, accessLogPath)
 	configPath := t.TempDir() + "/extproc-config.yaml"
 
-	cc := internaltesting.RequireNewCredentialsContext(t)
+	cc := internaltesting.RequireNewCredentialsContext()
 
 	requireWriteFilterConfig(t, configPath, &filterapi.Config{
 		MetadataNamespace: "ai_gateway_llm_ns",

--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -352,6 +352,10 @@ func TestWithRealProviders(t *testing.T) {
 			"us.anthropic.claude-3-5-sonnet-20240620-v1:0",
 			"o1",
 			"gemini-2.0-flash-lite",
+			"llama-3.1-8b-instant",
+			"grok-3",
+			"Meta-Llama-3.1-8B-Instruct",
+			"meta-llama/Meta-Llama-3-8B-Instruct",
 		}, models)
 	})
 	t.Run("aws-bedrock-large-body", func(t *testing.T) {


### PR DESCRIPTION
**Description**

This adds the following four AI providers in extproc tests:

* Groq https://console.groq.com/docs/openai
* Grok https://docs.x.ai/docs/api-reference#chat-completions
* Samba Nova https://docs.sambanova.ai/cloud/api-reference/endpoints/chat
* Deep Infra https://deepinfra.com/docs/openai_api

