### PR TITLE
chore: adds internal/testing for coverage ignore

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -18,7 +18,7 @@ exclude:
     - cmd/
     # Generated code should not be tested.
     - zz_generated.deepcopy.go
-    # They are the test libraries.
+    # They are test-only libraries.
     - tests/internal/envtest.go
     - internal/testing/
     # TODO: Remove this exclusion.


### PR DESCRIPTION
**Description**

This will add `internal/testing` directly to the ignore target of test coverage. That package's code path varies depending on the credentials so it is flaky, not only it is a test only package.