### PR TITLE
chore: use Install func instead of AddToScheme(Deprecated)

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -192,22 +192,22 @@ func ApplyIndexing(ctx context.Context, indexer func(ctx context.Context, obj cl
 	err := indexer(ctx, &aigv1a1.AIGatewayRoute{},
 		k8sClientIndexBackendToReferencingAIGatewayRoute, aiGatewayRouteIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field from AIGatewayRoute to Backends: %w", err)
+		return fmt.Errorf("failed to create index from Backends to AIGatewayRoute: %w", err)
 	}
 	err = indexer(ctx, &aigv1a1.AIGatewayRoute{},
 		k8sClientIndexAIGatewayRouteToAttachedGateway, aiGatewayRouteToAttachedGatewayIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field from AIGatewayRoute to Gateway: %w", err)
+		return fmt.Errorf("failed to create index from Gateway to AIGatewayRoute: %w", err)
 	}
 	err = indexer(ctx, &aigv1a1.AIServiceBackend{},
 		k8sClientIndexBackendSecurityPolicyToReferencingAIServiceBackend, aiServiceBackendIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field from AIServiceBackend to BackendSecurityPolicy: %w", err)
+		return fmt.Errorf("failed to create index from BackendSecurityPolicy to AIServiceBackend: %w", err)
 	}
 	err = indexer(ctx, &aigv1a1.BackendSecurityPolicy{},
 		k8sClientIndexSecretToReferencingBackendSecurityPolicy, backendSecurityPolicyIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field from BackendSecurityPolicy to Secret: %w", err)
+		return fmt.Errorf("failed to create index from Secret to BackendSecurityPolicy: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -42,7 +42,7 @@ func init() {
 	utilruntime.Must(egv1a1.AddToScheme(Scheme))
 	utilruntime.Must(gwapiv1.Install(Scheme))
 	utilruntime.Must(gwapiv1b1.Install(Scheme))
-	utilruntime.Must(gwaiev1a2.AddToScheme(Scheme))
+	utilruntime.Must(gwaiev1a2.Install(Scheme))
 }
 
 // Scheme contains the necessary schemes for the AI Gateway.
@@ -192,22 +192,22 @@ func ApplyIndexing(ctx context.Context, indexer func(ctx context.Context, obj cl
 	err := indexer(ctx, &aigv1a1.AIGatewayRoute{},
 		k8sClientIndexBackendToReferencingAIGatewayRoute, aiGatewayRouteIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field for AIGatewayRoute to Backends: %w", err)
+		return fmt.Errorf("failed to index field from AIGatewayRoute to Backends: %w", err)
 	}
 	err = indexer(ctx, &aigv1a1.AIGatewayRoute{},
 		k8sClientIndexAIGatewayRouteToAttachedGateway, aiGatewayRouteToAttachedGatewayIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field for AIGatewayRoute to Gateway: %w", err)
+		return fmt.Errorf("failed to index field from AIGatewayRoute to Gateway: %w", err)
 	}
 	err = indexer(ctx, &aigv1a1.AIServiceBackend{},
 		k8sClientIndexBackendSecurityPolicyToReferencingAIServiceBackend, aiServiceBackendIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field for BackendSecurityPolicy to AIServiceBackend: %w", err)
+		return fmt.Errorf("failed to index field from AIServiceBackend to BackendSecurityPolicy: %w", err)
 	}
 	err = indexer(ctx, &aigv1a1.BackendSecurityPolicy{},
 		k8sClientIndexSecretToReferencingBackendSecurityPolicy, backendSecurityPolicyIndexFunc)
 	if err != nil {
-		return fmt.Errorf("failed to index field for BackendSecurityPolicy: %w", err)
+		return fmt.Errorf("failed to index field from BackendSecurityPolicy to Secret: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**
- use Install func instead of AddToScheme(Deprecated)
- use from instead of "for" in ApplyIndexing func


**Related Issues/PRs (if applicable)**
None


**Special notes for reviewers (if applicable)**
None

