### PR TITLE
revert: avoid content-length in the signature for AWS

### DIFF
--- a/internal/extproc/backendauth/aws.go
+++ b/internal/extproc/backendauth/aws.go
@@ -106,6 +106,14 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, h
 	if err != nil {
 		return fmt.Errorf("cannot create request: %w", err)
 	}
+	// By setting the content length to -1, we can avoid the inclusion of the `Content-Length` header in the signature.
+	// https://github.com/aws/aws-sdk-go-v2/blob/755839b2eebb246c7eec79b65404aee105196d5b/aws/signer/v4/v4.go#L427-L431
+	//
+	// The reason why we want to avoid this is that the ExtProc filter will remove the content-length header
+	// from the request currently. Envoy will instead do "transfer-encoding: chunked" for the request body,
+	// which should be acceptable for AWS Bedrock or any modern HTTP service.
+	// https://github.com/envoyproxy/envoy/blob/60b2b5187cf99db79ecfc54675354997af4765ea/source/extensions/filters/http/ext_proc/processor_state.cc#L180-L183
+	req.ContentLength = -1
 
 	err = a.signer.SignHTTP(ctx, a.credentials, req,
 		hex.EncodeToString(payloadHash[:]), "bedrock", a.region, time.Now())


### PR DESCRIPTION
**Description**
As we are reverting https://github.com/envoyproxy/ai-gateway/pull/814 to keep using REPLACE_AND_CONTINUE, we need to reverts the commit 92e5202b96f7c1ba17c17bc77a6381412c0175fe to avoid the inclusion of content-length header in the signature with chunked encoding.
