### PR TITLE
refactor: deprecate targetRefs in favor or parentRefs 

### DIFF
--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -59,12 +59,24 @@ type AIGatewayRouteList struct {
 }
 
 // AIGatewayRouteSpec details the AIGatewayRoute configuration.
+//
+// +kubebuilder:validation:XValidation:rule="!has(self.parentRefs) || !has(self.targetRefs) || size(self.targetRefs) == 0", message="targetRefs is deprecated, use parentRefs only"
 type AIGatewayRouteSpec struct {
 	// TargetRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
 	//
-	// +kubebuilder:validation:MinItems=1
+	// Deprecated: use the ParentRefs field instead. This field will be dropped in Envoy AI Gateway v0.4.0.
+	//
 	// +kubebuilder:validation:MaxItems=128
-	TargetRefs []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName `json:"targetRefs"`
+	TargetRefs []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName `json:"targetRefs,omitempty"`
+
+	// ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
+	// Cross namespace references are not supported. In other words, the Gateway resources must be in the
+	// same namespace as the AIGatewayRoute. Currently, each reference's Kind must be Gateway.
+	//
+	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:XValidation:rule="self.all(match, match.kind == 'Gateway')", message="only Gateway is supported"
+	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
+
 	// APISchema specifies the API schema of the input that the target Gateway(s) will receive.
 	// Based on this schema, the ai-gateway will perform the necessary transformation to the
 	// output schema specified in the selected AIServiceBackend during the routing process.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -216,6 +216,13 @@ func (in *AIGatewayRouteSpec) DeepCopyInto(out *AIGatewayRouteSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ParentRefs != nil {
+		in, out := &in.ParentRefs, &out.ParentRefs
+		*out = make([]v1.ParentReference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.APISchema.DeepCopyInto(&out.APISchema)
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules

--- a/examples/basic/basic.yaml
+++ b/examples/basic/basic.yaml
@@ -30,7 +30,7 @@ metadata:
 spec:
   schema:
     name: OpenAI
-  targetRefs:
+  parentRefs:
     - name: envoy-ai-gateway-basic
       kind: Gateway
       group: gateway.networking.k8s.io

--- a/examples/token_ratelimit/token_ratelimit.yaml
+++ b/examples/token_ratelimit/token_ratelimit.yaml
@@ -30,6 +30,12 @@ metadata:
 spec:
   schema:
     name: OpenAI
+  # parentRefs:
+  #   - name: envoy-ai-gateway-token-ratelimit
+  #     kind: Gateway
+  #     group: gateway.networking.k8s.io
+  # Use parentRefs above instead of targetRefs below, targetRefs will be deprecated in the next version.
+  # Here, we use targetRefs just for the reference as well as to ensure there's an upgrade path.
   targetRefs:
     - name: envoy-ai-gateway-token-ratelimit
       kind: Gateway

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -215,7 +215,10 @@ func ApplyIndexing(ctx context.Context, indexer func(ctx context.Context, obj cl
 func aiGatewayRouteToAttachedGatewayIndexFunc(o client.Object) []string {
 	aiGatewayRoute := o.(*aigv1a1.AIGatewayRoute)
 	var ret []string
-	for _, ref := range aiGatewayRoute.Spec.TargetRefs { // TODO: handle parentRefs per #580.
+	for _, ref := range aiGatewayRoute.Spec.TargetRefs {
+		ret = append(ret, fmt.Sprintf("%s.%s", ref.Name, aiGatewayRoute.Namespace))
+	}
+	for _, ref := range aiGatewayRoute.Spec.ParentRefs {
 		ret = append(ret, fmt.Sprintf("%s.%s", ref.Name, aiGatewayRoute.Namespace))
 	}
 	return ret

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -27,16 +27,16 @@ func TestMain(m *testing.M) {
 func Test_aiGatewayRouteIndexFunc(t *testing.T) {
 	c := requireNewFakeClientWithIndexes(t)
 
-	// Create a AIGatewayRoute.
+	// Create an AIGatewayRoute.
 	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myroute",
 			Namespace: "default",
 		},
 		Spec: aigv1a1.AIGatewayRouteSpec{
-			TargetRefs: []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
-				{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "mytarget"}},
-				{LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "mytarget2"}},
+			ParentRefs: []gwapiv1a2.ParentReference{
+				{Name: "mytarget", Kind: ptr.To(gwapiv1a2.Kind("Gateway"))},
+				{Name: "mytarget2", Kind: ptr.To(gwapiv1a2.Kind("HTTPRoute"))},
 			},
 			Rules: []aigv1a1.AIGatewayRouteRule{
 				{

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -257,6 +257,163 @@ spec:
                   type: object
                 maxItems: 36
                 type: array
+              parentRefs:
+                description: |-
+                  ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
+                  Cross namespace references are not supported. In other words, the Gateway resources must be in the
+                  same namespace as the AIGatewayRoute. Currently, each reference's Kind must be Gateway.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+                        <gateway:experimental:description>
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+                        </gateway:experimental:description>
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+                        <gateway:experimental:description>
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+                        </gateway:experimental:description>
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: only Gateway is supported
+                  rule: self.all(match, match.kind == 'Gateway')
               rules:
                 description: |-
                   Rules is the list of AIGatewayRouteRule that this AIGatewayRoute will match the traffic to.
@@ -537,8 +694,10 @@ spec:
                 x-kubernetes-validations:
                 - rule: self.name == 'OpenAI'
               targetRefs:
-                description: TargetRefs are the names of the Gateway resources this
-                  AIGatewayRoute is being attached to.
+                description: |-
+                  TargetRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
+
+                  Deprecated: use the ParentRefs field instead. This field will be dropped in Envoy AI Gateway v0.4.0.
                 items:
                   description: |-
                     LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
@@ -590,13 +749,15 @@ spec:
                   - name
                   type: object
                 maxItems: 128
-                minItems: 1
                 type: array
             required:
             - rules
             - schema
-            - targetRefs
             type: object
+            x-kubernetes-validations:
+            - message: targetRefs is deprecated, use parentRefs only
+              rule: '!has(self.parentRefs) || !has(self.targetRefs) || size(self.targetRefs)
+                == 0'
           status:
             description: Status defines the status details of the AIGatewayRoute.
             properties:

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -257,6 +257,163 @@ spec:
                   type: object
                 maxItems: 36
                 type: array
+              parentRefs:
+                description: |-
+                  ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
+                  Cross namespace references are not supported. In other words, the Gateway resources must be in the
+                  same namespace as the AIGatewayRoute. Currently, each reference's Kind must be Gateway.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+                        <gateway:experimental:description>
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+                        </gateway:experimental:description>
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+                        <gateway:experimental:description>
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+                        </gateway:experimental:description>
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: only Gateway is supported
+                  rule: self.all(match, match.kind == 'Gateway')
               rules:
                 description: |-
                   Rules is the list of AIGatewayRouteRule that this AIGatewayRoute will match the traffic to.
@@ -537,8 +694,10 @@ spec:
                 x-kubernetes-validations:
                 - rule: self.name == 'OpenAI'
               targetRefs:
-                description: TargetRefs are the names of the Gateway resources this
-                  AIGatewayRoute is being attached to.
+                description: |-
+                  TargetRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.
+
+                  Deprecated: use the ParentRefs field instead. This field will be dropped in Envoy AI Gateway v0.4.0.
                 items:
                   description: |-
                     LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
@@ -590,13 +749,15 @@ spec:
                   - name
                   type: object
                 maxItems: 128
-                minItems: 1
                 type: array
             required:
             - rules
             - schema
-            - targetRefs
             type: object
+            x-kubernetes-validations:
+            - message: targetRefs is deprecated, use parentRefs only
+              rule: '!has(self.parentRefs) || !has(self.targetRefs) || size(self.targetRefs)
+                == 0'
           status:
             description: Status defines the status details of the AIGatewayRoute.
             properties:

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -514,7 +514,12 @@ AIGatewayRouteSpec details the AIGatewayRoute configuration.
   name="targetRefs"
   type="[LocalPolicyTargetReferenceWithSectionName](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.LocalPolicyTargetReferenceWithSectionName) array"
   required="true"
-  description="TargetRefs are the names of the Gateway resources this AIGatewayRoute is being attached to."
+  description="TargetRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.<br />Deprecated: use the ParentRefs field instead. This field will be dropped in Envoy AI Gateway v0.4.0."
+/><ApiField
+  name="parentRefs"
+  type="ParentReference array"
+  required="true"
+  description="ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.<br />Cross namespace references are not supported. In other words, the Gateway resources must be in the<br />same namespace as the AIGatewayRoute. Currently, each reference's Kind must be Gateway."
 /><ApiField
   name="schema"
   type="[VersionedAPISchema](#versionedapischema)"

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -92,20 +92,26 @@ func TestStartControllers(t *testing.T) {
 		},
 	}
 	t.Run("setup routes", func(t *testing.T) {
-		for _, route := range []string{"route1", "route2"} {
+		for i, route := range []string{"route1", "route2"} {
+			var targetRefs []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName
+			var parentRefs []gwapiv1a2.ParentReference
+			if i == 0 {
+				targetRefs = []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{Name: "gtw", Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+					},
+				}
+			} else {
+				parentRefs = []gwapiv1a2.ParentReference{{Name: "gtw"}}
+			}
 			err := c.Create(ctx, &aigv1a1.AIGatewayRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: route, Namespace: "default",
 				},
 				Spec: aigv1a1.AIGatewayRouteSpec{
-					TargetRefs: []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
-						{
-							LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{
-								Name: "gtw", Kind: "Gateway", Group: "gateway.networking.k8s.io",
-							},
-						},
-					},
-					APISchema: defaultSchema,
+					TargetRefs: targetRefs,
+					ParentRefs: parentRefs,
+					APISchema:  defaultSchema,
 					Rules: []aigv1a1.AIGatewayRouteRule{
 						{
 							Matches: []aigv1a1.AIGatewayRouteRuleMatch{},

--- a/tests/crdcel/main_test.go
+++ b/tests/crdcel/main_test.go
@@ -32,6 +32,8 @@ func TestAIGatewayRoutes(t *testing.T) {
 	}{
 		{name: "basic.yaml"},
 		{name: "llmcosts.yaml"},
+		{name: "parent_refs.yaml"},
+		{name: "parent_refs_default_kind.yaml"},
 		{
 			name:   "non_openai_schema.yaml",
 			expErr: `spec.schema: Invalid value: "object": failed rule: self.name == 'OpenAI'`,
@@ -45,8 +47,12 @@ func TestAIGatewayRoutes(t *testing.T) {
 			expErr: "spec.rules[0].matches[0].headers: Invalid value: \"array\": currently only exact match is supported",
 		},
 		{
-			name:   "no_target_refs.yaml",
-			expErr: `spec.targetRefs: Invalid value: 0: spec.targetRefs in body should have at least 1 items`,
+			name:   "target_refs_with_parent_refs.yaml",
+			expErr: `spec: Invalid value: "object": targetRefs is deprecated, use parentRefs only`,
+		},
+		{
+			name:   "parent_refs_invalid_kind.yaml",
+			expErr: `spec.parentRefs: Invalid value: "array": only Gateway is supported`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/crdcel/testdata/aigatewayroutes/parent_refs.yaml
+++ b/tests/crdcel/testdata/aigatewayroutes/parent_refs.yaml
@@ -6,10 +6,13 @@
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute
 metadata:
-  name: apple
+  name: parent-refs
   namespace: default
 spec:
-  targetRefs: []
+  parentRefs:
+    - name: some-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
   schema:
     name: OpenAI
   rules:
@@ -20,8 +23,3 @@ spec:
               value: llama3-70b
       backendRefs:
         - name: kserve
-          weight: 20
-        - name: aws-bedrock
-          weight: 40
-        - name: azure-openai
-          weight: 40

--- a/tests/crdcel/testdata/aigatewayroutes/parent_refs_default_kind.yaml
+++ b/tests/crdcel/testdata/aigatewayroutes/parent_refs_default_kind.yaml
@@ -1,0 +1,26 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: parent-refs
+  namespace: default
+spec:
+  parentRefs:
+    - name: some-gateway
+  schema:
+    name: OpenAI
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: llama3-70b
+      backendRefs:
+        - name: kserve
+          weight: 20
+        - name: aws-bedrock
+          weight: 40

--- a/tests/crdcel/testdata/aigatewayroutes/parent_refs_invalid_kind.yaml
+++ b/tests/crdcel/testdata/aigatewayroutes/parent_refs_invalid_kind.yaml
@@ -1,0 +1,25 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: parent-refs-invalid-knid
+  namespace: default
+spec:
+  parentRefs:
+    - name: some-gateway
+      kind: SomeKind
+      group: gateway.networking.k8s.io
+  schema:
+    name: OpenAI
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: llama3-70b
+      backendRefs:
+        - name: kserve

--- a/tests/crdcel/testdata/aigatewayroutes/target_refs_with_parent_refs.yaml
+++ b/tests/crdcel/testdata/aigatewayroutes/target_refs_with_parent_refs.yaml
@@ -1,0 +1,29 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: apple
+  namespace: default
+spec:
+  targetRefs:
+    - name: some-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  parentRefs:
+    - name: some-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  schema:
+    name: OpenAI
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: llama3-70b
+      backendRefs:
+        - name: kserve


### PR DESCRIPTION
**Description**

This deprecates AIGatwayRoute.spec.targetRefs in favor of parentRefs to comply with the standard of Gateway API. This is a salvation of #580.

**Related Issues/PRs (if applicable)**

Closes #550