### PR TITLE
docs: fix aigw parentRefs in fallback

### DIFF
--- a/site/docs/capabilities/fallback.md
+++ b/site/docs/capabilities/fallback.md
@@ -27,7 +27,7 @@ metadata:
 spec:
   schema:
     name: OpenAI
-  targetRefs:
+  parentRefs:
     - name: provider-fallback
       kind: Gateway
       group: gateway.networking.k8s.io


### PR DESCRIPTION
**Description**

This PR fixed the AIGatewayRoute parentRefs in fallback guides.