### PR TITLE
extproc: return 404 instead of 500 for unknown path

### DIFF
--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -8,7 +8,6 @@ package extproc
 import (
 	"context"
 	"errors"
-	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"io"
 	"log/slog"
 	"testing"
@@ -16,6 +15,7 @@ import (
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -86,7 +86,7 @@ func TestWithTestUpstream(t *testing.T) {
 		responseBody,
 		// responseType is either empty, "sse" or "aws-event-stream" as implemented by the test upstream.
 		responseType,
-		// responseStatus is the HTTP status code of the response.
+		// responseStatus is the HTTP status code of the response returned by the test upstream.
 		responseStatus,
 		// responseHeaders are the headers sent in the HTTP response
 		// The value is a base64 encoded string of comma separated key-value pairs.
@@ -105,15 +105,14 @@ func TestWithTestUpstream(t *testing.T) {
 		expResponseBodyFunc func(require.TestingT, []byte)
 	}{
 		{
-			name:           "unknown path",
-			backend:        "openai",
-			path:           "/unknown",
-			method:         http.MethodPost,
-			requestBody:    `{"prompt": "hello"}`,
-			responseBody:   `{"error": "unknown path"}`,
-			expPath:        "/unknown",
-			responseStatus: "500",
-			expStatus:      http.StatusInternalServerError,
+			name:            "unknown path",
+			backend:         "openai",
+			path:            "/unknown",
+			method:          http.MethodPost,
+			requestBody:     `{"prompt": "hello"}`,
+			expPath:         "/unknown",
+			expStatus:       http.StatusNotFound,
+			expResponseBody: `unsupported path: /unknown`,
 		},
 		{
 			name:            "aws system role - /v1/chat/completions",

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -106,11 +106,8 @@ func TestWithTestUpstream(t *testing.T) {
 	}{
 		{
 			name:            "unknown path",
-			backend:         "openai",
 			path:            "/unknown",
-			method:          http.MethodPost,
 			requestBody:     `{"prompt": "hello"}`,
-			expPath:         "/unknown",
 			expStatus:       http.StatusNotFound,
 			expResponseBody: `unsupported path: /unknown`,
 		},


### PR DESCRIPTION
**Description**

Previously, unknown path was responded as an internal error as opposed to the fact that it's an 404 with the user input root cause. This fixes the extproc code that way, now that users will be able to know what's wrong with the operation instead of getting the cryptic 500 error.

**Related Issues/PRs (if applicable)**

Contributes to #810
Closes #724
