### PR TITLE
ci: commits to main pushes image/helm with sha suffix

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -264,5 +264,5 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - run: |
-          make helm-push HELM_CHART_VERSION=v0.0.0-latest
-          make helm-push HELM_CHART_VERSION=0.0.0-latest
+          make helm-push HELM_CHART_VERSION=v0.0.0-${{ github.sha }}
+          make helm-push HELM_CHART_VERSION=0.0.0-${{ github.sha }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -264,5 +264,7 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - run: |
-          make helm-push HELM_CHART_VERSION=v0.0.0-${{ github.sha }}
-          make helm-push HELM_CHART_VERSION=0.0.0-${{ github.sha }}
+          make helm-push HELM_CHART_VERSION=v0.0.0-latest
+          make helm-push HELM_CHART_VERSION=0.0.0-latest
+          make helm-push HELM_CHART_VERSION=v0.0.0-${{ github.sha }} TAG=${{ github.sha }}
+          make helm-push HELM_CHART_VERSION=0.0.0-${{ github.sha }} TAG=${{ github.sha }}

--- a/.github/workflows/docker_build_job.yaml
+++ b/.github/workflows/docker_build_job.yaml
@@ -57,3 +57,9 @@ jobs:
             TAG="${{ github.sha }}"
           fi
           make docker-build.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }}  ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"
+
+      - name: Build and Push Image Latest
+        run: |
+          if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+            make docker-push.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }}  ENABLE_MULTI_PLATFORMS=true TAG="latest" DOCKER_BUILD_ARGS="--push"
+          fi

--- a/.github/workflows/docker_build_job.yaml
+++ b/.github/workflows/docker_build_job.yaml
@@ -47,13 +47,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       # Push images for the push events, e.g. when a new tag is pushed as well as PR merges.
-      # * Only use the tag if the event is a tag event, otherwise use "latest".
+      # * Only use the tag if the event is a tag event, otherwise use the hash.
       # * Build for both amd64 and arm64 platforms.
       - name: Build and Push Image
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           else
-            TAG="latest"
+            TAG="${{ github.sha }}"
           fi
           make docker-build.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }}  ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"


### PR DESCRIPTION
**Description**

Replacing `latest` suffix for helm charts and docker image. Replacing suffix with commit message.

**Related Issues/PRs (if applicable)**

#851
