### PR TITLE
ci: drops EG v1.4 from e2e target

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -217,8 +217,6 @@ jobs:
         include:
           - name: latest
             envoy_gateway_version: v0.0.0-latest
-          - name: 1.4.0
-            envoy_gateway_version: 1.4.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
**Description**

Since the next EG v1.5 will be our target version that AIGW v0.3 will be based on, there's no reason to keep it at the moment. This is mainly to unblock the incoming feature patches that will rely on v1.5 feature, such as #823.