### PR TITLE
docs: add clearroutecache to dataplane flow

### DIFF
--- a/site/docs/concepts/architecture/data-plane.md
+++ b/site/docs/concepts/architecture/data-plane.md
@@ -56,7 +56,7 @@ sequenceDiagram
     Client->>Envoy: Request
     Envoy->>Processor: Router-level ExtProc Request
     Note over Processor: Extract Model Name
-    Processor-->>Envoy: ;
+    Processor-->>Envoy: ClearRouteCache;
     Envoy->>RLS: Check Rate Limit
     RLS-->>Envoy: ;
     loop Retry/Fallback loop


### PR DESCRIPTION
**Description**

This PR adds clearroutecache to dataplane flow. clearroutecache is an important functionality that envoy ai gw relies on.

Ref: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto#envoy-v3-api-field-service-ext-proc-v3-commonresponse-clear-route-cache