### PR TITLE
chore: enable golangci-lint on e2e dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ precommit: tidy codespell apigen apidoc format lint editorconfig yamllint helm-t
 .PHONY: lint
 lint: ## This runs the linter, formatter, and tidy on the codebase.
 	@echo "lint => ./..."
-	@go tool golangci-lint run --build-tags==test_crdcel,test_controller,test_extproc ./...
+	@go tool golangci-lint run --build-tags==test_crdcel,test_controller,test_extproc,test_e2e ./...
 
 .PHONY: codespell
 CODESPELL_SKIP := $(shell cat .codespell.skip | tr \\n ',')

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -41,10 +41,10 @@ func Test_Examples_Basic(t *testing.T) {
 		read, err := os.ReadFile(manifest)
 		require.NoError(t, err)
 		// Replace the placeholder with the actual credentials.
-		openAiApiKey := os.Getenv("TEST_OPENAI_API_KEY")
+		openAIAPIKey := os.Getenv("TEST_OPENAI_API_KEY")
 		awsAccessKeyID := os.Getenv("TEST_AWS_ACCESS_KEY_ID")
 		awsSecretAccessKey := os.Getenv("TEST_AWS_SECRET_ACCESS_KEY")
-		replaced := strings.ReplaceAll(string(read), "OPENAI_API_KEY", cmp.Or(openAiApiKey, "dummy-openai-api-key"))
+		replaced := strings.ReplaceAll(string(read), "OPENAI_API_KEY", cmp.Or(openAIAPIKey, "dummy-openai-api-key"))
 		replaced = strings.ReplaceAll(replaced, "AWS_ACCESS_KEY_ID", cmp.Or(awsAccessKeyID, "dummy-aws-access-key-id"))
 		replaced = strings.ReplaceAll(replaced, "AWS_SECRET_ACCESS_KEY", cmp.Or(awsSecretAccessKey, "dummy-aws-secret-access-key"))
 		require.NoError(t, kubectlApplyManifestStdin(t.Context(), replaced))
@@ -52,7 +52,7 @@ func Test_Examples_Basic(t *testing.T) {
 		time.Sleep(5 * time.Second) // At least 5 seconds for the updated secret to be propagated.
 
 		for _, tc := range []examplesBasicTestCase{
-			{name: "openai", modelName: "gpt-4o-mini", skip: openAiApiKey == ""},
+			{name: "openai", modelName: "gpt-4o-mini", skip: openAIAPIKey == ""},
 			{name: "aws", modelName: "us.meta.llama3-2-1b-instruct-v1:0", skip: awsAccessKeyID == "" || awsSecretAccessKey == ""},
 		} {
 			tc.run(t, egNamespace, egSelector)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -34,9 +34,8 @@ const (
 var egVersion = func() string {
 	if v, ok := os.LookupEnv("EG_VERSION"); ok {
 		return v
-	} else {
-		return egDefaultVersion
 	}
+	return egDefaultVersion
 }()
 
 // By default, kind logs are collected when the e2e tests fail. The TEST_KEEP_CLUSTER environment variable
@@ -63,7 +62,7 @@ func TestMain(m *testing.M) {
 
 	run := false
 	defer func() {
-		// If the setup or some tests panic, try to collect the cluster logs
+		// If the setup or some tests panic, try to collect the cluster logs.
 		if r := recover(); r != nil {
 			cleanupKindCluster(true)
 		}
@@ -103,7 +102,7 @@ func TestMain(m *testing.M) {
 
 	cleanupKindCluster(code != 0)
 
-	os.Exit(code)
+	os.Exit(code) // nolint: gocritic
 }
 
 func initKindCluster(ctx context.Context) (err error) {
@@ -211,12 +210,12 @@ func initAIGateway(ctx context.Context) (err error) {
 		initLog(fmt.Sprintf("\tdone (took %.2fs in total)\n", elapsed.Seconds()))
 	}()
 	initLog("\tHelm Install")
-	helm_crd := exec.CommandContext(ctx, "go", "tool", "helm", "upgrade", "-i", "ai-eg-crd",
+	helmCRD := exec.CommandContext(ctx, "go", "tool", "helm", "upgrade", "-i", "ai-eg-crd",
 		"../../manifests/charts/ai-gateway-crds-helm",
 		"-n", "envoy-ai-gateway-system", "--create-namespace")
-	helm_crd.Stdout = os.Stdout
-	helm_crd.Stderr = os.Stderr
-	if err = helm_crd.Run(); err != nil {
+	helmCRD.Stdout = os.Stdout
+	helmCRD.Stderr = os.Stderr
+	if err = helmCRD.Run(); err != nil {
 		return
 	}
 

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -53,6 +53,7 @@ func Test_Examples_TokenRateLimit(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
 		if resp.StatusCode == http.StatusOK {
 			var oaiBody openai.ChatCompletion
 			require.NoError(t, json.Unmarshal(body, &oaiBody))
@@ -113,6 +114,7 @@ func Test_Examples_TokenRateLimit(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
 		t.Logf("Response: status=%d, body=%s", resp.StatusCode, string(body))
 		if resp.StatusCode != http.StatusOK {
 			t.Logf("Failed to query Prometheus: status=%s", resp.Status)


### PR DESCRIPTION
**Description**

Due to a missing build tag, previously the golangci-lint hasn't been running for e2e dir. This fixes it.