### PR TITLE
extproc: unify metadata namespace

### DIFF
--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -232,8 +232,8 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 			GetStructValue().Fields["cel_int"].GetNumberValue())
 		require.Equal(t, float64(9999), md.Fields["ai_gateway_llm_ns"].
 			GetStructValue().Fields["cel_uint"].GetNumberValue())
-		require.Equal(t, "ai_gateway_llm", md.Fields["route"].GetStructValue().Fields["model_name_override"].GetStringValue())
-		require.Equal(t, "some_backend", md.Fields["route"].GetStructValue().Fields["backend_name"].GetStringValue())
+		require.Equal(t, "ai_gateway_llm", md.Fields["ai_gateway_llm_ns"].GetStructValue().Fields["model_name_override"].GetStringValue())
+		require.Equal(t, "some_backend", md.Fields["ai_gateway_llm_ns"].GetStructValue().Fields["backend_name"].GetStringValue())
 	})
 }
 

--- a/internal/extproc/embeddings_processor_test.go
+++ b/internal/extproc/embeddings_processor_test.go
@@ -194,9 +194,9 @@ func Test_embeddingsProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
 			GetStructValue().Fields["cel_int"].GetNumberValue())
 		require.Equal(t, float64(9999), md.Fields["ai_gateway_llm_ns"].
 			GetStructValue().Fields["cel_uint"].GetNumberValue())
-		require.Equal(t, "some_backend", md.Fields["route"].
+		require.Equal(t, "some_backend", md.Fields["ai_gateway_llm_ns"].
 			GetStructValue().Fields["backend_name"].GetStringValue())
-		require.Equal(t, "some_model", md.Fields["route"].
+		require.Equal(t, "some_model", md.Fields["ai_gateway_llm_ns"].
 			GetStructValue().Fields["model_name_override"].GetStringValue())
 	})
 }


### PR DESCRIPTION
**Description**
Aggregating the two metadata namespace under existing one -- `config.metadataNamespace`.

Avoid needing to define more receiving metadata namespace for route.
