### PR TITLE
fix: helm chart support specify namespace

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/admission_webhook.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/admission_webhook.yaml
@@ -37,6 +37,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .Values.controller.mutatingWebhook.certManager.certificateName }}
+  namespace: {{ .Release.Namespace }}
 spec:
   commonName: {{ include "ai-gateway-helm.controller.fullname" . }}.{{ .Release.Namespace }}.svc
   dnsNames:
@@ -50,6 +51,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Values.controller.mutatingWebhook.certManager.issuerName }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- else }}
@@ -58,6 +60,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.controller.mutatingWebhook.tlsCertSecretName }}
+  namespace: {{ .Release.Namespace }}
 stringData:
   ca.crt: |
     -----BEGIN CERTIFICATE-----

--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ai-gateway-helm.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ai-gateway-helm.labels" . | nindent 4 }}
 spec:

--- a/manifests/charts/ai-gateway-helm/templates/service.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/service.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ai-gateway-helm.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ai-gateway-helm.labels" . | nindent 4 }}
 spec:

--- a/manifests/charts/ai-gateway-helm/templates/serviceaccount.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ai-gateway-helm.controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ai-gateway-helm.labels" . | nindent 4 }}
   {{- with .Values.controller.serviceAccount.annotations }}


### PR DESCRIPTION
**Description**

This PR added missing namespace in chart templates, which addes the support for --namespace when helm install.