### PR TITLE
fix: extproc openai assistant message type

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -180,7 +180,7 @@ func (s *StringOrAssistantRoleContentUnion) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var content ChatCompletionAssistantMessageParamContent
+	var content []ChatCompletionAssistantMessageParamContent
 	err = json.Unmarshal(data, &content)
 	if err == nil {
 		s.Value = content

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -108,7 +108,7 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
                          {"role": "developer", "content": "you are a helpful dev assistant"},
                          {"role": "user", "content": "what do you see in this image"},
                          {"role": "tool", "content": "some tool", "tool_call_id": "123"},
-                         {"role": "assistant", "content": {"text": "you are a helpful assistant"}}
+			                   {"role": "assistant", "content": "you are a helpful assistant"}
                     ]}
 `),
 			out: &ChatCompletionRequest{
@@ -152,7 +152,7 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 					{
 						Value: ChatCompletionAssistantMessageParam{
 							Role:    ChatMessageRoleAssistant,
-							Content: StringOrAssistantRoleContentUnion{Value: ChatCompletionAssistantMessageParamContent{Text: ptr.To("you are a helpful assistant")}},
+							Content: StringOrAssistantRoleContentUnion{Value: "you are a helpful assistant"},
 						},
 						Type: ChatMessageRoleAssistant,
 					},
@@ -164,7 +164,7 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 			in: []byte(`{"model": "gpu-o4",
                         "messages": [
                          {"role": "assistant", "content": "you are a helpful assistant"},
-                         {"role": "assistant", "content": "{'text': 'you are a helpful assistant'}"}
+			                   {"role": "assistant", "content": [{"text": "you are a helpful assistant content", "type": "text"}]}
                     ]}
 `),
 			out: &ChatCompletionRequest{
@@ -179,8 +179,10 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 					},
 					{
 						Value: ChatCompletionAssistantMessageParam{
-							Role:    ChatMessageRoleAssistant,
-							Content: StringOrAssistantRoleContentUnion{Value: "{'text': 'you are a helpful assistant'}"},
+							Role: ChatMessageRoleAssistant,
+							Content: StringOrAssistantRoleContentUnion{Value: []ChatCompletionAssistantMessageParamContent{
+								{Text: ptr.To("you are a helpful assistant content"), Type: "text"},
+							}},
 						},
 						Type: ChatMessageRoleAssistant,
 					},

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -415,6 +415,25 @@ data: [DONE]
 			expStatus:           http.StatusOK,
 			expResponseBodyFunc: checkModels(expectedModels),
 		},
+		{
+			name:    "openai - /v1/chat/completions - assistant text content",
+			backend: "openai",
+			path:    "/v1/chat/completions",
+			method:  http.MethodPost,
+			requestBody: `
+{
+       "model": "whatever",
+       "messages": [
+               {"role": "user", "content": [{"type": "text", "text": "hi sir"}]},
+               {"role": "assistant","content": [{"type": "text", "text": "Hello! How can I assist you today?"}]},
+               {"role": "user", "content": [{"type": "text", "text": "what are you?"}]}
+       ]
+}`,
+			expPath:         "/v1/chat/completions",
+			responseBody:    `{"choices":[{"message":{"content":"This is a test."}}]}`,
+			expStatus:       http.StatusOK,
+			expResponseBody: `{"choices":[{"message":{"content":"This is a test."}}]}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Eventually(t, func() bool {


### PR DESCRIPTION
**Description**

According to https://platform.openai.com/docs/api-reference/chat/create
Assistant message's content should be string or array. 

**Related Issues/PRs (if applicable)**

https://github.com/envoyproxy/ai-gateway/issues/891

**Special notes for reviewers (if applicable)**

