### PR TITLE
fix: enable inferencepool e2e test

### DIFF
--- a/tests/e2e/inference_pool_test.go
+++ b/tests/e2e/inference_pool_test.go
@@ -3,8 +3,6 @@
 // The full text of the Apache license is available in the LICENSE file at
 // the root of the repo.
 
-//go:build test_e2e
-
 package e2e
 
 import (


### PR DESCRIPTION
**Description**

This PR enables inferencepool e2e test by removing tags.
