### PR TITLE
docs: set default docs display version to latest

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -46,7 +46,7 @@ const config: Config = {
           remarkPlugins: [
             [require('@docusaurus/theme-mermaid'), {}],
           ],
-          lastVersion: '0.2',
+          lastVersion: 'current',
           versions: {
             current: {
               label: 'latest',
@@ -55,7 +55,7 @@ const config: Config = {
             },
             '0.2': {
               label: '0.2',
-              path: '',
+              path: '0.2',
               banner: 'none'
             },
             '0.1': {

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -50,8 +50,8 @@ const config: Config = {
           versions: {
             current: {
               label: 'latest',
-              path: 'latest',
-              banner: 'unreleased'
+              path: '/',
+              banner: 'none'
             },
             '0.2': {
               label: '0.2',


### PR DESCRIPTION
**Description**

Set default docs display version to `latest` version

**Related Issues/PRs (if applicable)**
n/a

**Special notes for reviewers (if applicable)**

as we add docs to latest version, and as the project is new and changing fast, most people are looking to view latest docs. people can still navigate to view a specific version.
