### PR TITLE
ci: use Envoy v1.35 for extproc test

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -129,9 +129,9 @@ jobs:
         # Once it's supported, the following "binary installation" steps below can be just removed and
         # we can simply exec.Cmd with "go tool func-e run" with the envoy version configured via ENVOY_VERSION env var.
         include:
-          - version: 1.34.1  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
+          - version: 1.35.0  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
             os: ubuntu-latest
-          - version: 1.34.1  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
+          - version: 1.35.0  # NOTE: when updating this, also update the comment in the CONTRIBUTING.md file.
             os: macos-latest
           - version: latest
             os: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ For example,
 
 * The latest `kubectl` binary for running `make test-e2e`.
   * See: https://kubernetes.io/docs/tasks/tools/
-* The latest `envoy` binary for running `make test-extproc`. The current required version is v1.34 or later.
+* The latest `envoy` binary for running `make test-extproc`. The current required version is v1.35 or later.
   * On Linux, you can download the latest Envoy binary as described in https://www.envoyproxy.io/docs/envoy/latest/start/install.
     Alternatively, you can use `func-e` on Linux as well like on macOS below.
   * On macOS, since `brew envoy` tends to behind the latest version, it is recommended use `func-e` to run the latest Envoy. See https://func-e.io/.


### PR DESCRIPTION
**Description**

Envoy v1.35 has been released today, so this upgrades the Envoy version used in the extproc integration tests.

https://github.com/envoyproxy/envoy/releases/tag/v1.35.0