### PR TITLE
extproc: force stream_options.include_usage=true part 2

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -107,10 +107,10 @@ func (c *chatCompletionProcessorRouterFilter) ProcessRequestBody(_ context.Conte
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse request body: %w", err)
 	}
-	if body.Stream && body.StreamOptions != nil && !body.StreamOptions.IncludeUsage && len(c.config.requestCosts) > 0 {
+	if body.Stream && (body.StreamOptions == nil || !body.StreamOptions.IncludeUsage) && len(c.config.requestCosts) > 0 {
 		// If the request is a streaming request and cost metrics are configured, we need to include usage in the response
 		// to avoid the bypassing of the token usage calculation.
-		body.StreamOptions.IncludeUsage = true
+		body.StreamOptions = &openai.StreamOptions{IncludeUsage: true}
 		// Rewrite the original bytes to include the stream_options.include_usage=true so that forcing the request body
 		// mutation, which uses this raw body, will also result in the stream_options.include_usage=true.
 		rawBody.Body, err = sjson.SetBytesOptions(rawBody.Body, "stream_options.include_usage", true, &sjson.Options{})

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -84,7 +84,7 @@ func Test_chatCompletionProcessorRouterFilter_ProcessRequestBody(t *testing.T) {
 			requestHeaders: headers,
 			logger:         slog.Default(),
 		}
-		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model", false, false)})
+		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model", false, nil)})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		re, ok := resp.Response.(*extprocv3.ProcessingResponse_RequestBody)
@@ -99,24 +99,29 @@ func Test_chatCompletionProcessorRouterFilter_ProcessRequestBody(t *testing.T) {
 		require.Equal(t, "/foo", string(setHeaders[1].Header.RawValue))
 	})
 
-	t.Run("ok_stream_with_include_usage_false", func(t *testing.T) {
-		headers := map[string]string{":path": "/foo"}
-		const modelKey = "x-ai-gateway-model-key"
-		p := &chatCompletionProcessorRouterFilter{
-			config: &processorConfig{
-				modelNameHeaderKey: modelKey,
-				// Ensure that the stream_options.include_usage be forced to true.
-				requestCosts: []processorConfigRequestCost{{}},
-			},
-			requestHeaders: headers,
-			logger:         slog.Default(),
+	t.Run("ok_stream_without_include_usage", func(t *testing.T) {
+		for _, opt := range []*openai.StreamOptions{
+			nil, {IncludeUsage: false},
+		} {
+			headers := map[string]string{":path": "/foo"}
+			const modelKey = "x-ai-gateway-model-key"
+			p := &chatCompletionProcessorRouterFilter{
+				config: &processorConfig{
+					modelNameHeaderKey: modelKey,
+					// Ensure that the stream_options.include_usage be forced to true.
+					requestCosts: []processorConfigRequestCost{{}},
+				},
+				requestHeaders: headers,
+				logger:         slog.Default(),
+			}
+			resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model", true, opt)})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, p.originalRequestBody.StreamOptions)
+			require.True(t, p.forcedStreamOptionIncludeUsage)
+			require.True(t, p.originalRequestBody.StreamOptions.IncludeUsage)
+			require.Contains(t, string(p.originalRequestBodyRaw), `"stream_options":{"include_usage":true}`)
 		}
-		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: bodyFromModel(t, "some-model", true, false)})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.True(t, p.forcedStreamOptionIncludeUsage)
-		require.True(t, p.originalRequestBody.StreamOptions.IncludeUsage)
-		require.Contains(t, string(p.originalRequestBodyRaw), `"stream_options":{"include_usage":true}`)
 	})
 }
 
@@ -256,11 +261,11 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 	})
 }
 
-func bodyFromModel(t *testing.T, model string, stream, streamOptionIncludeUsage bool) []byte {
+func bodyFromModel(t *testing.T, model string, stream bool, streamOptions *openai.StreamOptions) []byte {
 	openAIReq := &openai.ChatCompletionRequest{}
 	openAIReq.Model = model
 	openAIReq.Stream = stream
-	openAIReq.StreamOptions = &openai.StreamOptions{IncludeUsage: streamOptionIncludeUsage}
+	openAIReq.StreamOptions = streamOptions
 	bytes, err := json.Marshal(openAIReq)
 	require.NoError(t, err)
 	return bytes
@@ -304,7 +309,7 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessRequestHeaders(t *testing
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("translator error", func(t *testing.T) {
 				headers := map[string]string{":path": "/foo", modelKey: "some-model"}
-				someBody := bodyFromModel(t, "some-model", tc.stream, false)
+				someBody := bodyFromModel(t, "some-model", tc.stream, nil)
 				var body openai.ChatCompletionRequest
 				require.NoError(t, json.Unmarshal(someBody, &body))
 				tr := mockTranslator{t: t, retErr: errors.New("test error"), expRequestBody: &body}
@@ -328,7 +333,7 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessRequestHeaders(t *testing
 				mm.RequireSelectedModel(t, "some-model")
 			})
 			t.Run("ok", func(t *testing.T) {
-				someBody := bodyFromModel(t, "some-model", tc.stream, false)
+				someBody := bodyFromModel(t, "some-model", tc.stream, nil)
 				headers := map[string]string{":path": "/foo", modelKey: "some-model"}
 				headerMut := &extprocv3.HeaderMutation{
 					SetHeaders: []*corev3.HeaderValueOption{{Header: &corev3.HeaderValue{Key: "foo", RawValue: []byte("bar")}}},

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -100,9 +100,7 @@ func Test_chatCompletionProcessorRouterFilter_ProcessRequestBody(t *testing.T) {
 	})
 
 	t.Run("ok_stream_without_include_usage", func(t *testing.T) {
-		for _, opt := range []*openai.StreamOptions{
-			nil, {IncludeUsage: false},
-		} {
+		for _, opt := range []*openai.StreamOptions{nil, {IncludeUsage: false}} {
 			headers := map[string]string{":path": "/foo"}
 			const modelKey = "x-ai-gateway-model-key"
 			p := &chatCompletionProcessorRouterFilter{

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -304,6 +304,29 @@ data: [DONE]
 `,
 		},
 		{
+			name:           "openai - /v1/chat/completions - streaming - forced to include usage without steam_options",
+			backend:        "openai",
+			path:           "/v1/chat/completions",
+			responseType:   "sse",
+			method:         http.MethodPost,
+			requestBody:    `{"model":"something","messages":[{"role":"system","content":"You are a chatbot."}], "stream": true}`,
+			expRequestBody: `{"model":"something","messages":[{"role":"system","content":"You are a chatbot."}], "stream": true,"stream_options":{"include_usage":true}}`,
+			expPath:        "/v1/chat/completions",
+			responseBody: `
+{"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":13,"completion_tokens":12,"total_tokens":25,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+[DONE]
+`,
+			expStatus: http.StatusOK,
+			expResponseBody: `data: {"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":13,"completion_tokens":12,"total_tokens":25,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+data: [DONE]
+
+`,
+		},
+		{
 			name:           "gcp-vertexai - /v1/chat/completions - streaming",
 			backend:        "gcp-vertexai",
 			path:           "/v1/chat/completions",


### PR DESCRIPTION
**Description**

This is a follow up on https://github.com/envoyproxy/ai-gateway/pull/934 to handle the case where the "stream_options" is not present in the first place.