### PR TITLE
cli: fixes race with EG logs for aigw run

### DIFF
--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -173,8 +173,8 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 	server := root.GetRootCommand()
 	// TODO: enable the log by default after the issue is resolved: https://github.com/envoyproxy/gateway/issues/6596
 	if c.Debug {
-		server.SetOut(os.Stdout)
-		server.SetErr(os.Stderr)
+		server.SetOut(stdout)
+		server.SetErr(stderr)
 	} else {
 		server.SetOut(io.Discard)
 		server.SetErr(io.Discard)

--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -171,14 +171,18 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 	// Then the agent will read the resources from the file pointed inside the config and start the Envoy process.
 
 	server := root.GetRootCommand()
-	egOut := &bytes.Buffer{}
-	server.SetOut(egOut)
-	server.SetErr(egOut)
+	// TODO: enable the log by default after the issue is resolved: https://github.com/envoyproxy/gateway/issues/6596
+	if c.Debug {
+		server.SetOut(os.Stdout)
+		server.SetErr(os.Stderr)
+	} else {
+		server.SetOut(io.Discard)
+		server.SetErr(io.Discard)
+	}
 	server.SetArgs([]string{"server", "--config-path", egConfigPath})
 	if err := server.ExecuteContext(ctx); err != nil {
 		return fmt.Errorf("failed to execute server: %w", err)
 	}
-	stderrLogger.Info("Envoy Gateway output", "output", egOut.String())
 	return nil
 }
 


### PR DESCRIPTION
**Description**

Previously, there was a flake in the use of bytes.Buffer passed to EG command as well as on our aigw run side, we are reading it concurrently. This fixes it temporarily by passing os.Stdout or io.Discard. 

The race was occasionally happening on CI which was causing the flake, so this fixes it.