### PR TITLE
site: update CSP setting for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@ command = "npm run build"
     Content-Security-Policy = """
       default-src 'self';
       frame-src 'self' https://www.youtube.com https://app.netlify.com;
-      script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com;
+      script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://widget.kapa.ai;
       style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
       img-src 'self' data: https: blob:;
       font-src 'self' data: https://fonts.gstatic.com;


### PR DESCRIPTION
**Description**
Add Kapa and Google Analytics to the CSP settings in Netlify.

**Related Issues/PRs (if applicable)**

Related PR: #949 


**Special notes for reviewers (if applicable)**
Without this setting, the Kapa buttons don't appear on the site.
