### PR TITLE
fix: embedding fake response

### DIFF
--- a/tests/internal/testupstreamlib/testupstream/main.go
+++ b/tests/internal/testupstreamlib/testupstream/main.go
@@ -395,6 +395,9 @@ func getFakeResponse(path string) ([]byte, error) {
 			chatCompletionFakeResponses[rand.New(rand.NewSource(uint64(time.Now().UnixNano()))).
 				Intn(len(chatCompletionFakeResponses))])
 		return []byte(msg), nil
+	case "/v1/embeddings":
+		const embeddingTemplate = `{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2,0.3,0.4,0.5],"index":0}],"model":"some-cool-self-hosted-model","usage":{"prompt_tokens":3,"total_tokens":3}}`
+		return []byte(embeddingTemplate), nil
 	default:
 		return nil, fmt.Errorf("unknown path: %s", path)
 	}


### PR DESCRIPTION
**Description**

- Added fake response for embedding requests.
- Kept the response in line with documentation https://aigateway.envoyproxy.io/docs/getting-started/basic-usage#embeddings-response

**Testing**
* Tested on local setup by running the testupstream server and sending following embedding request
```
❯ curl -H "Content-Type: application/json" \
     -d '{
       "model": "some-cool-self-hosted-model",
       "input": "Hello, world!"
     }' \
     http://localhost:8080/v1/embeddings
```
* testupstream server logs
```
❯ go run main.go
[testupstream] Version:  dev


[testupstream] header "Accept": [*/*]
[testupstream] header "Content-Type": [application/json]
[testupstream] header "Content-Length": [87]
[testupstream] header "User-Agent": [curl/8.7.1]
[testupstream] no expected host: got localhost:8080
[testupstream] no expected headers
[testupstream] no non-expected headers in the request
[testupstream] no expected testupstream-id
[testupstream] no expected request body
[testupstream] no response headers
[testupstream] response sent: {"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2,0.3,0.4,0.5],"index":0}],"model":"some-cool-self-hosted-model","usage":{"prompt_tokens":3,"total_tokens":3}}
```
* Response after fix
```
{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2,0.3,0.4,0.5],"index":0}],"model":"some-cool-self-hosted-model","usage":{"prompt_tokens":3,"total_tokens":3}}
```

**Related Issues/PRs (if applicable)**

Fixes https://github.com/envoyproxy/ai-gateway/issues/967

**Special notes for reviewers (if applicable)**
* Tested only on the local environment.
