### PR TITLE
chore: cleans up the deprecated backendSecurityPolicyRef

### DIFF
--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -181,11 +181,6 @@ spec:
     kind: Backend
     group: gateway.envoyproxy.io
     namespace: default
-  backendSecurityPolicyRef:
-    name: openai-apikey
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
-    namespace: default
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIServiceBackend
@@ -201,11 +196,6 @@ spec:
     name: aws
     kind: Backend
     group: gateway.envoyproxy.io
-    namespace: default
-  backendSecurityPolicyRef:
-    name: aws-credentials
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
     namespace: default
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
@@ -230,6 +220,10 @@ metadata:
   name: openai-apikey
   namespace: default
 spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: openai
   type: APIKey
   apiKey:
     secretRef:
@@ -241,6 +235,10 @@ metadata:
   name: aws-credentials
   namespace: default
 spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: aws
   type: AWSCredentials
   awsCredentials:
     region: us-east-1

--- a/cmd/aigw/testdata/translate_basic.in.yaml
+++ b/cmd/aigw/testdata/translate_basic.in.yaml
@@ -75,10 +75,6 @@ spec:
     name: envoy-ai-gateway-basic-openai
     kind: Backend
     group: gateway.envoyproxy.io
-  backendSecurityPolicyRef:
-    name: envoy-ai-gateway-basic-openai-apikey
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIServiceBackend
@@ -92,10 +88,6 @@ spec:
     name: envoy-ai-gateway-basic-aws
     kind: Backend
     group: gateway.envoyproxy.io
-  backendSecurityPolicyRef:
-    name: envoy-ai-gateway-basic-aws-credentials
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: BackendSecurityPolicy
@@ -103,6 +95,10 @@ metadata:
   name: envoy-ai-gateway-basic-openai-apikey
   namespace: default
 spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: envoy-ai-gateway-basic-openai
   type: APIKey
   apiKey:
     secretRef:
@@ -115,6 +111,10 @@ metadata:
   name: envoy-ai-gateway-basic-aws-credentials
   namespace: default
 spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: envoy-ai-gateway-basic-aws
   type: AWSCredentials
   awsCredentials:
     region: us-east-1

--- a/examples/provider_fallback/base.yaml
+++ b/examples/provider_fallback/base.yaml
@@ -58,10 +58,6 @@ spec:
     name: provider-fallback-aws
     kind: Backend
     group: gateway.envoyproxy.io
-  backendSecurityPolicyRef:
-    name: provider-fallback-aws-credentials
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: BackendSecurityPolicy
@@ -69,6 +65,10 @@ metadata:
   name: provider-fallback-aws-credentials
   namespace: default
 spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: provider-fallback-aws
   type: AWSCredentials
   awsCredentials:
     region: us-east-1

--- a/site/docs/capabilities/llm-integrations/connect-providers.md
+++ b/site/docs/capabilities/llm-integrations/connect-providers.md
@@ -48,12 +48,6 @@ spec:
     name: my-provider-backend
     kind: Backend
     group: gateway.envoyproxy.io
-
-  # Security policy for authentication
-  backendSecurityPolicyRef:
-    name: my-provider-auth
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
 ```
 
 #### Schema Configuration Examples
@@ -288,10 +282,6 @@ spec:
     name: openai-backend
     kind: Backend
     group: gateway.envoyproxy.io
-  backendSecurityPolicyRef:
-    name: openai-auth
-    kind: BackendSecurityPolicy
-    group: aigateway.envoyproxy.io
 
 ---
 # Security configuration
@@ -300,6 +290,10 @@ kind: BackendSecurityPolicy
 metadata:
   name: openai-auth
 spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: openai-backend
   type: APIKey
   apiKey:
     secretRef:


### PR DESCRIPTION
**Description**

backendSecurityPolicyRef has been marked deprecated, so this cleans up the remaining reference of backendSecurityPolicyRef in various places.

**Related Issues/PRs (if applicable)**

Follow up on #762
