### PR TITLE
controller: skipping user-applied HTTPRoute is not an error

### DIFF
--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -164,7 +164,7 @@ func (s *Server) maybeModifyCluster(cluster *clusterv3.Cluster) {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			s.log.Info("Skipping user-created HTTPRoute cluster modification",
-				"cluster_name", cluster.Name, "namespace", httpRouteNamespace, "name")
+				"namespace", httpRouteNamespace, "name", httpRouteName)
 			return
 		}
 		s.log.Error(err, "failed to get AIGatewayRoute object",

--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -162,14 +162,13 @@ func (s *Server) maybeModifyCluster(cluster *clusterv3.Cluster) {
 	var aigwRoute aigv1a1.AIGatewayRoute
 	err = s.k8sClient.Get(context.Background(), client.ObjectKey{Namespace: httpRouteNamespace, Name: httpRouteName}, &aigwRoute)
 	if err != nil {
-		// This can support directly using inferencePool in httproute.
-		if apierrors.IsNotFound(err) && pool != nil {
-			s.log.Info("AIGatewayRoute not found, but found InferencePool in cluster metadata. Skipping cluster modification.",
-				"namespace", httpRouteNamespace, "name", httpRouteName)
-			return
+		if apierrors.IsNotFound(err) {
+			s.log.Info("Skipping user-created HTTPRoute cluster modification",
+				"cluster_name", cluster.Name, "namespace", httpRouteNamespace, "name")
+		} else {
+			s.log.Error(err, "failed to get AIGatewayRoute",
+				"cluster_name", cluster.Name, "namespace", httpRouteNamespace, "name", httpRouteName)
 		}
-		s.log.Error(err, "failed to get AIGatewayRoute object",
-			"namespace", httpRouteNamespace, "name", httpRouteName)
 		return
 	}
 

--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -165,10 +165,10 @@ func (s *Server) maybeModifyCluster(cluster *clusterv3.Cluster) {
 		if apierrors.IsNotFound(err) {
 			s.log.Info("Skipping user-created HTTPRoute cluster modification",
 				"cluster_name", cluster.Name, "namespace", httpRouteNamespace, "name")
-		} else {
-			s.log.Error(err, "failed to get AIGatewayRoute",
-				"cluster_name", cluster.Name, "namespace", httpRouteNamespace, "name", httpRouteName)
+			return
 		}
+		s.log.Error(err, "failed to get AIGatewayRoute object",
+			"namespace", httpRouteNamespace, "name", httpRouteName)
 		return
 	}
 


### PR DESCRIPTION
**Description**

Previously, the extension server implementation treats HTTPRoute not generated by AIGW as an error during the cluster modification phase. That resulted in the errors like below:

```
ERROR   envoy-gateway-extension-server  failed to get AIGatewayRoute object     {"namespace": "default", "name": "non-llm-route", "error": "AIGatewayRoute.aigateway.envoyproxy.io \"non-llm-route\" not found"}
```

In practice, since #963, users can freely attach normal HTTPRoutes in conjunction with AIGatewayRoutes, this switches the log level for that case to Info.