### PR TITLE
controller: use RetryOnConflict on status update

### DIFF
--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -353,7 +353,6 @@ func (c *AIGatewayRouteController) backend(ctx context.Context, namespace, name 
 // updateAIGatewayRouteStatus updates the status of the AIGatewayRoute.
 func (c *AIGatewayRouteController) updateAIGatewayRouteStatus(ctx context.Context, route *aigv1a1.AIGatewayRoute, conditionType string, message string) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the latest version of the route to avoid conflicts.
 		if err := c.client.Get(ctx, client.ObjectKey{Name: route.Name, Namespace: route.Namespace}, route); err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil

--- a/internal/controller/ai_service_backend.go
+++ b/internal/controller/ai_service_backend.go
@@ -105,7 +105,6 @@ func (c *AIBackendController) syncAIServiceBackend(ctx context.Context, aiBacken
 // updateAIServiceBackendStatus updates the status of the AIServiceBackend.
 func (c *AIBackendController) updateAIServiceBackendStatus(ctx context.Context, backend *aigv1a1.AIServiceBackend, conditionType string, message string) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the latest version of the route to avoid conflicts.
 		if err := c.client.Get(ctx, client.ObjectKey{Name: backend.Name, Namespace: backend.Namespace}, backend); err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil

--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -311,7 +311,6 @@ func (c *BackendSecurityPolicyController) syncBackendSecurityPolicy(ctx context.
 // updateBackendSecurityPolicyStatus updates the status of the BackendSecurityPolicy.
 func (c *BackendSecurityPolicyController) updateBackendSecurityPolicyStatus(ctx context.Context, bsp *aigv1a1.BackendSecurityPolicy, conditionType string, message string) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the latest version of the route to avoid conflicts.
 		if err := c.client.Get(ctx, client.ObjectKey{Name: bsp.Name, Namespace: bsp.Namespace}, bsp); err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil


### PR DESCRIPTION
**Description**

Previously, we didn't do utilize the retryonconflict function that is a standard method to do proper status updates on CRDs. 