### PR TITLE
feat: add kube-deploy commands for Kind cluster management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@
 # The Go-based tools are defined in Makefile.tools.mk.
 include Makefile.tools.mk
 
+# The Kubernetes deployment targets are defined in Makefile.kube.mk.
+include Makefile.kube.mk
+
 # The list of commands that can be built.
 COMMANDS := controller extproc
 

--- a/Makefile.kube.mk
+++ b/Makefile.kube.mk
@@ -1,0 +1,110 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+##@ Kubernetes: Targets for managing Kubernetes clusters and deployments
+
+KIND_CLUSTER_NAME ?= envoy-ai-gateway
+KUBE_NAMESPACE ?= envoy-ai-gateway-system
+KUBE_WAIT_TIMEOUT ?= 2m
+EG_VERSION ?= v0.0.0-latest
+
+# Kind cluster management
+.PHONY: create-cluster
+create-cluster: ## Create a Kind cluster with same setup as e2e tests
+	@echo "Setting up the kind cluster"
+	@tools/hack/create-cluster.sh
+
+.PHONY: delete-cluster
+delete-cluster: ## Delete the Kind cluster
+	@echo "Deleting Kind cluster: $(KIND_CLUSTER_NAME)"
+	@kind delete cluster --name $(KIND_CLUSTER_NAME)
+	@echo "Kind cluster deleted successfully"
+
+# Load local images (for development)
+.PHONY: load-local-images
+load-local-images: build ## Load locally built images into Kind cluster
+	@echo "Loading local Docker images into kind cluster"
+	@kind load docker-image docker.io/envoyproxy/ai-gateway-controller:latest --name $(KIND_CLUSTER_NAME)
+	@kind load docker-image docker.io/envoyproxy/ai-gateway-extproc:latest --name $(KIND_CLUSTER_NAME)
+	@kind load docker-image docker.io/envoyproxy/ai-gateway-testupstream:latest --name $(KIND_CLUSTER_NAME)
+	@echo "Local images loaded successfully"
+
+# Envoy Gateway setup (mirrors initEnvoyGateway)
+.PHONY: deploy-envoy-gateway
+deploy-envoy-gateway: ## Deploy Envoy Gateway (same as e2e tests)
+	@echo "Installing Envoy Gateway"
+	@echo "Helm Install"
+	@helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm --version $(EG_VERSION) -n envoy-gateway-system --create-namespace
+	@echo "Applying Patch for Envoy Gateway"
+	@kubectl apply -f manifests/envoy-gateway-config/
+	@echo "Applying InferencePool Patch for Envoy Gateway"
+	@kubectl apply -f examples/inference-pool/config.yaml
+	@echo "Restart Envoy Gateway deployment"
+	@kubectl rollout restart -n envoy-gateway-system deployment/envoy-gateway
+	@echo "Waiting for Envoy Gateway deployment to be ready"
+	@kubectl wait --timeout=$(KUBE_WAIT_TIMEOUT) -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+	@echo "Envoy Gateway deployed successfully"
+
+# AI Gateway setup (mirrors initAIGateway)
+.PHONY: deploy-ai-gateway
+deploy-ai-gateway: ## Deploy AI Gateway (same as e2e tests)
+	@echo "Installing AI Gateway"
+	@echo "Helm Install CRDs"
+	@helm upgrade -i ai-eg-crd manifests/charts/ai-gateway-crds-helm -n $(KUBE_NAMESPACE) --create-namespace
+	@echo "Helm Install AI Gateway"
+	@helm upgrade -i ai-eg manifests/charts/ai-gateway-helm \
+		--set controller.metricsRequestHeaderLabels=x-user-id:user_id \
+		-n $(KUBE_NAMESPACE) --create-namespace
+	@echo "Restart AI Gateway controller"
+	@kubectl rollout restart -n $(KUBE_NAMESPACE) deployment/ai-gateway-controller
+	@kubectl wait --timeout=$(KUBE_WAIT_TIMEOUT) -n $(KUBE_NAMESPACE) deployment/ai-gateway-controller --for=condition=Available
+	@echo "AI Gateway deployed successfully"
+
+# Prometheus setup (mirrors initPrometheus)
+.PHONY: deploy-prometheus
+deploy-prometheus: ## Deploy Prometheus monitoring (same as e2e tests)
+	@echo "Installing Prometheus"
+	@echo "Applying manifests"
+	@kubectl apply -f examples/monitoring/monitoring.yaml
+	@echo "Waiting for deployment"
+	@kubectl wait --timeout=$(KUBE_WAIT_TIMEOUT) -n monitoring deployment/prometheus --for=condition=Available
+	@echo "Prometheus deployed successfully"
+
+# Complete deployment workflow (mirrors TestMain sequence)
+.PHONY: deploy-complete
+deploy-complete: deploy-envoy-gateway deploy-ai-gateway deploy-prometheus ## Deploy complete stack (same as e2e tests)
+
+# Development setup (build + deploy)
+.PHONY: dev-setup
+dev-setup: build create-cluster deploy-complete ## Complete development setup with local images
+
+# Deploy with local images
+.PHONY: deploy-with-local-images
+deploy-with-local-images: load-local-images deploy-complete ## Deploy with locally built images
+
+# Undeploy everything
+.PHONY: undeploy-all
+undeploy-all: ## Undeploy all components
+	@echo "Undeploying all components"
+	@kubectl delete -f examples/monitoring/monitoring.yaml --ignore-not-found || true
+	@helm uninstall ai-eg -n $(KUBE_NAMESPACE) --ignore-not-found || true
+	@helm uninstall ai-eg-crd -n $(KUBE_NAMESPACE) --ignore-not-found || true
+	@helm uninstall eg -n envoy-gateway-system --ignore-not-found || true
+	@kubectl delete namespace $(KUBE_NAMESPACE) --ignore-not-found || true
+	@kubectl delete namespace envoy-gateway-system --ignore-not-found || true
+	@kubectl delete namespace monitoring --ignore-not-found || true
+	@echo "All components undeployed successfully"
+
+# Complete cleanup
+.PHONY: dev-cleanup
+dev-cleanup: undeploy-all delete-cluster ## Complete development cleanup
+
+# Main kube-deploy target (similar to Envoy Gateway)
+.PHONY: kube-deploy
+kube-deploy: create-cluster deploy-complete ## Deploy AI Gateway to Kind cluster
+
+# Undeploy target (similar to Envoy Gateway)
+.PHONY: kube-undeploy
+kube-undeploy: undeploy-all delete-cluster ## Undeploy AI Gateway from cluster 

--- a/tools/hack/create-cluster.sh
+++ b/tools/hack/create-cluster.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Setup default values (match e2e constants)
+CLUSTER_NAME=${CLUSTER_NAME:-"envoy-ai-gateway"}
+METALLB_VERSION=${METALLB_VERSION:-"v0.13.10"}
+
+## Check if kind cluster already exists.
+if go tool kind get clusters | grep -q "${CLUSTER_NAME}"; then
+  echo "Cluster ${CLUSTER_NAME} already exists."
+else
+  echo "Creating kind cluster ${CLUSTER_NAME}"
+  # Use simple kind create (like e2e) instead of complex config
+  go tool kind create cluster --name "${CLUSTER_NAME}"
+fi
+
+# Export kubeconfig (like e2e)
+echo "Switching kubectl context to ${CLUSTER_NAME}"
+go tool kind export kubeconfig --name "${CLUSTER_NAME}"
+
+## Load Docker images into kind cluster (exactly like e2e)
+echo "Loading Docker images into kind cluster"
+for image in \
+  "docker.io/envoyproxy/ai-gateway-controller:latest" \
+  "docker.io/envoyproxy/ai-gateway-extproc:latest" \
+  "docker.io/envoyproxy/ai-gateway-testupstream:latest"; do
+  go tool kind load docker-image "${image}" --name "${CLUSTER_NAME}"
+done
+
+## Install MetalLB (exactly like e2e)
+echo "Installing MetalLB"
+echo "Applying MetalLB manifests"
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/"${METALLB_VERSION}"/config/manifests/metallb-native.yaml
+
+# Create memberlist secret if it doesn't exist (exactly like e2e)
+echo "Creating memberlist secret if needed"
+needCreate="$(kubectl get secret -n metallb-system memberlist --no-headers --ignore-not-found -o custom-columns=NAME:.metadata.name)"
+if [ -z "$needCreate" ]; then
+    kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+fi
+
+# Wait for MetalLB deployments (exactly like e2e)
+echo "Waiting for MetalLB controller deployment to be ready"
+kubectl wait --timeout=2m -n metallb-system deployment/controller --for=condition=Available
+
+echo "Waiting for MetalLB speaker daemonset to be ready"
+kubectl wait --timeout=2m -n metallb-system daemonset/speaker --for=create
+kubectl wait --timeout=2m -n metallb-system daemonset/speaker --for=jsonpath='{.status.numberReady}'=1
+
+# Configure IP address pools (simplified but matches e2e logic)
+echo "Configuring IP address pools"
+subnet_v4=$(docker network inspect kind | jq -r '.[].IPAM.Config[] | select(.Subnet | contains(":") | not) | .Subnet')
+address_prefix_v4=$(echo "${subnet_v4}" | awk -F. '{print $1"."$2"."$3}')
+address_range_v4="${address_prefix_v4}.200-${address_prefix_v4}.250"
+
+kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: kube-services
+spec:
+  addresses:
+  - ${address_range_v4}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kube-services
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - kube-services
+EOF
+
+echo "Kind cluster setup complete!" 


### PR DESCRIPTION
**Description**

Add Kubernetes deployment commands to simplify AI Gateway development workflow with Kind clusters.

**Changes**

- **New Makefile**: `Makefile.kube.mk` with Kubernetes deployment targets
- **New Script**: `tools/hack/create-cluster.sh` for Kind cluster setup (matches e2e test implementation)
- **New Commands**:
  - `make kube-deploy` - Deploy complete stack to Kind cluster
  - `make kube-undeploy` - Undeploy and delete cluster
  - `make dev-setup` - Build images and deploy complete stack
  - `make dev-cleanup` - Clean up everything

**Testing**

✅ Tested successfully:
- Kind cluster creation with MetalLB
- Envoy Gateway deployment
- AI Gateway deployment with CRDs
- Prometheus monitoring setup
- All components running and healthy

**Motivation**

Similar to **Envoy Gateway**'s approach, this provides a simple way to deploy AI Gateway for development without manual steps.