### PR TITLE
extproc: lift error status handling from translators 

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -336,26 +336,24 @@ func (c *chatCompletionProcessorUpstreamFilter) ProcessResponseBody(ctx context.
 		br = bytes.NewReader(body.Body)
 	}
 
-	if v, ok := c.responseHeaders[":status"]; ok {
-		code, _ := strconv.Atoi(v)
-		if code >= 200 && code < 300 {
-			var headerMutation *extprocv3.HeaderMutation
-			var bodyMutation *extprocv3.BodyMutation
-			headerMutation, bodyMutation, err = c.translator.ResponseError(c.responseHeaders, br)
-			if err != nil {
-				return nil, fmt.Errorf("failed to transform response error: %w", err)
-			}
-			return &extprocv3.ProcessingResponse{
-				Response: &extprocv3.ProcessingResponse_ResponseBody{
-					ResponseBody: &extprocv3.BodyResponse{
-						Response: &extprocv3.CommonResponse{
-							HeaderMutation: headerMutation,
-							BodyMutation:   bodyMutation,
-						},
+	code, _ := strconv.Atoi(c.responseHeaders[":status"]) // Assume all responses have a status code.
+	if isGoodStatusCode(code) {
+		var headerMutation *extprocv3.HeaderMutation
+		var bodyMutation *extprocv3.BodyMutation
+		headerMutation, bodyMutation, err = c.translator.ResponseError(c.responseHeaders, br)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform response error: %w", err)
+		}
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseBody{
+				ResponseBody: &extprocv3.BodyResponse{
+					Response: &extprocv3.CommonResponse{
+						HeaderMutation: headerMutation,
+						BodyMutation:   bodyMutation,
 					},
 				},
-			}, nil
-		}
+			},
+		}, nil
 	}
 
 	headerMutation, bodyMutation, tokenUsage, err := c.translator.ResponseBody(c.responseHeaders, br, body.EndOfStream)

--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -336,8 +336,8 @@ func (c *chatCompletionProcessorUpstreamFilter) ProcessResponseBody(ctx context.
 		br = bytes.NewReader(body.Body)
 	}
 
-	code, _ := strconv.Atoi(c.responseHeaders[":status"]) // Assume all responses have a status code.
-	if isGoodStatusCode(code) {
+	// Assume all responses have a valid status code header.
+	if code, _ := strconv.Atoi(c.responseHeaders[":status"]); !isGoodStatusCode(code) {
 		var headerMutation *extprocv3.HeaderMutation
 		var bodyMutation *extprocv3.BodyMutation
 		headerMutation, bodyMutation, err = c.translator.ResponseError(c.responseHeaders, br)

--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -336,6 +336,28 @@ func (c *chatCompletionProcessorUpstreamFilter) ProcessResponseBody(ctx context.
 		br = bytes.NewReader(body.Body)
 	}
 
+	if v, ok := c.responseHeaders[":status"]; ok {
+		code, _ := strconv.Atoi(v)
+		if code >= 200 && code < 300 {
+			var headerMutation *extprocv3.HeaderMutation
+			var bodyMutation *extprocv3.BodyMutation
+			headerMutation, bodyMutation, err = c.translator.ResponseError(c.responseHeaders, br)
+			if err != nil {
+				return nil, fmt.Errorf("failed to transform response error: %w", err)
+			}
+			return &extprocv3.ProcessingResponse{
+				Response: &extprocv3.ProcessingResponse_ResponseBody{
+					ResponseBody: &extprocv3.BodyResponse{
+						Response: &extprocv3.CommonResponse{
+							HeaderMutation: headerMutation,
+							BodyMutation:   bodyMutation,
+						},
+					},
+				},
+			}, nil
+		}
+	}
+
 	headerMutation, bodyMutation, tokenUsage, err := c.translator.ResponseBody(c.responseHeaders, br, body.EndOfStream)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform response: %w", err)

--- a/internal/extproc/chatcompletion_processor_test.go
+++ b/internal/extproc/chatcompletion_processor_test.go
@@ -295,6 +295,7 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 					},
 				},
 			},
+			responseHeaders:   map[string]string{":status": "200"},
 			backendName:       "some_backend",
 			modelNameOverride: "ai_gateway_llm",
 		}

--- a/internal/extproc/embeddings_processor.go
+++ b/internal/extproc/embeddings_processor.go
@@ -255,8 +255,8 @@ func (e *embeddingsProcessorUpstreamFilter) ProcessResponseBody(ctx context.Cont
 		br = bytes.NewReader(body.Body)
 	}
 
-	code, _ := strconv.Atoi(e.responseHeaders[":status"]) // Assume all responses have a status code.
-	if isGoodStatusCode(code) {
+	// Assume all responses have a valid status code header.
+	if code, _ := strconv.Atoi(e.responseHeaders[":status"]); !isGoodStatusCode(code) {
 		var headerMutation *extprocv3.HeaderMutation
 		var bodyMutation *extprocv3.BodyMutation
 		headerMutation, bodyMutation, err = e.translator.ResponseError(e.responseHeaders, br)

--- a/internal/extproc/embeddings_processor_test.go
+++ b/internal/extproc/embeddings_processor_test.go
@@ -125,8 +125,9 @@ func Test_embeddingsProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
 		mm := &mockEmbeddingsMetrics{}
 		mt := &mockEmbeddingTranslator{t: t}
 		p := &embeddingsProcessorUpstreamFilter{
-			translator: mt,
-			metrics:    mm,
+			translator:      mt,
+			metrics:         mm,
+			responseHeaders: map[string]string{":status": "200"},
 		}
 		mt.retErr = errors.New("test error")
 		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{})
@@ -170,6 +171,7 @@ func Test_embeddingsProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
 			},
 			backendName:       "some_backend",
 			modelNameOverride: "some_model",
+			responseHeaders:   map[string]string{":status": "200"},
 		}
 		res, err := p.ProcessResponseBody(t.Context(), inBody)
 		require.NoError(t, err)
@@ -193,6 +195,26 @@ func Test_embeddingsProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
 			GetStructValue().Fields["backend_name"].GetStringValue())
 		require.Equal(t, "some_model", md.Fields["ai_gateway_llm_ns"].
 			GetStructValue().Fields["model_name_override"].GetStringValue())
+	})
+
+	t.Run("error/streaming", func(t *testing.T) {
+		inBody := &extprocv3.HttpBody{Body: []byte("some-body"), EndOfStream: true}
+		mm := &mockEmbeddingsMetrics{}
+		mt := &mockEmbeddingTranslator{t: t, expResponseBody: inBody}
+		p := &embeddingsProcessorUpstreamFilter{
+			translator:        mt,
+			logger:            slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
+			metrics:           mm,
+			config:            &processorConfig{},
+			backendName:       "some_backend",
+			modelNameOverride: "some_model",
+			responseHeaders:   map[string]string{":status": "500"},
+		}
+		res, err := p.ProcessResponseBody(t.Context(), inBody)
+		require.NoError(t, err)
+		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseBody).ResponseBody.Response
+		require.NotNil(t, commonRes)
+		require.True(t, mt.responseErrorCalled)
 	})
 }
 
@@ -222,7 +244,7 @@ func Test_embeddingsProcessorUpstreamFilter_ProcessRequestHeaders(t *testing.T) 
 		someBody := embeddingBodyFromModel(t, "some-model")
 		var body openai.EmbeddingRequest
 		require.NoError(t, json.Unmarshal(someBody, &body))
-		tr := mockEmbeddingTranslator{t: t, retErr: errors.New("test error"), expRequestBody: &body}
+		tr := &mockEmbeddingTranslator{t: t, retErr: errors.New("test error"), expRequestBody: &body}
 		mm := &mockEmbeddingsMetrics{}
 		p := &embeddingsProcessorUpstreamFilter{
 			config: &processorConfig{
@@ -251,7 +273,7 @@ func Test_embeddingsProcessorUpstreamFilter_ProcessRequestHeaders(t *testing.T) 
 
 		var expBody openai.EmbeddingRequest
 		require.NoError(t, json.Unmarshal(someBody, &expBody))
-		mt := mockEmbeddingTranslator{t: t, expRequestBody: &expBody, retHeaderMutation: headerMut, retBodyMutation: bodyMut}
+		mt := &mockEmbeddingTranslator{t: t, expRequestBody: &expBody, retHeaderMutation: headerMut, retBodyMutation: bodyMut}
 		mm := &mockEmbeddingsMetrics{}
 		p := &embeddingsProcessorUpstreamFilter{
 			config:                 &processorConfig{modelNameHeaderKey: modelKey},

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -284,6 +284,11 @@ func (m mockEmbeddingTranslator) ResponseBody(_ map[string]string, body io.Reade
 	return m.retHeaderMutation, m.retBodyMutation, m.retUsedToken, m.retErr
 }
 
+// ResponseError implements [translator.OpenAIEmbeddingTranslator].
+func (m mockEmbeddingTranslator) ResponseError(map[string]string, io.Reader) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
+	return nil, nil, nil
+}
+
 // mockEmbeddingsMetrics implements [x.EmbeddingsMetrics] for testing.
 type mockEmbeddingsMetrics struct {
 	requestStart        time.Time

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -252,30 +252,31 @@ var _ metrics.ChatCompletionMetrics = &mockChatCompletionMetrics{}
 
 // mockEmbeddingTranslator implements [translator.OpenAIEmbeddingTranslator] for testing.
 type mockEmbeddingTranslator struct {
-	t                 *testing.T
-	expHeaders        map[string]string
-	expRequestBody    *openai.EmbeddingRequest
-	expResponseBody   *extprocv3.HttpBody
-	retHeaderMutation *extprocv3.HeaderMutation
-	retBodyMutation   *extprocv3.BodyMutation
-	retUsedToken      translator.LLMTokenUsage
-	retErr            error
+	t                   *testing.T
+	expHeaders          map[string]string
+	expRequestBody      *openai.EmbeddingRequest
+	expResponseBody     *extprocv3.HttpBody
+	retHeaderMutation   *extprocv3.HeaderMutation
+	retBodyMutation     *extprocv3.BodyMutation
+	retUsedToken        translator.LLMTokenUsage
+	responseErrorCalled bool
+	retErr              error
 }
 
 // RequestBody implements [translator.OpenAIEmbeddingTranslator].
-func (m mockEmbeddingTranslator) RequestBody(_ []byte, body *openai.EmbeddingRequest, _ bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
+func (m *mockEmbeddingTranslator) RequestBody(_ []byte, body *openai.EmbeddingRequest, _ bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
 	require.Equal(m.t, m.expRequestBody, body)
 	return m.retHeaderMutation, m.retBodyMutation, m.retErr
 }
 
 // ResponseHeaders implements [translator.OpenAIEmbeddingTranslator].
-func (m mockEmbeddingTranslator) ResponseHeaders(headers map[string]string) (headerMutation *extprocv3.HeaderMutation, err error) {
+func (m *mockEmbeddingTranslator) ResponseHeaders(headers map[string]string) (headerMutation *extprocv3.HeaderMutation, err error) {
 	require.Equal(m.t, m.expHeaders, headers)
 	return m.retHeaderMutation, m.retErr
 }
 
 // ResponseBody implements [translator.OpenAIEmbeddingTranslator].
-func (m mockEmbeddingTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, tokenUsage translator.LLMTokenUsage, err error) {
+func (m *mockEmbeddingTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, tokenUsage translator.LLMTokenUsage, err error) {
 	if m.expResponseBody != nil {
 		buf, err := io.ReadAll(body)
 		require.NoError(m.t, err)
@@ -285,7 +286,8 @@ func (m mockEmbeddingTranslator) ResponseBody(_ map[string]string, body io.Reade
 }
 
 // ResponseError implements [translator.OpenAIEmbeddingTranslator].
-func (m mockEmbeddingTranslator) ResponseError(map[string]string, io.Reader) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
+func (m *mockEmbeddingTranslator) ResponseError(map[string]string, io.Reader) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
+	m.responseErrorCalled = true
 	return nil, nil, nil
 }
 

--- a/internal/extproc/translator/openai_embeddings.go
+++ b/internal/extproc/translator/openai_embeddings.go
@@ -80,18 +80,9 @@ func (o *openAIToOpenAITranslatorV1Embedding) ResponseHeaders(map[string]string)
 }
 
 // ResponseBody implements [OpenAIEmbeddingTranslator.ResponseBody].
-func (o *openAIToOpenAITranslatorV1Embedding) ResponseBody(respHeaders map[string]string, body io.Reader, _ bool) (
+func (o *openAIToOpenAITranslatorV1Embedding) ResponseBody(_ map[string]string, body io.Reader, _ bool) (
 	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, tokenUsage LLMTokenUsage, err error,
 ) {
-	if v, ok := respHeaders[statusHeaderName]; ok {
-		if v, err := strconv.Atoi(v); err == nil {
-			if !isGoodStatusCode(v) {
-				headerMutation, bodyMutation, err = o.ResponseError(respHeaders, body)
-				return headerMutation, bodyMutation, LLMTokenUsage{}, err
-			}
-		}
-	}
-
 	var resp openai.EmbeddingResponse
 	if err := json.NewDecoder(body).Decode(&resp); err != nil {
 		return nil, nil, tokenUsage, fmt.Errorf("failed to unmarshal body: %w", err)

--- a/internal/extproc/translator/openai_gcpvertexai_test.go
+++ b/internal/extproc/translator/openai_gcpvertexai_test.go
@@ -712,7 +712,6 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_StreamingResponseBody(t *
 	gcpChunk := `{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"finishReason":"STOP"}]}`
 
 	headerMut, bodyMut, tokenUsage, err := translator.handleStreamingResponse(
-		map[string]string{},
 		bytes.NewReader([]byte(gcpChunk)),
 		false,
 	)
@@ -737,7 +736,6 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_StreamingEndOfStream(t *t
 
 	// Test end of stream marker.
 	_, bodyMut, _, err := translator.handleStreamingResponse(
-		map[string]string{},
 		bytes.NewReader([]byte("")),
 		true,
 	)

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -81,7 +81,7 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(raw []byte, req *
 	return
 }
 
-// ResponseError implements [Translator.ResponseError]
+// ResponseError implements [OpenAIChatCompletionTranslator.ResponseError]
 // For OpenAI based backend we return the OpenAI error type as is.
 // If connection fails the error body is translated to OpenAI error type for events such as HTTP 503 or 504.
 func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseError(respHeaders map[string]string, body io.Reader) (
@@ -114,23 +114,15 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseError(respHeaders map
 	return nil, nil, nil
 }
 
-// ResponseHeaders implements [Translator.ResponseHeaders].
+// ResponseHeaders implements [OpenAIChatCompletionTranslator.ResponseHeaders].
 func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseHeaders(map[string]string) (headerMutation *extprocv3.HeaderMutation, err error) {
 	return nil, nil
 }
 
-// ResponseBody implements [Translator.ResponseBody].
-func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseBody(respHeaders map[string]string, body io.Reader, _ bool) (
+// ResponseBody implements [OpenAIChatCompletionTranslator.ResponseBody].
+func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseBody(_ map[string]string, body io.Reader, _ bool) (
 	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, tokenUsage LLMTokenUsage, err error,
 ) {
-	if v, ok := respHeaders[statusHeaderName]; ok {
-		if v, err := strconv.Atoi(v); err == nil {
-			if !isGoodStatusCode(v) {
-				headerMutation, bodyMutation, err = o.ResponseError(respHeaders, body)
-				return headerMutation, bodyMutation, LLMTokenUsage{}, err
-			}
-		}
-	}
 	if o.stream {
 		if !o.bufferingDone {
 			buf, err := io.ReadAll(body)

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -25,13 +25,6 @@ const (
 	awsBedrockBackendError = "AWSBedrockBackendError"
 )
 
-// isGoodStatusCode checks if the HTTP status code of the upstream response is successful.
-// The 2xx - Successful: The request is received by upstream and processed successfully.
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses
-func isGoodStatusCode(code int) bool {
-	return code >= 200 && code < 300
-}
-
 // OpenAIChatCompletionTranslator translates the request and response messages between the client and the backend API schemas
 // for /v1/chat/completion endpoint of OpenAI.
 //
@@ -66,6 +59,11 @@ type OpenAIChatCompletionTranslator interface {
 		tokenUsage LLMTokenUsage,
 		err error,
 	)
+
+	// ResponseError translates the response error. This is called when the upstream response status code is not successful (2xx).
+	// 	- `respHeaders` is the response headers.
+	// 	- `body` is the response body that contains the error message.
+	ResponseError(respHeaders map[string]string, body io.Reader) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error)
 }
 
 func setContentLength(headers *extprocv3.HeaderMutation, body []byte) {
@@ -111,6 +109,11 @@ type OpenAIEmbeddingTranslator interface {
 		tokenUsage LLMTokenUsage,
 		err error,
 	)
+
+	// ResponseError translates the response error. This is called when the upstream response status code is not successful (2xx).
+	// 	- `respHeaders` is the response headers.
+	// 	- `body` is the response body that contains the error message.
+	ResponseError(respHeaders map[string]string, body io.Reader) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error)
 }
 
 // LLMTokenUsage represents the token usage reported usually by the backend API in the response body.

--- a/internal/extproc/translator/translator_test.go
+++ b/internal/extproc/translator/translator_test.go
@@ -12,15 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsGoodStatusCode(t *testing.T) {
-	for _, s := range []int{200, 201, 299} {
-		require.True(t, isGoodStatusCode(s))
-	}
-	for _, s := range []int{100, 300, 400, 500} {
-		require.False(t, isGoodStatusCode(s))
-	}
-}
-
 func TestSetContentLength(t *testing.T) {
 	hm := &extprocv3.HeaderMutation{}
 	setContentLength(hm, nil)

--- a/internal/extproc/util.go
+++ b/internal/extproc/util.go
@@ -1,0 +1,13 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+// isGoodStatusCode checks if the HTTP status code of the upstream response is successful.
+// The 2xx - Successful: The request is received by upstream and processed successfully.
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses
+func isGoodStatusCode(code int) bool {
+	return code >= 200 && code < 300
+}

--- a/internal/extproc/util_test.go
+++ b/internal/extproc/util_test.go
@@ -1,0 +1,21 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGoodStatusCode(t *testing.T) {
+	for _, s := range []int{200, 201, 299} {
+		require.True(t, isGoodStatusCode(s))
+	}
+	for _, s := range []int{100, 300, 400, 500} {
+		require.False(t, isGoodStatusCode(s))
+	}
+}


### PR DESCRIPTION
**Description**


This lifts the error status code from each translators into the processors level so that we could share the same logic and won't need to copy paste anymore.