### PR TITLE
test: updates CRDs used in envtest

### DIFF
--- a/tests/internal/envtest.go
+++ b/tests/internal/envtest.go
@@ -48,8 +48,8 @@ func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.I
 	t.Setenv("KUBEBUILDER_ASSETS", string(output))
 
 	const (
-		egURLBase    = "https://raw.githubusercontent.com/envoyproxy/gateway/refs/tags/v1.3.0/charts/gateway-helm/crds/generated/"
-		gwAPIURLBase = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/tags/v1.2.1/config/crd/standard/"
+		egURLBase    = "https://raw.githubusercontent.com/envoyproxy/gateway/refs/tags/v1.5.0-rc.2/charts/gateway-helm/crds/generated/"
+		gwAPIURLBase = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/tags/v1.3.0/config/crd/standard/"
 	)
 	for _, url := range []string{
 		egURLBase + "gateway.envoyproxy.io_envoyextensionpolicies.yaml",
@@ -61,7 +61,7 @@ func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.I
 		crds = append(crds, requireThirdPartyCRDDownloaded(t, path, url))
 	}
 
-	const infExtURL = "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v0.2.0/manifests.yaml"
+	const infExtURL = "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v0.5.1/manifests.yaml"
 	crds = append(crds, requireThirdPartyCRDDownloaded(t, "inference_extension_for_tests.yaml", infExtURL))
 
 	env := &envtest.Environment{CRDDirectoryPaths: crds}

--- a/tests/internal/envtest.go
+++ b/tests/internal/envtest.go
@@ -7,7 +7,6 @@ package testsinternal
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,23 +46,7 @@ func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.I
 	t.Logf("Using envtest assets from %s", string(output))
 	t.Setenv("KUBEBUILDER_ASSETS", string(output))
 
-	const (
-		egURLBase    = "https://raw.githubusercontent.com/envoyproxy/gateway/refs/tags/v1.5.0-rc.2/charts/gateway-helm/crds/generated/"
-		gwAPIURLBase = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/tags/v1.3.0/config/crd/standard/"
-	)
-	for _, url := range []string{
-		egURLBase + "gateway.envoyproxy.io_envoyextensionpolicies.yaml",
-		egURLBase + "gateway.envoyproxy.io_httproutefilters.yaml",
-		gwAPIURLBase + "gateway.networking.k8s.io_httproutes.yaml",
-		gwAPIURLBase + "gateway.networking.k8s.io_gateways.yaml",
-	} {
-		path := filepath.Base(url) + "_for_tests.yaml"
-		crds = append(crds, requireThirdPartyCRDDownloaded(t, path, url))
-	}
-
-	const infExtURL = "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v0.5.1/manifests.yaml"
-	crds = append(crds, requireThirdPartyCRDDownloaded(t, "inference_extension_for_tests.yaml", infExtURL))
-
+	crds = append(crds, requireThirdPartyCRDDownloaded(t))
 	env := &envtest.Environment{CRDDirectoryPaths: crds}
 	cfg, err = env.Start()
 	require.NoError(t, err)
@@ -79,22 +62,24 @@ func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.I
 	return c, cfg, k
 }
 
-// requireThirdPartyCRDDownloaded downloads the CRD from the given URL if it does not exist at the given path.
-// It returns the path to the CRD as-is to make it easier to use in the caller.
-func requireThirdPartyCRDDownloaded(t *testing.T, path, url string) string {
+// requireThirdPartyCRDDownloaded downloads the CRD from the Envoy Gateway Helm chart if it does not exist,
+// including the compatible GWAPI CRDs.
+func requireThirdPartyCRDDownloaded(t *testing.T) string {
+	const path = "3rd_party_crds_for_tests.yaml"
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		var crd *http.Response
-		crd, err = http.DefaultClient.Get(url)
-		require.NoError(t, err)
+		f, err := os.Create(path)
 		defer func() {
-			_ = crd.Body.Close()
+			_ = f.Close()
 		}()
-		require.Equal(t, http.StatusOK, crd.StatusCode)
-		var body *os.File
-		body, err = os.Create(path)
-		require.NoError(t, err)
-		_, err = body.ReadFrom(crd.Body)
-		require.NoError(t, err)
+
+		helm := exec.Command(
+			"go", "tool", "helm", "show", "crds", "oci://docker.io/envoyproxy/gateway-helm",
+			"--version", "1.5.0-rc.2",
+		)
+		helm.Stdout = f
+		helm.Stderr = os.Stderr
+		err = helm.Run()
+		require.NoError(t, err, "Failed to download third-party CRD")
 	} else if err != nil {
 		panic(fmt.Sprintf("Failed to check if CRD exists: %v", err))
 	}

--- a/tests/internal/envtest.go
+++ b/tests/internal/envtest.go
@@ -86,11 +86,12 @@ func requireThirdPartyCRDDownloaded(t *testing.T, path, url string) string {
 		var crd *http.Response
 		crd, err = http.DefaultClient.Get(url)
 		require.NoError(t, err)
-		var body *os.File
-		body, err = os.Create(path)
 		defer func() {
 			_ = crd.Body.Close()
 		}()
+		require.Equal(t, http.StatusOK, crd.StatusCode)
+		var body *os.File
+		body, err = os.Create(path)
 		require.NoError(t, err)
 		_, err = body.ReadFrom(crd.Body)
 		require.NoError(t, err)

--- a/tests/internal/envtest.go
+++ b/tests/internal/envtest.go
@@ -67,10 +67,12 @@ func NewEnvTest(t *testing.T) (c client.Client, cfg *rest.Config, k kubernetes.I
 func requireThirdPartyCRDDownloaded(t *testing.T) string {
 	const path = "3rd_party_crds_for_tests.yaml"
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		f, err := os.Create(path)
+		var f *os.File
+		f, err = os.Create(path)
 		defer func() {
 			_ = f.Close()
 		}()
+		require.NoError(t, err, "Failed to create file for third-party CRD")
 
 		helm := exec.Command(
 			"go", "tool", "helm", "show", "crds", "oci://docker.io/envoyproxy/gateway-helm",


### PR DESCRIPTION
**Description**

This switches to use CRDs from EG's Chart to avoid manually maintaining GWAPI version as well as manually list necessary components.
