### PR TITLE
api: removes obsolete comment on AIGatewayRoute

### DIFF
--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -22,7 +22,7 @@ import (
 //   - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
 //     The name of the HTTPRoute is the same as the AIGatewayRoute.
 //   - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
-//     The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
+//     The name of the HTTPRouteFilter is `ai-eg-host-rewrite-${AIGatewayRoute.Name}`.
 //
 // All of these resources are created in the same namespace as the AIGatewayRoute. Note that this is the implementation
 // detail subject to change. If you want to customize the default behavior of the Envoy AI Gateway, you can use these

--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -21,8 +21,6 @@ import (
 //
 //   - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
 //     The name of the HTTPRoute is the same as the AIGatewayRoute.
-//   - EnvoyExtensionPolicy of the Envoy Gateway API to attach the AI Gateway filter into the target Gateways.
-//     This will be created per Gateway, and its name is `ai-eg-eep-${gateway-name}`.
 //   - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
 //     The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
 //

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -37,7 +37,7 @@ spec:
             - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
               The name of the HTTPRoute is the same as the AIGatewayRoute.
             - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
-              The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
+              The name of the HTTPRouteFilter is `ai-eg-host-rewrite-${AIGatewayRoute.Name}`.
 
           All of these resources are created in the same namespace as the AIGatewayRoute. Note that this is the implementation
           detail subject to change. If you want to customize the default behavior of the Envoy AI Gateway, you can use these

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -36,8 +36,6 @@ spec:
 
             - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
               The name of the HTTPRoute is the same as the AIGatewayRoute.
-            - EnvoyExtensionPolicy of the Envoy Gateway API to attach the AI Gateway filter into the target Gateways.
-              This will be created per Gateway, and its name is `ai-eg-eep-${gateway-name}`.
             - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
               The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
 

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -37,7 +37,7 @@ spec:
             - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
               The name of the HTTPRoute is the same as the AIGatewayRoute.
             - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
-              The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
+              The name of the HTTPRouteFilter is `ai-eg-host-rewrite-${AIGatewayRoute.Name}`.
 
           All of these resources are created in the same namespace as the AIGatewayRoute. Note that this is the implementation
           detail subject to change. If you want to customize the default behavior of the Envoy AI Gateway, you can use these

--- a/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-helm/crds/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -36,8 +36,6 @@ spec:
 
             - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
               The name of the HTTPRoute is the same as the AIGatewayRoute.
-            - EnvoyExtensionPolicy of the Envoy Gateway API to attach the AI Gateway filter into the target Gateways.
-              This will be created per Gateway, and its name is `ai-eg-eep-${gateway-name}`.
             - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
               The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
 

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -40,7 +40,7 @@ Envoy AI Gateway will generate the following k8s resources corresponding to the 
   - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
     The name of the HTTPRoute is the same as the AIGatewayRoute.
   - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
-    The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
+    The name of the HTTPRouteFilter is `ai-eg-host-rewrite-${AIGatewayRoute.Name}`.
 
 All of these resources are created in the same namespace as the AIGatewayRoute. Note that this is the implementation
 detail subject to change. If you want to customize the default behavior of the Envoy AI Gateway, you can use these

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -39,8 +39,6 @@ Envoy AI Gateway will generate the following k8s resources corresponding to the 
 
   - HTTPRoute of the Gateway API as a top-level resource to bind all backends.
     The name of the HTTPRoute is the same as the AIGatewayRoute.
-  - EnvoyExtensionPolicy of the Envoy Gateway API to attach the AI Gateway filter into the target Gateways.
-    This will be created per Gateway, and its name is `ai-eg-eep-${gateway-name}`.
   - HTTPRouteFilter of the Envoy Gateway API per namespace for automatic hostname rewrite.
     The name of the HTTPRouteFilter is `ai-eg-host-rewrite`.
 


### PR DESCRIPTION
**Description**

This updates the documentation on AIGatewayRoute to reflect the correct information. Notably, EnvoyExtensionPolicy is no longer generated.