### PR TITLE
extproc: fixes modelNameOverride + forced stream_options

### DIFF
--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -137,10 +137,7 @@ func (c *chatCompletionProcessorRouterFilter) ProcessRequestBody(ctx context.Con
 		body.StreamOptions = &openai.StreamOptions{IncludeUsage: true}
 		// Rewrite the original bytes to include the stream_options.include_usage=true so that forcing the request body
 		// mutation, which uses this raw body, will also result in the stream_options.include_usage=true.
-		rawBody.Body, err = sjson.SetBytesOptions(rawBody.Body, "stream_options.include_usage", true, &sjson.Options{
-			Optimistic:     true,
-			ReplaceInPlace: true,
-		})
+		rawBody.Body, err = sjson.SetBytesOptions(rawBody.Body, "stream_options.include_usage", true, translator.SJSONOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set stream_options: %w", err)
 		}

--- a/internal/extproc/chatcompletion_processor.go
+++ b/internal/extproc/chatcompletion_processor.go
@@ -137,7 +137,10 @@ func (c *chatCompletionProcessorRouterFilter) ProcessRequestBody(ctx context.Con
 		body.StreamOptions = &openai.StreamOptions{IncludeUsage: true}
 		// Rewrite the original bytes to include the stream_options.include_usage=true so that forcing the request body
 		// mutation, which uses this raw body, will also result in the stream_options.include_usage=true.
-		rawBody.Body, err = sjson.SetBytesOptions(rawBody.Body, "stream_options.include_usage", true, &sjson.Options{})
+		rawBody.Body, err = sjson.SetBytesOptions(rawBody.Body, "stream_options.include_usage", true, &sjson.Options{
+			Optimistic:     true,
+			ReplaceInPlace: true,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to set stream_options: %w", err)
 		}

--- a/internal/extproc/translator/openai_embeddings.go
+++ b/internal/extproc/translator/openai_embeddings.go
@@ -32,17 +32,16 @@ type openAIToOpenAITranslatorV1Embedding struct {
 }
 
 // RequestBody implements [OpenAIEmbeddingTranslator.RequestBody].
-func (o *openAIToOpenAITranslatorV1Embedding) RequestBody(raw []byte, _ *openai.EmbeddingRequest, onRetry bool) (
+func (o *openAIToOpenAITranslatorV1Embedding) RequestBody(original []byte, _ *openai.EmbeddingRequest, onRetry bool) (
 	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error,
 ) {
 	var newBody []byte
 	if o.modelNameOverride != "" {
 		// If modelName is set we override the model to be used for the request.
-		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, SJSONOptions)
+		newBody, err = sjson.SetBytesOptions(original, "model", o.modelNameOverride, SJSONOptions)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
 		}
-		newBody = raw
 	}
 
 	// Always set the path header to the embeddings endpoint so that the request is routed correctly.
@@ -55,8 +54,8 @@ func (o *openAIToOpenAITranslatorV1Embedding) RequestBody(raw []byte, _ *openai.
 		},
 	}
 
-	if onRetry {
-		newBody = raw
+	if onRetry && len(newBody) == 0 {
+		newBody = original
 	}
 
 	if len(newBody) > 0 {

--- a/internal/extproc/translator/openai_embeddings.go
+++ b/internal/extproc/translator/openai_embeddings.go
@@ -38,10 +38,7 @@ func (o *openAIToOpenAITranslatorV1Embedding) RequestBody(raw []byte, _ *openai.
 	var newBody []byte
 	if o.modelNameOverride != "" {
 		// If modelName is set we override the model to be used for the request.
-		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, &sjson.Options{
-			Optimistic:     true,
-			ReplaceInPlace: true,
-		})
+		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, SJSONOptions)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
 		}

--- a/internal/extproc/translator/openai_embeddings.go
+++ b/internal/extproc/translator/openai_embeddings.go
@@ -38,14 +38,14 @@ func (o *openAIToOpenAITranslatorV1Embedding) RequestBody(raw []byte, _ *openai.
 	var newBody []byte
 	if o.modelNameOverride != "" {
 		// If modelName is set we override the model to be used for the request.
-		out, err := sjson.SetBytesOptions(raw, "model", o.modelNameOverride, &sjson.Options{
+		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, &sjson.Options{
 			Optimistic:     true,
 			ReplaceInPlace: true,
 		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
 		}
-		newBody = out
+		newBody = raw
 	}
 
 	// Always set the path header to the embeddings endpoint so that the request is routed correctly.

--- a/internal/extproc/translator/openai_embeddings_test.go
+++ b/internal/extproc/translator/openai_embeddings_test.go
@@ -39,6 +39,13 @@ func TestOpenAIToOpenAITranslatorV1EmbeddingRequestBody(t *testing.T) {
 			onRetry: true,
 			expPath: "/v1/embeddings",
 		},
+		{
+			name:              "model_name_override",
+			modelNameOverride: "custom-embedding-model",
+			onRetry:           true,
+			expPath:           "/v1/embeddings",
+			expBodyContains:   `"model":"custom-embedding-model"`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			translator := NewEmbeddingOpenAIToOpenAITranslator("v1", tc.modelNameOverride)

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -36,7 +36,7 @@ type openAIToOpenAITranslatorV1ChatCompletion struct {
 }
 
 // RequestBody implements [OpenAIChatCompletionTranslator.RequestBody].
-func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(raw []byte, req *openai.ChatCompletionRequest, forceBodyMutation bool) (
+func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(original []byte, req *openai.ChatCompletionRequest, forceBodyMutation bool) (
 	headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error,
 ) {
 	if req.Stream {
@@ -45,11 +45,10 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(raw []byte, req *
 	var newBody []byte
 	if o.modelNameOverride != "" {
 		// If modelName is set we override the model to be used for the request.
-		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, SJSONOptions)
+		newBody, err = sjson.SetBytesOptions(original, "model", o.modelNameOverride, SJSONOptions)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
 		}
-		newBody = raw
 	}
 
 	// Always set the path header to the chat completions endpoint so that the request is routed correctly.
@@ -62,8 +61,8 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(raw []byte, req *
 		},
 	}
 
-	if forceBodyMutation {
-		newBody = raw
+	if forceBodyMutation && len(newBody) == 0 {
+		newBody = original
 	}
 
 	if len(newBody) > 0 {

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -45,10 +45,7 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(raw []byte, req *
 	var newBody []byte
 	if o.modelNameOverride != "" {
 		// If modelName is set we override the model to be used for the request.
-		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, &sjson.Options{
-			Optimistic:     true,
-			ReplaceInPlace: true,
-		})
+		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, SJSONOptions)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
 		}

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -45,14 +45,14 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) RequestBody(raw []byte, req *
 	var newBody []byte
 	if o.modelNameOverride != "" {
 		// If modelName is set we override the model to be used for the request.
-		out, err := sjson.SetBytesOptions(raw, "model", o.modelNameOverride, &sjson.Options{
+		raw, err = sjson.SetBytesOptions(raw, "model", o.modelNameOverride, &sjson.Options{
 			Optimistic:     true,
 			ReplaceInPlace: true,
 		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
 		}
-		newBody = out
+		newBody = raw
 	}
 
 	// Always set the path header to the chat completions endpoint so that the request is routed correctly.

--- a/internal/extproc/translator/openai_openai_test.go
+++ b/internal/extproc/translator/openai_openai_test.go
@@ -40,24 +40,42 @@ func TestOpenAIToOpenAITranslatorV1ChatCompletionRequestBody(t *testing.T) {
 		}
 	})
 	t.Run("model name override", func(t *testing.T) {
-		originalReq := &openai.ChatCompletionRequest{Model: "gpt-4o-mini", Stream: false}
-		var newReq openai.ChatCompletionRequest
-		rawReq, err := json.Marshal(originalReq)
+		for _, forcedMutation := range []bool{true, false} {
+			originalReq := &openai.ChatCompletionRequest{Model: "gpt-4o-mini", Stream: false}
+			rawReq, err := json.Marshal(originalReq)
+			require.NoError(t, err)
+			modelName := "gpt-4o-mini-2024-07-18" // Example model name override.
+			o := &openAIToOpenAITranslatorV1ChatCompletion{modelNameOverride: modelName, path: "/v1/chat/completions"}
+			hm, bm, err := o.RequestBody(rawReq, originalReq, forcedMutation)
+			require.NoError(t, err)
+			require.NotNil(t, bm)
+			var newReq openai.ChatCompletionRequest
+			err = json.Unmarshal(bm.Mutation.(*extprocv3.BodyMutation_Body).Body, &newReq)
+			require.NoError(t, err)
+			require.Equal(t, modelName, newReq.Model)
+			require.NotNil(t, hm)
+			require.Len(t, hm.SetHeaders, 2)
+			require.Equal(t, ":path", hm.SetHeaders[0].Header.Key)
+			require.Equal(t, o.path, string(hm.SetHeaders[0].Header.RawValue))
+			require.Equal(t, "content-length", hm.SetHeaders[1].Header.Key)
+			require.Equal(t, strconv.Itoa(len(bm.Mutation.(*extprocv3.BodyMutation_Body).Body)), string(hm.SetHeaders[1].Header.RawValue))
+		}
+	})
+	t.Run("forced mutation", func(t *testing.T) {
+		originalReq := &openai.ChatCompletionRequest{Model: "foo-bar-ai", Stream: true}
+		original := []byte("whatever")
+		o := NewChatCompletionOpenAIToOpenAITranslator("foo/v1", "").(*openAIToOpenAITranslatorV1ChatCompletion)
+		hm, bm, err := o.RequestBody(original, originalReq, true)
 		require.NoError(t, err)
-		modelName := "gpt-4o-mini-2024-07-18" // Example model name override.
-		o := &openAIToOpenAITranslatorV1ChatCompletion{modelNameOverride: modelName, path: "/v1/chat/completions"}
-		hm, bm, err := o.RequestBody(rawReq, originalReq, false)
-		require.NoError(t, err)
+		require.True(t, o.stream)
 		require.NotNil(t, bm)
-		err = json.Unmarshal(bm.Mutation.(*extprocv3.BodyMutation_Body).Body, &newReq)
-		require.NoError(t, err)
-		require.Equal(t, modelName, newReq.Model)
 		require.NotNil(t, hm)
 		require.Len(t, hm.SetHeaders, 2)
 		require.Equal(t, ":path", hm.SetHeaders[0].Header.Key)
 		require.Equal(t, o.path, string(hm.SetHeaders[0].Header.RawValue))
 		require.Equal(t, "content-length", hm.SetHeaders[1].Header.Key)
 		require.Equal(t, strconv.Itoa(len(bm.Mutation.(*extprocv3.BodyMutation_Body).Body)), string(hm.SetHeaders[1].Header.RawValue))
+		require.Len(t, bm.Mutation.(*extprocv3.BodyMutation_Body).Body, len(original))
 	})
 }
 

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -7,11 +7,11 @@ package translator
 
 import (
 	"fmt"
-	"github.com/tidwall/sjson"
 	"io"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 )

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -7,6 +7,7 @@ package translator
 
 import (
 	"fmt"
+	"github.com/tidwall/sjson"
 	"io"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -124,4 +125,11 @@ type LLMTokenUsage struct {
 	OutputTokens uint32
 	// TotalTokens is the total number of tokens consumed.
 	TotalTokens uint32
+}
+
+// SJSONOptions are the options used for sjson operations in the translator.
+// This is also used outside the package to share the same options for consistency.
+var SJSONOptions = &sjson.Options{
+	Optimistic:     true,
+	ReplaceInPlace: true,
 }

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -326,6 +326,52 @@ data: [DONE]
 `,
 		},
 		{
+			name:           "openai - /v1/chat/completions - streaming - forced to include usage with model override",
+			backend:        "modelname-override",
+			path:           "/v1/chat/completions",
+			responseType:   "sse",
+			method:         http.MethodPost,
+			requestBody:    `{"model":"requested-model","messages":[{"role":"system","content":"You are a chatbot."}], "stream": true, "stream_options": {"include_usage": false}}`,
+			expRequestBody: `{"model":"override-model","messages":[{"role":"system","content":"You are a chatbot."}], "stream": true, "stream_options": {"include_usage": true}}`,
+			expPath:        "/v1/chat/completions",
+			responseBody: `
+{"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":13,"completion_tokens":12,"total_tokens":25,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+[DONE]
+`,
+			expStatus: http.StatusOK,
+			expResponseBody: `data: {"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":13,"completion_tokens":12,"total_tokens":25,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+data: [DONE]
+
+`,
+		},
+		{
+			name:           "openai - /v1/chat/completions - streaming - forced to include usage without steam_options with model override",
+			backend:        "modelname-override",
+			path:           "/v1/chat/completions",
+			responseType:   "sse",
+			method:         http.MethodPost,
+			requestBody:    `{"model":"requested-model","messages":[{"role":"system","content":"You are a chatbot."}], "stream": true}`,
+			expRequestBody: `{"model":"override-model","messages":[{"role":"system","content":"You are a chatbot."}], "stream": true,"stream_options":{"include_usage":true}}`,
+			expPath:        "/v1/chat/completions",
+			responseBody: `
+{"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+{"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":13,"completion_tokens":12,"total_tokens":25,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+[DONE]
+`,
+			expStatus: http.StatusOK,
+			expResponseBody: `data: {"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-foo","object":"chat.completion.chunk","created":1731618222,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":13,"completion_tokens":12,"total_tokens":25,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+data: [DONE]
+
+`,
+		},
+		{
 			name:           "gcp-vertexai - /v1/chat/completions - streaming",
 			backend:        "gcp-vertexai",
 			path:           "/v1/chat/completions",

--- a/tests/internal/testenvironment/test_environment.go
+++ b/tests/internal/testenvironment/test_environment.go
@@ -40,6 +40,7 @@ func (e *TestEnvironment) LogOutput(t *testing.T) {
 	t.Logf("=== Envoy Stdout ===\n%s", e.envoyStdout.String())
 	t.Logf("=== Envoy Stderr ===\n%s", e.envoyStderr.String())
 	t.Logf("=== ExtProc Output (stdout + stderr) ===\n%s", e.extprocOut.String())
+	t.Logf("=== Upstream Output ===\n%s", e.upstreamOut.String())
 	// TODO: dump extproc and envoy metrics.
 }
 


### PR DESCRIPTION
**Description**

There was a bug in the translation of OpenAI->OpenAI layer where the body mutation is broken when forceBodyMutation = true. forceBodyMutation becomes true when stream_options is not present in the original body and we lacked the test case for it. 

**Related Issues/PRs (if applicable)**

Closes #1017