### PR TITLE
Fix numAttemptsPerPriority in  provider-fallback.md

### DIFF
--- a/site/docs/capabilities/traffic/provider-fallback.md
+++ b/site/docs/capabilities/traffic/provider-fallback.md
@@ -91,6 +91,9 @@ spec:
       kind: HTTPRoute
       name: provider-fallback # HTTPRoute is created with the same name as AIGatewayRoute
   retry:
+    # This ensures that only one attempt is made per priority.
+    # For example, if the primary backend fails, it will not retry on the same backend.
+    numAttemptsPerPriority: 1
     numRetries: 5
     perRetry:
       backOff:
@@ -98,9 +101,7 @@ spec:
         maxInterval: 10s
       timeout: 30s
     retryOn:
-      # This ensures that only one attempt is made per priority.
-      # For example, if the primary backend fails, it will not retry on the same backend.
-      numAttemptsPerPriority: 1
+      
       httpStatusCodes:
         - 500
       triggers:


### PR DESCRIPTION
**Description**

Fix  numPerAttemptPriority per https://github.com/envoyproxy/gateway/blob/main/api/v1alpha1/retry_types.go#L13-L38

**Related Issues/PRs (if applicable)**
#881 


**Special notes for reviewers (if applicable)**
After fix the position of `numAttemptsPerPriority` still get error

`Error from server (BadRequest): error when creating "STDIN": BackendTrafficPolicy in version "v1alpha1" cannot be handled as a BackendTrafficPolicy: strict decoding error: unknown field "spec.retry.numAttemptsPerPriority`
