### PR TITLE
chore: group all dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: site
     schedule:
       interval: weekly
+    groups:
+      node:
+        patterns:
+          - "*"
 
   - package-ecosystem: gomod
     directories:
@@ -16,15 +20,8 @@ updates:
     schedule:
       interval: weekly
     groups:
-      k8s.io:
+      go:
         patterns:
-          - "k8s.io/*"
-      golang.org:
-        patterns:
-          - "golang.org/*"
-      react:
-        patterns:
-          - "react"
-          - "react-*"
+          - "*"
     ignore:
       - dependency-name: "github.com/envoyproxy/gateway"


### PR DESCRIPTION
**Description**

I noticed that the commit history of the repository is confusing due to a large number of dependabot PRs. We also see many cancelled CI runs show up as red x's, which isn't necessarily a problem but just something.

I couldn't think of a reason to group only `k8s.io` and `golang.org` and not group any other dependencies - they'll all be merged anyways. So this proposes grouping them all so you have one PR for Go and one PR for node per dependabot run.

If this is not desired, I can rework this to at least just a bugfix of the react grouping, which currently doesn't do anything since it's under `gomod` instead of `npm` block