### PR TITLE
fix: correct phoenix docs by defaulting to postgresql

### DIFF
--- a/site/docs/capabilities/observability/tracing.md
+++ b/site/docs/capabilities/observability/tracing.md
@@ -34,11 +34,9 @@ installing Envoy Gateway and AI Gateway.
 ### Install Phoenix for LLM observability
 
 ```shell
-# Install Phoenix using SQLite
+# Install Phoenix using PostgreSQL storage.
 helm install phoenix oci://registry-1.docker.io/arizephoenix/phoenix-helm \
   --namespace envoy-ai-gateway-system \
-  --set postgresql.enabled=false \
-  --set persistence.enabled=true \
   --set auth.enableAuth=false \
   --set server.port=6006
 ```


### PR DESCRIPTION
**Description**

This corrects the Phoenix instructions to use the default storage PostgreSQL. Most users will have a StorageClass available in their cluster, so won't fail.

**Related Issues/PRs (if applicable)**

Fixes #1070
