### PR TITLE
cli: fixes race during config writes on pre-startup

### DIFF
--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -122,6 +122,7 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 	udsPath := filepath.Join(tmpdir, "uds.sock")
 	_ = os.Remove(udsPath)
 
+	// Do the translation of the given AI Gateway resources Yaml into Envoy Gateway resources and write them to the file.
 	resourcesBuf := &bytes.Buffer{}
 	runCtx := &runCmdContext{envoyGatewayResourcesOut: resourcesBuf, stderrLogger: stderrLogger, udsPath: udsPath, tmpdir: tmpdir, isDebug: c.Debug}
 	// Use the default configuration if the path is not given.

--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -100,7 +100,10 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 		return fmt.Errorf("failed to execute certgen: %w: %s", err, certGenOut.String())
 	}
 
-	tmpdir := os.TempDir()
+	tmpdir := filepath.Join(os.TempDir(), "aigw-run")
+	if err := recreateDir(tmpdir); err != nil {
+		return fmt.Errorf("failed to create temporary directory %s: %w", tmpdir, err)
+	}
 	egConfigPath := filepath.Join(tmpdir, "envoy-gateway-config.yaml")      // 1. The path to the Envoy Gateway config.
 	resourcesTmpdir := filepath.Join(tmpdir, "/envoy-ai-gateway-resources") // 2. The path to the resources.
 	if err := recreateDir(resourcesTmpdir); err != nil {


### PR DESCRIPTION
**Description**

Previously, there was a slight possibility that the config writes are not flushed by the time when EG starts running. This fixes it.

**Related Issues/PRs (if applicable)**
Closes #1059