### PR TITLE
docs: workaround for aigw CLI installation

### DIFF
--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -9,7 +9,7 @@ To install the `aigw` CLI, run the following command (This may take a while):
 
 ```shell
 git clone https://github.com/envoyproxy/ai-gateway.git
-go install ./cmd/aigw@main
+go install ./cmd/aigw
 ```
 
 :::tip

--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -8,7 +8,8 @@ sidebar_position: 1
 To install the `aigw` CLI, run the following command (This may take a while):
 
 ```shell
-go install github.com/envoyproxy/ai-gateway/cmd/aigw@main
+git clone https://github.com/envoyproxy/ai-gateway.git
+go install ./cmd/aigw@main
 ```
 
 :::tip
@@ -19,6 +20,9 @@ For example, you can add the following line to your shell profile (e.g., `~/.bas
 ```sh
 export PATH=$PATH:$(go env GOPATH)/bin
 ```
+
+
+Also, `git clone` part is a workaround for the issue with `go install`. See the issue [#1064](https://github.com/envoyproxy/ai-gateway/issues/1064) for details.
 :::
 
 Now, you can check if the installation was successful by running the following command:


### PR DESCRIPTION
**Description**

Currently, our go.mod has replace statements due to the very complex dependency resolution for otelgrpc package. Unfortunately, it causes the problem with go install command which cannot support the module with replace statements. https://github.com/golang/go/issues/44840

This adds a workaround for it temporarily for v0.3. We hope we can resolve the issue by v0.4.

**Related Issues/PRs (if applicable)**

Workaround for https://github.com/envoyproxy/ai-gateway/issues/1064
