### PR TITLE
chore: fixes codecov exclusion on examples

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,7 +13,7 @@ coverage:
         if_ci_failed: error
 ignore:
   - "cmd"
-  - "examples"
+  - "examples/**/*"
   - "**/*.pb.go"
   - "**/zz_generated.*.go"
   - "tests/internal/envtest.go"


### PR DESCRIPTION
**Description**
