### PR TITLE
cli: adds default buffer limit on aigw run

### DIFF
--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -57,6 +57,21 @@ spec:
       kind: EnvoyProxy
       name: envoy-ai-gateway
 ---
+# By default, Envoy Gateway sets the buffer limit to 32kiB which is not sufficient for AI workloads.
+# This ClientTrafficPolicy sets the buffer limit to 50MiB as an example.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: client-buffer-limit
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: aigw-run
+  connection:
+    bufferLimit: 50Mi
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:


### PR DESCRIPTION
**Description**

This adds a default ClientTrafficPolicy to aigw run.
