### PR TITLE
docs: removes debug flag from aigw docker

### DIFF
--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -72,7 +72,7 @@ services:
       - ./testdata/ai-gateway-ollama-docker.yaml:/app/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
-    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run --debug /app/config.yaml"]
+    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]
 
   # chat-completion is the standard OpenAI client (`openai` in pip), instrumented
   # with the following OpenTelemetry instrumentation libraries:


### PR DESCRIPTION
**Description**

The debug flag is too chatty and wasn't intended to be in config users would end up using by default.
