### PR TITLE
feat: allow env variable substitution in CLI config

### DIFF
--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -288,9 +288,10 @@ metadata:
   namespace: default
 spec:
   endpoints:
-    - fqdn:  # Default to the special 127.0.0.1.nip.io hostname that resolves to 127.0.0.1
-        hostname: ${OLLAMA_HOST:=127.0.0.1.nip.io}
-        port: 11434  # There is no OLLAMA_PORT as it optionally a part of OLLAMA_HOST.
+    - ip:
+        address: 0.0.0.0
+        # https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-expose-ollama-on-my-network
+        port: 11434
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy

--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -288,8 +288,8 @@ metadata:
   namespace: default
 spec:
   endpoints:
-    - fqdn:  # Default to the special fbi.com hostname that resolves to 127.0.0.1
-        hostname: ${OLLAMA_HOST:=fbi.com}
+    - fqdn:  # Default to the special 127.0.0.1.nip.io hostname that resolves to 127.0.0.1
+        hostname: ${OLLAMA_HOST:=127.0.0.1.nip.io}
         port: 11434  # There is no OLLAMA_PORT as it optionally a part of OLLAMA_HOST.
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3

--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -288,10 +288,9 @@ metadata:
   namespace: default
 spec:
   endpoints:
-    - ip:
-        address: 0.0.0.0
-        # https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-expose-ollama-on-my-network
-        port: 11434
+    - fqdn:  # Default to the special fbi.com hostname that resolves to 127.0.0.1
+        hostname: ${OLLAMA_HOST:=fbi.com}
+        port: 11434  # There is no OLLAMA_PORT as it optionally a part of OLLAMA_HOST.
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy

--- a/cmd/aigw/ai-gateway-local.yaml
+++ b/cmd/aigw/ai-gateway-local.yaml
@@ -3,7 +3,10 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-# Ollama-only configuration for AI Gateway with OpenTelemetry tracing
+# Configuration for running Envoy AI Gateway with an OpenAI compatible
+# inference platform, defaulting to Ollama.
+#
+# Override with the OPENAI_HOST and OPENAI_PORT environment variables.
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
@@ -75,9 +78,10 @@ metadata:
   namespace: default
 spec:
   endpoints:
+    # Use fqdn, not ip, to allow changing to host.docker.internal
     - fqdn:
-        hostname: host.docker.internal
-        port: 11434
+        hostname: ${OPENAI_HOST:=fbi.com}  # Resolves to 127.0.0.1
+        port: ${OPENAI_PORT:=11434}  # Default to Ollama's port
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIServiceBackend

--- a/cmd/aigw/ai-gateway-local.yaml
+++ b/cmd/aigw/ai-gateway-local.yaml
@@ -7,6 +7,7 @@
 # inference platform, defaulting to Ollama.
 #
 # Override with the OPENAI_HOST and OPENAI_PORT environment variables.
+# For example, to use RamaLama you would set OPENAI_PORT=8080.
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
@@ -80,7 +81,7 @@ spec:
   endpoints:
     # Use fqdn, not ip, to allow changing to host.docker.internal
     - fqdn:
-        hostname: ${OPENAI_HOST:=fbi.com}  # Resolves to 127.0.0.1
+        hostname: ${OPENAI_HOST:=127.0.0.1.nip.io}  # Resolves to 127.0.0.1
         port: ${OPENAI_PORT:=11434}  # Default to Ollama's port
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1

--- a/cmd/aigw/config_test.go
+++ b/cmd/aigw/config_test.go
@@ -25,7 +25,7 @@ func TestReadConfig(t *testing.T) {
 	}{
 		{
 			name:           "default hostname and port",
-			expectHostname: "fbi.com",
+			expectHostname: "127.0.0.1.nip.io",
 			expectPort:     "11434",
 		},
 		{
@@ -39,7 +39,7 @@ func TestReadConfig(t *testing.T) {
 		{
 			name:           "non default config",
 			path:           aiGatewayLocalPath,
-			expectHostname: "fbi.com",
+			expectHostname: "127.0.0.1.nip.io",
 			expectPort:     "11434",
 		},
 		{

--- a/cmd/aigw/config_test.go
+++ b/cmd/aigw/config_test.go
@@ -25,19 +25,6 @@ func TestReadConfig(t *testing.T) {
 		expectPort     string
 	}{
 		{
-			name:           "default hostname and port",
-			expectHostname: "127.0.0.1.nip.io",
-			expectPort:     "11434",
-		},
-		{
-			name: "default config override with OLLAMA_HOST",
-			envVars: map[string]string{
-				"OLLAMA_HOST": "host.docker.internal",
-			},
-			expectHostname: "host.docker.internal",
-			expectPort:     "11434",
-		},
-		{
 			name:           "non default config",
 			path:           aiGatewayLocalPath,
 			expectHostname: "127.0.0.1.nip.io",
@@ -67,6 +54,17 @@ func TestReadConfig(t *testing.T) {
 			require.Contains(t, config, "port: "+tt.expectPort)
 		})
 	}
+
+	// Historical configuration used an IP for ollama. We can't use this
+	// config in docker, as it needs a hostname. However, we have another
+	// config to use in docker, ai-gateway-local.yaml. So, we leave this
+	// one alone.
+	t.Run("Default config uses 0.0.0.0 IP for Ollama", func(t *testing.T) {
+		config, err := readConfig("")
+		require.NoError(t, err)
+		require.Contains(t, config, "address: 0.0.0.0")
+		require.Contains(t, config, "port: 11434")
+	})
 
 	t.Run("error when file does not exist", func(t *testing.T) {
 		_, err := readConfig("/non/existent/file.yaml")

--- a/cmd/aigw/config_test.go
+++ b/cmd/aigw/config_test.go
@@ -1,0 +1,75 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadConfig(t *testing.T) {
+	aiGatewayLocalPath := sourceRelativePath("ai-gateway-local.yaml")
+
+	tests := []struct {
+		name           string
+		path           string
+		envVars        map[string]string
+		expectHostname string
+		expectPort     string
+	}{
+		{
+			name:           "default hostname and port",
+			expectHostname: "fbi.com",
+			expectPort:     "11434",
+		},
+		{
+			name: "default config override with OLLAMA_HOST",
+			envVars: map[string]string{
+				"OLLAMA_HOST": "host.docker.internal",
+			},
+			expectHostname: "host.docker.internal",
+			expectPort:     "11434",
+		},
+		{
+			name:           "non default config",
+			path:           aiGatewayLocalPath,
+			expectHostname: "fbi.com",
+			expectPort:     "11434",
+		},
+		{
+			name: "non default config with OPENAI_HOST OPENAI_PORT",
+			path: aiGatewayLocalPath,
+			envVars: map[string]string{
+				"OPENAI_HOST": "host.docker.internal",
+				"OPENAI_PORT": "8080",
+			},
+			expectHostname: "host.docker.internal",
+			expectPort:     "8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			config, err := readConfig(tt.path)
+			require.NoError(t, err)
+			require.Contains(t, config, "hostname: "+tt.expectHostname)
+			require.Contains(t, config, "port: "+tt.expectPort)
+		})
+	}
+}
+
+func sourceRelativePath(file string) string {
+	_, filename, _, _ := runtime.Caller(0)
+	testDir := filepath.Dir(filename)
+	return filepath.Join(testDir, file)
+}

--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -70,10 +70,10 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - aigw-target:/app
-      - ./ai-gateway-local.yaml:/app/config.yaml:ro
+      - ./ai-gateway-local.yaml:/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
-    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]
+    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /config.yaml"]
 
   # chat-completion is the standard OpenAI client (`openai` in pip), instrumented
   # with the following OpenTelemetry instrumentation libraries:

--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -63,13 +63,14 @@ services:
       # See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
       - OPENINFERENCE_HIDE_INPUTS=false
       - OPENINFERENCE_HIDE_OUTPUTS=false
+      - OPENAI_HOST=host.docker.internal
     ports:
       - "1975:1975"
     extra_hosts:  # localhost:host-gateway trick doesn't work with aigw
       - "host.docker.internal:host-gateway"
     volumes:
       - aigw-target:/app
-      - ./testdata/ai-gateway-ollama-docker.yaml:/app/config.yaml:ro
+      - ./testdata/ai-gateway-local.yaml:/app/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
     command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]

--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -70,7 +70,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - aigw-target:/app
-      - ./testdata/ai-gateway-local.yaml:/app/config.yaml:ro
+      - ./ai-gateway-local.yaml:/app/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
     command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -41,13 +41,15 @@ services:
         condition: service_completed_successfully
       ollama-pull:
         condition: service_completed_successfully
+    environment:
+      - OPENAI_HOST=host.docker.internal
     ports:
       - "1975:1975"
     extra_hosts:  # localhost:host-gateway trick doesn't work with aigw
       - "host.docker.internal:host-gateway"
     volumes:
       - aigw-target:/app
-      - ./testdata/ai-gateway-ollama-docker.yaml:/app/config.yaml:ro
+      - ./testdata/ai-gateway-local.yaml:/app/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
     command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - aigw-target:/app
-      - ./testdata/ai-gateway-local.yaml:/app/config.yaml:ro
+      - ./ai-gateway-local.yaml:/app/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
     command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -49,10 +49,10 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - aigw-target:/app
-      - ./ai-gateway-local.yaml:/app/config.yaml:ro
+      - ./ai-gateway-local.yaml:/config.yaml:ro
       - envoy-cache:/tmp/envoy-gateway
     working_dir: /app
-    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /app/config.yaml"]
+    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /config.yaml"]
 
   # chat-completion is a simple curl-based test client for sending requests to aigw.
   chat-completion:

--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/a8m/envsubst"
 	"github.com/envoyproxy/gateway/cmd/envoy-gateway/root"
 	egextension "github.com/envoyproxy/gateway/proto/extension"
 	"google.golang.org/grpc"
@@ -128,15 +129,9 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 	// Do the translation of the given AI Gateway resources Yaml into Envoy Gateway resources and write them to the file.
 	resourcesBuf := &bytes.Buffer{}
 	runCtx := &runCmdContext{envoyGatewayResourcesOut: resourcesBuf, stderrLogger: stderrLogger, udsPath: udsPath, tmpdir: tmpdir, isDebug: c.Debug}
-	// Use the default configuration if the path is not given.
-	aiGatewayResourcesYaml := aiGatewayDefaultResources
-	if c.Path != "" {
-		var yamlBytes []byte
-		yamlBytes, err = os.ReadFile(c.Path)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", c.Path, err)
-		}
-		aiGatewayResourcesYaml = string(yamlBytes)
+	aiGatewayResourcesYaml, err := readConfig(c.Path)
+	if err != nil {
+		return err
 	}
 	fakeClient, err := runCtx.writeEnvoyResourcesAndRunExtProc(ctx, aiGatewayResourcesYaml)
 	if err != nil {
@@ -186,6 +181,20 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 		return fmt.Errorf("failed to execute server: %w", err)
 	}
 	return nil
+}
+
+// readConfig returns config from the given path, substituting ENV variables
+// similar to `envsubst`. If the path is empty the default config is returned.
+func readConfig(path string) (string, error) {
+	if path == "" {
+		return envsubst.String(aiGatewayDefaultResources)
+	}
+	var yamlBytes []byte
+	yamlBytes, err := envsubst.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read config file %s: %w", path, err)
+	}
+	return string(yamlBytes), nil
 }
 
 // recreateDir removes the directory at the given path and creates a new one.

--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -187,7 +187,7 @@ func run(ctx context.Context, c cmdRun, stdout, stderr io.Writer) error {
 // similar to `envsubst`. If the path is empty the default config is returned.
 func readConfig(path string) (string, error) {
 	if path == "" {
-		return envsubst.String(aiGatewayDefaultResources)
+		return aiGatewayDefaultResources, nil
 	}
 	var yamlBytes []byte
 	yamlBytes, err := envsubst.ReadFile(path)

--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -192,7 +192,7 @@ func readConfig(path string) (string, error) {
 	var yamlBytes []byte
 	yamlBytes, err := envsubst.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read config file %s: %w", path, err)
+		return "", fmt.Errorf("error reading config: %w", err)
 	}
 	return string(yamlBytes), nil
 }

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -43,7 +43,7 @@ func setupDefaultAIGatewayResourcesWithAvailableCredentials(t *testing.T) (strin
 
 func TestRun(t *testing.T) {
 	resourcePath, cc := setupDefaultAIGatewayResourcesWithAvailableCredentials(t)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
@@ -169,7 +169,7 @@ func TestRunCmdContext_writeEnvoyResourcesAndRunExtProc(t *testing.T) {
 	}
 	content, err := os.ReadFile(resourcePath)
 	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	_, err = runCtx.writeEnvoyResourcesAndRunExtProc(ctx, string(content))
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
@@ -179,7 +179,7 @@ func TestRunCmdContext_writeEnvoyResourcesAndRunExtProc(t *testing.T) {
 }
 
 func Test_mustStartExtProc(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	runCtx := &runCmdContext{
 		tmpdir: t.TempDir(),

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelg
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0
+	github.com/a8m/envsubst v1.4.3
 	github.com/alecthomas/kong v1.12.1
 	github.com/anthropics/anthropic-sdk-go v1.9.1
 	github.com/aws/aws-sdk-go-v2 v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsu
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1/go.mod h1:q4DKzC4UcVaAvcfd41CZh0PWpGgzrVxUYBlgKNGquUo=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/a8m/envsubst v1.4.3 h1:kDF7paGK8QACWYaQo6KtyYBozY2jhQrTuNNuUxQkhJY=
+github.com/a8m/envsubst v1.4.3/go.mod h1:4jjHWQlZoaXPoLQUb7H2qT4iLkZDdmEQiOUogdUmqVU=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.19.0 h1:Im+SLRgT8maArxv81mULDWN8oKxkzboH07CHesxElq4=

--- a/site/docs/cli/run.md
+++ b/site/docs/cli/run.md
@@ -96,6 +96,22 @@ Next, let's say change the `mistral:latest` model to `deepseek-r1:1.5b` and save
 +              value: deepseek-r1:1.5b
 ```
 
+You can also use environment variable substitution (`envsubst`) to allow small
+changes without needing to copy a file. For example, you could use this syntax
+instead, to default the model to the `CHAT_MODEL` variable.
+
+```diff
+--- default.yaml        2025-03-26 11:27:30
++++ custom.yaml 2025-03-26 11:28:55
+@@ -115,9 +115,9 @@
+     - matches:
+         - headers:
+             - type: Exact
+               name: x-ai-eg-model
+-              value: mistral:latest
++              value: ${CHAT_MODEL:=deepseek-r1:1.5b}
+```
+
 ### Run with the Custom Configuration
 
 Now, run the AI Gateway with the custom configuration by running the following command:


### PR DESCRIPTION
**Description**

Before, we had to make different copies of config files in order to make small changes like to the ollama host or the model in use. This now implements ENV substitution.

Example:

```diff
--- default.yaml        2025-03-26 11:27:30
+++ custom.yaml 2025-03-26 11:28:55
@@ -115,9 +115,9 @@
     - matches:
         - headers:
             - type: Exact
               name: x-ai-eg-model
-              value: mistral:latest
+              value: ${CHAT_MODEL:=deepseek-r1:1.5b}
```

**Special notes for reviewers (if applicable)**

This uses the special "127.0.0.1.nip.io" hostname in *local* configs, which allows ENV substitution to work with docker vs normal go. This requires Ollama to be started with OLLAMA_HOST=0.0.0.0, which was already documented in the README. The ENV variables OPENAI_HOST and OPENAI_PORT allows use of non-ollama local servers like ramalama.