### PR TITLE
chore: exclude Claude Code settings from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ site/temp
 
 # auto generated conformance report
 inference-extension-conformance-test-report.yaml
+
+# Claude Code settings and generated files
+.claude/
+.env
+.mcp.json


### PR DESCRIPTION
**Description**

Add .claude/ directory, .env, and .mcp.json to .gitignore to prevent committing Claude Code settings and generated files.

