### PR TITLE
ci: removes PR title length check

### DIFF
--- a/.github/workflows/pr_style_check.yaml
+++ b/.github/workflows/pr_style_check.yaml
@@ -89,16 +89,3 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
-
-      - name: Check length of PR title
-        env:
-          # Do not use ${{ github.event.pull_request.title }} directly in run command.
-          TITLE: ${{ github.event.pull_request.title }}
-        # We want to make sure that each commit "subject" is <=60 characters not to
-        # be truncated in the git log as well as in the GitHub UI.
-        # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst?id=bc7938deaca7f474918c41a0372a410049bd4e13#n664
-        run: |
-          if (( ${#TITLE} > 60 )); then
-            echo "The PR title is too long. Please keep it <=60 characters."
-            exit 1
-          fi


### PR DESCRIPTION
**Description**

This removes the length check in the PR title. This has existed to enforce the single format of commit message but it was too restrict and has been annoying to be honest. 