### PR TITLE
test: decouple run lifecycle tests from extproc internals

### DIFF
--- a/cmd/aigw/main.go
+++ b/cmd/aigw/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alecthomas/kong"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
 	"github.com/envoyproxy/ai-gateway/internal/version"
 )
 
@@ -84,7 +85,7 @@ func doMain(ctx context.Context, stdout, stderr io.Writer, args []string, exitFn
 			log.Fatalf("Error translating: %v", err)
 		}
 	case "run", "run <path>":
-		err = rf(ctx, c.Run, runOpts{}, stdout, stderr)
+		err = rf(ctx, c.Run, runOpts{extProcLauncher: mainlib.Main}, stdout, stderr)
 		if err != nil {
 			log.Fatalf("Error running: %v", err)
 		}


### PR DESCRIPTION
**Description**

This improves the `aigw run` lifecycle test to not rely on implementation details of how extproc is executed.
The previous test relied on how extproc uses and binds the UDS, which couples the test to the extproc internals, making it error-prone and less maintainable.

This PR refactors the code so that the run tests can verify the lifecycle without relying on extproc internal details.

**Related Issues/PRs (if applicable)**

Related PR: https://github.com/envoyproxy/ai-gateway/pull/1134

**Special notes for reviewers (if applicable)**

N/A
