### PR TITLE
ci: require inference extension test to pass before publish

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -258,7 +258,7 @@ jobs:
     # Docker builds are verified in test_e2e job, so we only need to push the images when the event is a push event.
     if: github.event_name == 'push'
     name: Push Docker Images
-    needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e]
+    needs: [unittest, test_crdcel, test_controller, test_extproc, test_e2e, test_e2e_inference_extension]
     uses: ./.github/workflows/docker_build_job.yaml
     secrets: inherit
 


### PR DESCRIPTION
**Description**

test_e2e_inference_extension was missing from the "needs" list for publication of docker images.