### PR TITLE
ci: upload coverage only from ubuntu host

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -73,6 +73,7 @@ jobs:
           TEST_OPENAI_API_KEY: ${{ secrets.ENVOY_AI_GATEWAY_OPENAI_API_KEY }}
         run: make test-coverage
       - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
**Description**

There's no reason to upload the coverage from macos. Otherwise, there would be a conflict like macOS result compared against the ubuntu result on PRs. 

