### PR TITLE
feat: support gcp safety settings

### DIFF
--- a/internal/apischema/gcp/gcp.go
+++ b/internal/apischema/gcp/gcp.go
@@ -31,4 +31,8 @@ type GenerateContentRequest struct {
 	//
 	// https://github.com/googleapis/go-genai/blob/6a8184fcaf8bf15f0c566616a7b356560309be9b/types.go#L858
 	SystemInstruction *genai.Content `json:"system_instruction,omitempty"`
+	// Optional: Safety settings in the request to block unsafe content in the response.
+	//
+	// https://github.com/googleapis/go-genai/blob/6a8184fcaf8bf15f0c566616a7b356560309be9b/types.go#L1057
+	SafetySettings []*genai.SafetySetting `json:"safetySettings,omitempty"`
 }

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -758,8 +758,11 @@ type ChatCompletionRequest struct {
 	// Docs: https://platform.openai.com/docs/guides/tools-web-search?api-mode=chat
 	WebSearchOptions *WebSearchOptions `json:"web_search_options,omitempty"` //nolint:tagliatelle //follow openai api
 
+	// GCPVertexAIVendorFields configures the GCP VertexAI specific fields during schema translation.
 	*GCPVertexAIVendorFields `json:",inline,omitempty"`
-	*AnthropicVendorFields   `json:",inline,omitempty"`
+
+	// AnthropicVendorFields configures the Anthropic specific fields during schema translation.
+	*AnthropicVendorFields `json:",inline,omitempty"`
 }
 
 type StreamOptions struct {
@@ -1313,6 +1316,11 @@ type GCPVertexAIVendorFields struct {
 	//
 	// https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerationConfig
 	GenerationConfig *GCPVertexAIGenerationConfig `json:"generationConfig,omitzero"`
+
+	// SafetySettings: Safety settings in the request to block unsafe content in the response.
+	//
+	// https://cloud.google.com/vertex-ai/docs/reference/rest/v1/SafetySetting
+	SafetySettings []*genai.SafetySetting `json:"safetySettings,omitzero"`
 }
 
 // GCPVertexAIGenerationConfig represents Gemini generation configuration options.

--- a/internal/apischema/openai/vendor_fields_test.go
+++ b/internal/apischema/openai/vendor_fields_test.go
@@ -39,7 +39,11 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 						"includeThoughts": true,
 						"thinkingBudget": 1000
 					}
-				}
+				},
+                "safetySettings": [{
+                    "category": "HARM_CATEGORY_HARASSMENT",
+                    "threshold": "BLOCK_ONLY_HIGH"
+                }]
 			}`),
 			expected: &ChatCompletionRequest{
 				Model: "gemini-1.5-pro",
@@ -57,6 +61,12 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 						ThinkingConfig: &genai.GenerationConfigThinkingConfig{
 							IncludeThoughts: true,
 							ThinkingBudget:  ptr.To(int32(1000)),
+						},
+					},
+					SafetySettings: []*genai.SafetySetting{
+						{
+							Category:  genai.HarmCategoryHarassment,
+							Threshold: genai.HarmBlockThresholdBlockOnlyHigh,
 						},
 					},
 				},

--- a/internal/extproc/translator/openai_gcpvertexai.go
+++ b/internal/extproc/translator/openai_gcpvertexai.go
@@ -308,6 +308,9 @@ func (o *openAIToGCPVertexAITranslatorV1ChatCompletion) applyVendorSpecificField
 			gcr.GenerationConfig.ThinkingConfig = vendorGenConfig.ThinkingConfig
 		}
 	}
+	if gcpVendorFields.SafetySettings != nil {
+		gcr.SafetySettings = gcpVendorFields.SafetySettings
+	}
 }
 
 func (o *openAIToGCPVertexAITranslatorV1ChatCompletion) geminiResponseToOpenAIMessage(gcr genai.GenerateContentResponse) (*openai.ChatCompletionResponse, error) {


### PR DESCRIPTION
**Description**
Support GCP specific safetySetting field for openai compatible API translation.
reference: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference
