### PR TITLE
ci: attach aigw cli artifacts to the releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,21 +29,32 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Push Helm chart
         run: |
           make helm-push HELM_CHART_VERSION=${HELM_CHART_VERSION}
           make helm-push HELM_CHART_VERSION=${HELM_CHART_VERSION_WITHOUT_V}
 
+      - name: Build CLI release binaries
+        run: |
+          make build.aigw GOOS_LIST="linux darwin" GOARCH_LIST="amd64 arm64"
+
       - name: Create a release candidate
         if: ${{ contains(github.ref, '-rc') }}
         run: |
-          gh release create $TAG --prerelease --title $TAG --notes "Release candidate" ./out/ai-gateway-crds-helm-${TAG}.tgz ./out/ai-gateway-helm-${TAG}.tgz
+          gh release create $TAG --prerelease --title $TAG --notes "Release candidate" \
+            ./out/ai-gateway-crds-helm-${TAG}.tgz \
+            ./out/ai-gateway-helm-${TAG}.tgz \
+            ./out/aigw-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a stable release
         if: ${{ !contains(github.ref, '-rc') }}
         run: |
-          gh release create $TAG --draft --title $TAG --notes "To be written by the release manager" ./out/ai-gateway-crds-helm-${TAG}.tgz ./out/ai-gateway-helm-${TAG}.tgz
+          gh release create $TAG --draft --title $TAG --notes "To be written by the release manager" \
+            ./out/ai-gateway-crds-helm-${TAG}.tgz \
+            ./out/ai-gateway-helm-${TAG}.tgz \
+            ./out/aigw-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,8 @@ jobs:
       - name: Build CLI release binaries
         run: |
           make build.aigw GOOS_LIST="linux" GOARCH_LIST="amd64 arm64"
+          # amd64 for macos is not available on archive-envoy for the last few table versions
+          # which in turn is used by EG's standalone mode used by aigw, so we skip it
           make build.aigw GOOS_LIST="darwin" GOARCH_LIST="arm64"
 
       - name: Create a release candidate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Build CLI release binaries
         run: |
-          make build.aigw GOOS_LIST="linux darwin" GOARCH_LIST="amd64 arm64"
+          make build.aigw GOOS_LIST="linux" GOARCH_LIST="amd64 arm64"
+          make build.aigw GOOS_LIST="darwin" GOARCH_LIST="arm64"
 
       - name: Create a release candidate
         if: ${{ contains(github.ref, '-rc') }}

--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -4,8 +4,15 @@ title: Installation
 sidebar_position: 1
 ---
 
+## Official CLI binaries
 
-To install the `aigw` CLI, run the following command (This may take a while):
+Each release includes the binaries for the `aigw` CLI build for different platforms.<br/>
+They can be downloaded directly from the corresponding release in the
+[GitHub releases page](https://github.com/envoyproxy/ai-gateway/releases).
+
+## Building the latest version
+
+To use the latest version, you can use the following commands to clone the repo and build hte CLI:
 
 ```shell
 git clone https://github.com/envoyproxy/ai-gateway.git
@@ -60,4 +67,3 @@ The following sections provide more information about each of the CLI commands:
 
 - [aigw run](./run.md): Run the AI Gateway locally for a given configuration.
 - [aigw translate](./translate.md): Translate AI Gateway resources to Envoy Gateway and Kubernetes resources.
-

--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -12,7 +12,7 @@ They can be downloaded directly from the corresponding release in the
 
 ## Building the latest version
 
-To use the latest version, you can use the following commands to clone the repo and build hte CLI:
+To use the latest version, you can use the following commands to clone the repo and build the CLI:
 
 ```shell
 git clone https://github.com/envoyproxy/ai-gateway.git
@@ -21,8 +21,6 @@ go install ./cmd/aigw
 ```
 
 :::tip
-`git clone` step is a temporary workaround for the issue with `go install`. See the issue [#1064](https://github.com/envoyproxy/ai-gateway/issues/1064) for details.
-
 `go install` command installs a binary in the `$(go env GOPATH)/bin` directory.
 Make sure that the `$(go env GOPATH)/bin` directory is in your `PATH` environment variable.
 


### PR DESCRIPTION
**Description**

Build the `aigw` CLI binaries as part of the release process and attaches them as release artifacts.

**Related Issues/PRs (if applicable)**

Fixes https://github.com/envoyproxy/ai-gateway/issues/1064

**Special notes for reviewers (if applicable)**

N/A
