### PR TITLE
cli: generate Docker images for the aigw command

### DIFF
--- a/.github/workflows/docker_build_job.yaml
+++ b/.github/workflows/docker_build_job.yaml
@@ -14,6 +14,8 @@ jobs:
             cmd_path_prefix: cmd
           - command_name: "extproc"
             cmd_path_prefix: cmd
+          - command_name: "aigw"
+            cmd_path_prefix: cmd
           - command_name: "testupstream"
             cmd_path_prefix: tests/internal/testupstreamlib
     steps:
@@ -56,10 +58,10 @@ jobs:
           else
             TAG="${{ github.sha }}"
           fi
-          make docker-build.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }}  ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"
+          make docker-build.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }} ENABLE_MULTI_PLATFORMS=true TAG=$TAG DOCKER_BUILD_ARGS="--push"
 
       - name: Build and Push Image Latest
         run: |
           if [[ "$GITHUB_REF" != refs/tags/* ]]; then
-            make docker-build.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }}  ENABLE_MULTI_PLATFORMS=true TAG="latest" DOCKER_BUILD_ARGS="--push"
+            make docker-build.${{ matrix.command_name }} CMD_PATH_PREFIX=${{ matrix.cmd_path_prefix }} ENABLE_MULTI_PLATFORMS=true TAG="latest" DOCKER_BUILD_ARGS="--push"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-FROM gcr.io/distroless/static-debian11:nonroot
+# Variant to use as the base image. By default 'static' is used, but the 'aigw' image
+# needs to use 'base-nossl' because it needs 'glibc' to use func-e to pull the Envoy binaries.
+ARG VARIANT
+
+FROM gcr.io/distroless/${VARIANT}-debian12:nonroot
 ARG COMMAND_NAME
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -255,9 +255,13 @@ docker-build.%: GOARCH_LIST = amd64 arm64
 docker-build.%: PLATFORMS = --platform linux/amd64,linux/arm64
 endif
 docker-build.%: ## Build a docker image for a given command.
-	$(eval COMMAND_NAME := $(subst docker-build.,,$@))
+	$(eval COMMAND_NAME := $(*))
+	$(eval VARIANT := $(if $(filter aigw,$(COMMAND_NAME)),base-nossl,static))
 	@$(MAKE) build.$(COMMAND_NAME) GOOS_LIST="linux" GOARCH_LIST="$(GOARCH_LIST)"
-	docker buildx build . -t $(OCI_REPOSITORY_PREFIX)-$(COMMAND_NAME):$(TAG) --build-arg COMMAND_NAME=$(COMMAND_NAME) $(PLATFORMS) $(DOCKER_BUILD_ARGS)
+	docker buildx build . -t $(OCI_REPOSITORY_PREFIX)-$(COMMAND_NAME):$(TAG) \
+		--build-arg VARIANT=$(VARIANT) \
+		--build-arg COMMAND_NAME=$(COMMAND_NAME) \
+		$(PLATFORMS) $(DOCKER_BUILD_ARGS)
 
 # This builds docker images for all commands under cmd/ directory. All options for `docker-build.%` apply.
 #

--- a/Makefile
+++ b/Makefile
@@ -255,12 +255,12 @@ docker-build.%: GOARCH_LIST = amd64 arm64
 docker-build.%: PLATFORMS = --platform linux/amd64,linux/arm64
 endif
 docker-build.%: ## Build a docker image for a given command.
-	$(eval COMMAND_NAME := $(*))
-	$(eval VARIANT := $(if $(filter aigw,$(COMMAND_NAME)),base-nossl,static))
-	@$(MAKE) build.$(COMMAND_NAME) GOOS_LIST="linux" GOARCH_LIST="$(GOARCH_LIST)"
-	docker buildx build . -t $(OCI_REPOSITORY_PREFIX)-$(COMMAND_NAME):$(TAG) \
+	$(eval IMAGE_NAME := $(if $(filter aigw,$(*)),cli,$(*)))
+	$(eval VARIANT := $(if $(filter aigw,$(*)),base-nossl,static))
+	@$(MAKE) build.$(*) GOOS_LIST="linux" GOARCH_LIST="$(GOARCH_LIST)"
+	docker buildx build . -t $(OCI_REPOSITORY_PREFIX)-$(IMAGE_NAME):$(TAG) \
 		--build-arg VARIANT=$(VARIANT) \
-		--build-arg COMMAND_NAME=$(COMMAND_NAME) \
+		--build-arg COMMAND_NAME=$(*) \
 		$(PLATFORMS) $(DOCKER_BUILD_ARGS)
 
 # This builds docker images for all commands under cmd/ directory. All options for `docker-build.%` apply.

--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -13,16 +13,16 @@ They can be downloaded directly from the corresponding release in the
 ## Using the Docker image
 
 You can also use the official Docker images to run the CLI without installing it locally.
-The CLI images are available as: `docker.io/envoyproxy/ai-gateway-aigw:<version>`.
+The CLI images are available as: `docker.io/envoyproxy/ai-gateway-cli:<version>`.
 
-To run the `aigw` CLI using Docker, you only need to expose the port where the `aigw` CLI listens to
+To run the CLI using Docker, you only need to expose the port where the standalone `aigw` listens to
 and configure the environment variables for the credentials. If you want to use a custom configuration file,
 you can mount it as a volume.
 
 The following example runs the AI Gateway with the default configuration for the [OpenAI provider](../getting-started/connect-providers/openai.md):
 
 ```shell
-$ docker run --rm -p 1975:1975 -e OPENAI_API_KEY=OPENAI_API_KEY envoyproxy/ai-gateway-aigw run
+$ docker run --rm -p 1975:1975 -e OPENAI_API_KEY=OPENAI_API_KEY envoyproxy/ai-gateway-cli run
 looking up the latest Envoy version
 downloading https://archive.tetratelabs.io/envoy/download/v1.35.0/envoy-v1.35.0-linux-arm64.tar.xz
 starting: /tmp/envoy-gateway/versions/1.35.0/bin/envoy in run directory /tmp/envoy-gateway/runs/1756912322973222887

--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -10,6 +10,24 @@ Each release includes the binaries for the `aigw` CLI build for different platfo
 They can be downloaded directly from the corresponding release in the
 [GitHub releases page](https://github.com/envoyproxy/ai-gateway/releases).
 
+## Using the Docker image
+
+You can also use the official Docker images to run the CLI without installing it locally.
+The CLI images are available as: `docker.io/envoyproxy/ai-gateway-aigw:<version>`.
+
+To run the `aigw` CLI using Docker, you only need to expose the port where the `aigw` CLI listens to
+and configure the environment variables for the credentials. If you want to use a custom configuration file,
+you can mount it as a volume.
+
+The following example runs the AI Gateway with the default configuration for the [OpenAI provider](../getting-started/connect-providers/openai.md):
+
+```shell
+$ docker run --rm -p 1975:1975 -e OPENAI_API_KEY=OPENAI_API_KEY envoyproxy/ai-gateway-aigw run
+looking up the latest Envoy version
+downloading https://archive.tetratelabs.io/envoy/download/v1.35.0/envoy-v1.35.0-linux-arm64.tar.xz
+starting: /tmp/envoy-gateway/versions/1.35.0/bin/envoy in run directory /tmp/envoy-gateway/runs/1756912322973222887
+```
+
 ## Building the latest version
 
 To use the latest version, you can use the following commands to clone the repo and build the CLI:


### PR DESCRIPTION
**Description**

Generate Docker images for the `aigw` command.
To run it with the default config, only the port and the required credential environment variables need to be configured. For example:

```
$ docker run --rm -p 1975:1975 -e TARS_API_KEY=$TARS_API_KEY envoyproxy/ai-gateway-cli run
looking up the latest Envoy version
downloading https://archive.tetratelabs.io/envoy/download/v1.35.0/envoy-v1.35.0-linux-arm64.tar.xz
starting: /tmp/envoy-gateway/versions/1.35.0/bin/envoy in run directory /tmp/envoy-gateway/runs/1756912322973222887
```

**Related Issues/PRs (if applicable)**

Follow-up of: https://github.com/envoyproxy/ai-gateway/pull/1154#issuecomment-3248126209

**Special notes for reviewers (if applicable)**

N/A
