### PR TITLE
ci: better wait for the ollama port in test job

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -75,7 +75,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
-          sleep 10 # Wait for ollama to start. TODO: this is really hacky, so find a better way to wait for ollama to start. This can be a source of flakiness.
+          timeout 30 sh -c 'until nc -z localhost 11434; do sleep 1; done'
           ollama pull qwen3:0.6b
 
       - env:


### PR DESCRIPTION
**Description**

Update the CI test job to poll the Ollama port until it is open (waiting up to 30 seconds at most). This is a less flaky approach than just waiting 10 seconds, then continuing.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A