### PR TITLE
refactor: use tagged union for union types in openai schema if possible

### DIFF
--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -30,7 +30,7 @@ func TestOpenAIChatCompletionContentPartUserUnionParamUnmarshal(t *testing.T) {
 "text": "what do you see in this image"
 }`),
 			out: &ChatCompletionContentPartUserUnionParam{
-				TextContent: &ChatCompletionContentPartTextParam{
+				OfText: &ChatCompletionContentPartTextParam{
 					Type: string(ChatCompletionContentPartTextTypeText),
 					Text: "what do you see in this image",
 				},
@@ -43,7 +43,7 @@ func TestOpenAIChatCompletionContentPartUserUnionParamUnmarshal(t *testing.T) {
 "image_url": {"url": "https://example.com/image.jpg"}
 }`),
 			out: &ChatCompletionContentPartUserUnionParam{
-				ImageContent: &ChatCompletionContentPartImageParam{
+				OfImageURL: &ChatCompletionContentPartImageParam{
 					Type: ChatCompletionContentPartImageTypeImageURL,
 					ImageURL: ChatCompletionContentPartImageImageURLParam{
 						URL: "https://example.com/image.jpg",
@@ -58,7 +58,7 @@ func TestOpenAIChatCompletionContentPartUserUnionParamUnmarshal(t *testing.T) {
 "input_audio": {"data": "somebinarydata"}
 }`),
 			out: &ChatCompletionContentPartUserUnionParam{
-				InputAudioContent: &ChatCompletionContentPartInputAudioParam{
+				OfInputAudio: &ChatCompletionContentPartInputAudioParam{
 					Type: ChatCompletionContentPartInputAudioTypeInputAudio,
 					InputAudio: ChatCompletionContentPartInputAudioInputAudioParam{
 						Data: "somebinarydata",
@@ -192,46 +192,41 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "gpu-o4",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionSystemMessageParam{
+						OfSystem: &ChatCompletionSystemMessageParam{
 							Role: ChatMessageRoleSystem,
 							Content: StringOrArray{
 								Value: "you are a helpful assistant",
 							},
 						},
-						Type: ChatMessageRoleSystem,
 					},
 					{
-						Value: ChatCompletionDeveloperMessageParam{
+						OfDeveloper: &ChatCompletionDeveloperMessageParam{
 							Role: ChatMessageRoleDeveloper,
 							Content: StringOrArray{
 								Value: "you are a helpful dev assistant",
 							},
 						},
-						Type: ChatMessageRoleDeveloper,
 					},
 					{
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role: ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{
 								Value: "what do you see in this image",
 							},
 						},
-						Type: ChatMessageRoleUser,
 					},
 					{
-						Value: ChatCompletionToolMessageParam{
+						OfTool: &ChatCompletionToolMessageParam{
 							Role:       ChatMessageRoleTool,
 							ToolCallID: "123",
 							Content:    StringOrArray{Value: "some tool"},
 						},
-						Type: ChatMessageRoleTool,
 					},
 					{
-						Value: ChatCompletionAssistantMessageParam{
+						OfAssistant: &ChatCompletionAssistantMessageParam{
 							Role:    ChatMessageRoleAssistant,
 							Content: StringOrAssistantRoleContentUnion{Value: "you are a helpful assistant"},
 						},
-						Type: ChatMessageRoleAssistant,
 					},
 				},
 			},
@@ -248,20 +243,18 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "gpu-o4",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionAssistantMessageParam{
+						OfAssistant: &ChatCompletionAssistantMessageParam{
 							Role:    ChatMessageRoleAssistant,
 							Content: StringOrAssistantRoleContentUnion{Value: "you are a helpful assistant"},
 						},
-						Type: ChatMessageRoleAssistant,
 					},
 					{
-						Value: ChatCompletionAssistantMessageParam{
+						OfAssistant: &ChatCompletionAssistantMessageParam{
 							Role: ChatMessageRoleAssistant,
 							Content: StringOrAssistantRoleContentUnion{Value: []ChatCompletionAssistantMessageParamContent{
 								{Text: ptr.To("you are a helpful assistant content"), Type: "text"},
 							}},
 						},
-						Type: ChatMessageRoleAssistant,
 					},
 				},
 			},
@@ -277,7 +270,7 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "gpu-o4",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionSystemMessageParam{
+						OfSystem: &ChatCompletionSystemMessageParam{
 							Role: ChatMessageRoleSystem,
 							Content: StringOrArray{
 								Value: []ChatCompletionContentPartTextParam{
@@ -288,10 +281,9 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 								},
 							},
 						},
-						Type: ChatMessageRoleSystem,
 					},
 					{
-						Value: ChatCompletionDeveloperMessageParam{
+						OfDeveloper: &ChatCompletionDeveloperMessageParam{
 							Role: ChatMessageRoleDeveloper,
 							Content: StringOrArray{
 								Value: []ChatCompletionContentPartTextParam{
@@ -302,20 +294,18 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 								},
 							},
 						},
-						Type: ChatMessageRoleDeveloper,
 					},
 					{
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role: ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{
 								Value: []ChatCompletionContentPartUserUnionParam{
 									{
-										TextContent: &ChatCompletionContentPartTextParam{Text: "what do you see in this image", Type: "text"},
+										OfText: &ChatCompletionContentPartTextParam{Text: "what do you see in this image", Type: "text"},
 									},
 								},
 							},
 						},
-						Type: ChatMessageRoleUser,
 					},
 				},
 			},
@@ -338,13 +328,12 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "azure.gpt-4o",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role: ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{
 								Value: "Tell me a story",
 							},
 						},
-						Type: ChatMessageRoleUser,
 					},
 				},
 				ResponseFormat: &ChatCompletionResponseFormatUnion{
@@ -384,11 +373,10 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "gpu-o4",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "hello"},
 						},
-						Type: ChatMessageRoleUser,
 					},
 				},
 				MaxCompletionTokens: ptr.To[int64](1024),
@@ -410,11 +398,10 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "gpu-o4",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "hello"},
 						},
-						Type: ChatMessageRoleUser,
 					},
 				},
 				Stop: "stop",
@@ -431,11 +418,10 @@ func TestOpenAIChatCompletionMessageUnmarshal(t *testing.T) {
 				Model: "gpt-4o-mini-search-preview",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "What's the latest news?"},
 						},
-						Type: ChatMessageRoleUser,
 					},
 				},
 				WebSearchOptions: &WebSearchOptions{
@@ -495,8 +481,7 @@ func TestChatCompletionMessageParamUnionMarshal(t *testing.T) {
 		{
 			name: "user message",
 			input: ChatCompletionMessageParamUnion{
-				Type: ChatMessageRoleUser,
-				Value: ChatCompletionUserMessageParam{
+				OfUser: &ChatCompletionUserMessageParam{
 					Role: ChatMessageRoleUser,
 					Content: StringOrUserRoleContentUnion{
 						Value: "Hello!",
@@ -508,8 +493,7 @@ func TestChatCompletionMessageParamUnionMarshal(t *testing.T) {
 		{
 			name: "system message",
 			input: ChatCompletionMessageParamUnion{
-				Type: ChatMessageRoleSystem,
-				Value: ChatCompletionSystemMessageParam{
+				OfSystem: &ChatCompletionSystemMessageParam{
 					Role: ChatMessageRoleSystem,
 					Content: StringOrArray{
 						Value: "You are a helpful assistant",
@@ -521,8 +505,7 @@ func TestChatCompletionMessageParamUnionMarshal(t *testing.T) {
 		{
 			name: "assistant message",
 			input: ChatCompletionMessageParamUnion{
-				Type: ChatMessageRoleAssistant,
-				Value: ChatCompletionAssistantMessageParam{
+				OfAssistant: &ChatCompletionAssistantMessageParam{
 					Role: ChatMessageRoleAssistant,
 					Content: StringOrAssistantRoleContentUnion{
 						Value: "I can help you with that",
@@ -534,8 +517,7 @@ func TestChatCompletionMessageParamUnionMarshal(t *testing.T) {
 		{
 			name: "tool message",
 			input: ChatCompletionMessageParamUnion{
-				Type: ChatMessageRoleTool,
-				Value: ChatCompletionToolMessageParam{
+				OfTool: &ChatCompletionToolMessageParam{
 					Role:       ChatMessageRoleTool,
 					ToolCallID: "123",
 					Content:    StringOrArray{Value: "tool result"},
@@ -610,7 +592,7 @@ func TestStringOrUserRoleContentUnionMarshal(t *testing.T) {
 			input: StringOrUserRoleContentUnion{
 				Value: []ChatCompletionContentPartUserUnionParam{
 					{
-						TextContent: &ChatCompletionContentPartTextParam{
+						OfText: &ChatCompletionContentPartTextParam{
 							Type: "text",
 							Text: "What's in this image?",
 						},
@@ -730,7 +712,7 @@ func TestChatCompletionContentPartUserUnionParamMarshal(t *testing.T) {
 		{
 			name: "text content",
 			input: ChatCompletionContentPartUserUnionParam{
-				TextContent: &ChatCompletionContentPartTextParam{
+				OfText: &ChatCompletionContentPartTextParam{
 					Type: "text",
 					Text: "Hello world",
 				},
@@ -740,7 +722,7 @@ func TestChatCompletionContentPartUserUnionParamMarshal(t *testing.T) {
 		{
 			name: "image content",
 			input: ChatCompletionContentPartUserUnionParam{
-				ImageContent: &ChatCompletionContentPartImageParam{
+				OfImageURL: &ChatCompletionContentPartImageParam{
 					Type: ChatCompletionContentPartImageTypeImageURL,
 					ImageURL: ChatCompletionContentPartImageImageURLParam{
 						URL: "https://example.com/image.jpg",
@@ -752,7 +734,7 @@ func TestChatCompletionContentPartUserUnionParamMarshal(t *testing.T) {
 		{
 			name: "audio content",
 			input: ChatCompletionContentPartUserUnionParam{
-				InputAudioContent: &ChatCompletionContentPartInputAudioParam{
+				OfInputAudio: &ChatCompletionContentPartInputAudioParam{
 					Type: ChatCompletionContentPartInputAudioTypeInputAudio,
 					InputAudio: ChatCompletionContentPartInputAudioInputAudioParam{
 						Data: "audio-data",
@@ -778,26 +760,24 @@ func TestMarshalUnmarshalRoundTrip(t *testing.T) {
 		Model: "gpt-4",
 		Messages: []ChatCompletionMessageParamUnion{
 			{
-				Type: ChatMessageRoleSystem,
-				Value: ChatCompletionSystemMessageParam{
+				OfSystem: &ChatCompletionSystemMessageParam{
 					Role:    ChatMessageRoleSystem,
 					Content: StringOrArray{Value: "You are helpful"},
 				},
 			},
 			{
-				Type: ChatMessageRoleUser,
-				Value: ChatCompletionUserMessageParam{
+				OfUser: &ChatCompletionUserMessageParam{
 					Role: ChatMessageRoleUser,
 					Content: StringOrUserRoleContentUnion{
 						Value: []ChatCompletionContentPartUserUnionParam{
 							{
-								TextContent: &ChatCompletionContentPartTextParam{
+								OfText: &ChatCompletionContentPartTextParam{
 									Type: "text",
 									Text: "What's in this image?",
 								},
 							},
 							{
-								ImageContent: &ChatCompletionContentPartImageParam{
+								OfImageURL: &ChatCompletionContentPartImageParam{
 									Type: ChatCompletionContentPartImageTypeImageURL,
 									ImageURL: ChatCompletionContentPartImageImageURLParam{
 										URL: "https://example.com/image.jpg",
@@ -981,8 +961,7 @@ func TestChatCompletionRequest(t *testing.T) {
 				Model: "gpt-4o-audio-preview",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Hello!"},
 						},
@@ -1002,8 +981,7 @@ func TestChatCompletionRequest(t *testing.T) {
 				Model: "gpt-4.1-nano",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Hi"},
 						},
@@ -1027,8 +1005,7 @@ func TestChatCompletionRequest(t *testing.T) {
 				Model: "gpt-4o-audio-preview",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Hello!"},
 						},
@@ -1055,8 +1032,7 @@ func TestChatCompletionRequest(t *testing.T) {
 				Model: "gpt-4.1-nano",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Complete this: Hello"},
 						},
@@ -1079,8 +1055,7 @@ func TestChatCompletionRequest(t *testing.T) {
 				Model: "gpt-4o-mini-search-preview",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "What's the latest news?"},
 						},

--- a/internal/apischema/openai/vendor_fields_test.go
+++ b/internal/apischema/openai/vendor_fields_test.go
@@ -49,8 +49,7 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 				Model: "gemini-1.5-pro",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Hello, world!"},
 						},
@@ -97,8 +96,7 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 				Model: "claude-3",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Multiple vendors test"},
 						},
@@ -137,8 +135,7 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 				Model: "gpt-4",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Standard request"},
 						},
@@ -161,8 +158,7 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 				Model: "gemini-pro",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Empty vendor fields"},
 						},
@@ -185,8 +181,7 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 				Model: "gpt-3.5",
 				Messages: []ChatCompletionMessageParamUnion{
 					{
-						Type: ChatMessageRoleUser,
-						Value: ChatCompletionUserMessageParam{
+						OfUser: &ChatCompletionUserMessageParam{
 							Role:    ChatMessageRoleUser,
 							Content: StringOrUserRoleContentUnion{Value: "Null vendor fields"},
 						},

--- a/internal/extproc/translator/gemini_helper_test.go
+++ b/internal/extproc/translator/gemini_helper_test.go
@@ -31,29 +31,25 @@ func TestOpenAIMessagesToGeminiContents(t *testing.T) {
 			name: "happy-path",
 			messages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleDeveloper,
-					Value: openai.ChatCompletionDeveloperMessageParam{
+					OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 						Role:    openai.ChatMessageRoleDeveloper,
 						Content: openai.StringOrArray{Value: "This is a developer message"},
 					},
 				},
 				{
-					Type: openai.ChatMessageRoleSystem,
-					Value: openai.ChatCompletionSystemMessageParam{
+					OfSystem: &openai.ChatCompletionSystemMessageParam{
 						Role:    openai.ChatMessageRoleSystem,
 						Content: openai.StringOrArray{Value: "This is a system message"},
 					},
 				},
 				{
-					Type: openai.ChatMessageRoleUser,
-					Value: openai.ChatCompletionUserMessageParam{
+					OfUser: &openai.ChatCompletionUserMessageParam{
 						Role:    openai.ChatMessageRoleUser,
 						Content: openai.StringOrUserRoleContentUnion{Value: "This is a user message"},
 					},
 				},
 				{
-					Type: openai.ChatMessageRoleAssistant,
-					Value: openai.ChatCompletionAssistantMessageParam{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 						Role:    openai.ChatMessageRoleAssistant,
 						Audio:   openai.ChatCompletionAssistantMessageParamAudio{},
 						Content: openai.StringOrAssistantRoleContentUnion{Value: "This is a assistant message"},
@@ -70,8 +66,7 @@ func TestOpenAIMessagesToGeminiContents(t *testing.T) {
 					},
 				},
 				{
-					Type: openai.ChatMessageRoleTool,
-					Value: openai.ChatCompletionToolMessageParam{
+					OfTool: &openai.ChatCompletionToolMessageParam{
 						ToolCallID: "tool_call_1",
 						Content:    openai.StringOrArray{Value: "This is a message from the example_tool"},
 					},
@@ -528,13 +523,13 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							TextContent: &openai.ChatCompletionContentPartTextParam{
+							OfText: &openai.ChatCompletionContentPartTextParam{
 								Type: string(openai.ChatCompletionContentPartTextTypeText),
 								Text: "First message",
 							},
 						},
 						{
-							TextContent: &openai.ChatCompletionContentPartTextParam{
+							OfText: &openai.ChatCompletionContentPartTextParam{
 								Type: string(openai.ChatCompletionContentPartTextTypeText),
 								Text: "Second message",
 							},
@@ -554,7 +549,7 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							ImageContent: &openai.ChatCompletionContentPartImageParam{
+							OfImageURL: &openai.ChatCompletionContentPartImageParam{
 								Type: openai.ChatCompletionContentPartImageTypeImageURL,
 								ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 									URL: "https://example.com/image.jpg",
@@ -575,7 +570,7 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							ImageContent: &openai.ChatCompletionContentPartImageParam{
+							OfImageURL: &openai.ChatCompletionContentPartImageParam{
 								Type: openai.ChatCompletionContentPartImageTypeImageURL,
 								ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 									URL: "",
@@ -594,7 +589,7 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							ImageContent: &openai.ChatCompletionContentPartImageParam{
+							OfImageURL: &openai.ChatCompletionContentPartImageParam{
 								Type: openai.ChatCompletionContentPartImageTypeImageURL,
 								ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 									URL: ":%invalid-url%:",
@@ -613,13 +608,13 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							TextContent: &openai.ChatCompletionContentPartTextParam{
+							OfText: &openai.ChatCompletionContentPartTextParam{
 								Type: string(openai.ChatCompletionContentPartTextTypeText),
 								Text: "Check this image:",
 							},
 						},
 						{
-							ImageContent: &openai.ChatCompletionContentPartImageParam{
+							OfImageURL: &openai.ChatCompletionContentPartImageParam{
 								Type: openai.ChatCompletionContentPartImageTypeImageURL,
 								ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 									URL: "https://example.com/image.jpg",
@@ -641,7 +636,7 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							ImageContent: &openai.ChatCompletionContentPartImageParam{
+							OfImageURL: &openai.ChatCompletionContentPartImageParam{
 								Type: openai.ChatCompletionContentPartImageTypeImageURL,
 								ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 									URL: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q==",
@@ -667,7 +662,7 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							ImageContent: &openai.ChatCompletionContentPartImageParam{
+							OfImageURL: &openai.ChatCompletionContentPartImageParam{
 								Type: openai.ChatCompletionContentPartImageTypeImageURL,
 								ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 									URL: "data:invalid-format",
@@ -686,7 +681,7 @@ func TestUserMsgToGeminiParts(t *testing.T) {
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
 						{
-							InputAudioContent: &openai.ChatCompletionContentPartInputAudioParam{
+							OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{
 								Type: "audio",
 							},
 						},

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -39,50 +39,56 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model:  "gpt-4o",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: "from-system",
 							},
-						}, Type: openai.ChatMessageRoleSystem,
+							Role: openai.ChatMessageRoleSystem,
+						},
 					},
 					{
-						Value: openai.ChatCompletionDeveloperMessageParam{
+						OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 							Content: openai.StringOrArray{
 								Value: "from-developer",
 							},
-						}, Type: openai.ChatMessageRoleDeveloper,
+							Role: openai.ChatMessageRoleDeveloper,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "part1",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "part2",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 					{
-						Value: openai.ChatCompletionToolMessageParam{
+						OfTool: &openai.ChatCompletionToolMessageParam{
 							Content: openai.StringOrArray{
 								Value: "Weather in Queens, NY is 70F and clear skies.",
 							},
 							ToolCallID: "call_6g7a",
-						}, Type: openai.ChatMessageRoleTool,
+							Role:       openai.ChatMessageRoleTool,
+						},
 					},
 					{
-						Value: openai.ChatCompletionAssistantMessageParam{
+						OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 							Content: openai.StringOrAssistantRoleContentUnion{
 								Value: openai.ChatCompletionAssistantMessageParamContent{
 									Type: openai.ChatCompletionAssistantMessageParamContentTypeText,
@@ -99,21 +105,24 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 									Type: openai.ChatCompletionMessageToolCallTypeFunction,
 								},
 							},
-						}, Type: openai.ChatMessageRoleAssistant,
+							Role: openai.ChatMessageRoleAssistant,
+						},
 					},
 					{
-						Value: openai.ChatCompletionAssistantMessageParam{
+						OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 							Content: openai.StringOrAssistantRoleContentUnion{
 								Value: "I also dunno",
 							},
-						}, Type: openai.ChatMessageRoleAssistant,
+							Role: openai.ChatMessageRoleAssistant,
+						},
 					},
 					{
-						Value: openai.ChatCompletionAssistantMessageParam{
+						OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 							Content: openai.StringOrAssistantRoleContentUnion{
 								Value: "",
 							},
-						}, Type: openai.ChatMessageRoleAssistant,
+							Role: openai.ChatMessageRoleAssistant,
+						},
 					},
 				},
 			},
@@ -204,49 +213,54 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model:  "gpt-4o",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: []openai.ChatCompletionContentPartTextParam{
 									{Text: "from-system"},
 								},
 							},
-						}, Type: openai.ChatMessageRoleSystem,
+							Role: openai.ChatMessageRoleSystem,
+						},
 					},
 					{
-						Value: openai.ChatCompletionDeveloperMessageParam{
+						OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 							Content: openai.StringOrArray{
 								Value: []openai.ChatCompletionContentPartTextParam{
 									{Text: "from-developer"},
 								},
 							},
-						}, Type: openai.ChatMessageRoleDeveloper,
+							Role: openai.ChatMessageRoleDeveloper,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: []openai.ChatCompletionContentPartUserUnionParam{
-									{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "from-user"}},
+									{OfText: &openai.ChatCompletionContentPartTextParam{Text: "from-user"}},
 								},
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: []openai.ChatCompletionContentPartUserUnionParam{
-									{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "user1"}},
+									{OfText: &openai.ChatCompletionContentPartTextParam{Text: "user1"}},
 								},
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: []openai.ChatCompletionContentPartUserUnionParam{
-									{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "user2"}},
+									{OfText: &openai.ChatCompletionContentPartTextParam{Text: "user2"}},
 								},
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 			},
@@ -295,26 +309,28 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model:  "gpt-4o",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: []openai.ChatCompletionContentPartTextParam{
 									{Text: "from-system"},
 								},
 							},
-						}, Type: openai.ChatMessageRoleSystem,
+							Role: openai.ChatMessageRoleSystem,
+						},
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: []openai.ChatCompletionContentPartUserUnionParam{
-									{ImageContent: &openai.ChatCompletionContentPartImageParam{
+									{OfImageURL: &openai.ChatCompletionContentPartImageParam{
 										ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 											URL: "data:image/jpeg;base64,dGVzdA==",
 										},
 									}},
 								},
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 			},
@@ -352,11 +368,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Temperature: ptr.To(0.7),
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 			},
@@ -388,11 +405,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Temperature: ptr.To(0.7),
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 				Tools: []openai.Tool{
@@ -469,11 +487,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "gpt-4o",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 				Tools: []openai.Tool{
@@ -519,11 +538,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "gpt-4o",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 				Tools: []openai.Tool{
@@ -569,11 +589,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 				Tools: []openai.Tool{
@@ -623,11 +644,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 				Tools: []openai.Tool{
@@ -682,11 +704,12 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "gpt-4o",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "from-user",
 							},
-						}, Type: openai.ChatMessageRoleUser,
+							Role: openai.ChatMessageRoleUser,
+						},
 					},
 				},
 				Stop: []*string{ptr.To("stop_only")},
@@ -713,8 +736,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Type: openai.ChatMessageRoleUser,
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Role: openai.ChatMessageRoleUser,
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "What is the weather in Dallas, Texas and Orlando, Florida in Fahrenheit?",
@@ -722,8 +744,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 						},
 					},
 					{
-						Type: openai.ChatMessageRoleAssistant,
-						Value: openai.ChatCompletionAssistantMessageParam{
+						OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 							Role: openai.ChatMessageRoleAssistant,
 							ToolCalls: []openai.ChatCompletionMessageToolCallParam{
 								{
@@ -746,8 +767,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 						},
 					},
 					{
-						Type: openai.ChatMessageRoleTool,
-						Value: openai.ChatCompletionToolMessageParam{
+						OfTool: &openai.ChatCompletionToolMessageParam{
 							Content: openai.StringOrArray{
 								Value: "The weather in Dallas TX is 98 degrees fahrenheit with mostly cloudy skies and a change of rain in the evening.",
 							},
@@ -756,8 +776,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 						},
 					},
 					{
-						Type: openai.ChatMessageRoleTool,
-						Value: openai.ChatCompletionToolMessageParam{
+						OfTool: &openai.ChatCompletionToolMessageParam{
 							Content: openai.StringOrArray{
 								Value: "The weather in Orlando FL is 78 degrees fahrenheit with clear skies.",
 							},
@@ -827,11 +846,11 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_RequestBody(t *testing.T) 
 				Model: "anthropic.claude-3-sonnet-20240229-v1:0",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Type: openai.ChatMessageRoleUser,
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "Hello",
 							},
+							Role: openai.ChatMessageRoleUser,
 						},
 					},
 				},

--- a/internal/extproc/translator/openai_gcpanthropic_test.go
+++ b/internal/extproc/translator/openai_gcpanthropic_test.go
@@ -36,12 +36,10 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_RequestBody(t *testing.T
 		Model: claudeTestModel,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type:  openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{Content: openai.StringOrArray{Value: "You are a helpful assistant."}},
+				OfSystem: &openai.ChatCompletionSystemMessageParam{Content: openai.StringOrArray{Value: "You are a helpful assistant."}, Role: openai.ChatMessageRoleSystem},
 			},
 			{
-				Type:  openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"}},
+				OfUser: &openai.ChatCompletionUserMessageParam{Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"}, Role: openai.ChatMessageRoleUser},
 			},
 		},
 		MaxTokens:   ptr.To(int64(1024)),
@@ -92,18 +90,18 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_RequestBody(t *testing.T
 			Model:               "claude-3-opus-20240229",
 			Messages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleUser,
-					Value: openai.ChatCompletionUserMessageParam{
+					OfUser: &openai.ChatCompletionUserMessageParam{
 						Content: openai.StringOrUserRoleContentUnion{
 							Value: []openai.ChatCompletionContentPartUserUnionParam{
-								{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "What is in this image?"}},
-								{ImageContent: &openai.ChatCompletionContentPartImageParam{
+								{OfText: &openai.ChatCompletionContentPartTextParam{Text: "What is in this image?"}},
+								{OfImageURL: &openai.ChatCompletionContentPartImageParam{
 									ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 										URL: "data:image/jpeg;base64,dGVzdA==", // "test" in base64.
 									},
 								}},
 							},
 						},
+						Role: openai.ChatMessageRoleUser,
 					},
 				},
 			},
@@ -126,9 +124,9 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_RequestBody(t *testing.T
 		multiSystemReq := &openai.ChatCompletionRequest{
 			Model: claudeTestModel,
 			Messages: []openai.ChatCompletionMessageParamUnion{
-				{Type: openai.ChatMessageRoleSystem, Value: openai.ChatCompletionSystemMessageParam{Content: openai.StringOrArray{Value: firstMsg}}},
-				{Type: openai.ChatMessageRoleDeveloper, Value: openai.ChatCompletionDeveloperMessageParam{Content: openai.StringOrArray{Value: secondMsg}}},
-				{Type: openai.ChatMessageRoleUser, Value: openai.ChatCompletionUserMessageParam{Content: openai.StringOrUserRoleContentUnion{Value: thirdMsg}}},
+				{OfSystem: &openai.ChatCompletionSystemMessageParam{Content: openai.StringOrArray{Value: firstMsg}, Role: openai.ChatMessageRoleSystem}},
+				{OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{Content: openai.StringOrArray{Value: secondMsg}, Role: openai.ChatMessageRoleDeveloper}},
+				{OfUser: &openai.ChatCompletionUserMessageParam{Content: openai.StringOrUserRoleContentUnion{Value: thirdMsg}, Role: openai.ChatMessageRoleUser}},
 			},
 			MaxTokens: ptr.To(int64(100)),
 		}
@@ -384,9 +382,9 @@ func TestMessageTranslation(t *testing.T) {
 			name: "assistant message with text",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleAssistant,
-					Value: openai.ChatCompletionAssistantMessageParam{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 						Content: openai.StringOrAssistantRoleContentUnion{Value: "Hello from the assistant."},
+						Role:    openai.ChatMessageRoleAssistant,
 					},
 				},
 			},
@@ -401,8 +399,7 @@ func TestMessageTranslation(t *testing.T) {
 			name: "assistant message with tool call",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleAssistant,
-					Value: openai.ChatCompletionAssistantMessageParam{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 						ToolCalls: []openai.ChatCompletionMessageToolCallParam{
 							{
 								ID:       ptr.To(testTool),
@@ -410,6 +407,7 @@ func TestMessageTranslation(t *testing.T) {
 								Function: openai.ChatCompletionMessageToolCallFunctionParam{Name: "get_weather", Arguments: `{"location":"NYC"}`},
 							},
 						},
+						Role: openai.ChatMessageRoleAssistant,
 					},
 				},
 			},
@@ -433,14 +431,14 @@ func TestMessageTranslation(t *testing.T) {
 			name: "assistant message with refusal",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleAssistant,
-					Value: openai.ChatCompletionAssistantMessageParam{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 						Content: openai.StringOrAssistantRoleContentUnion{
 							Value: openai.ChatCompletionAssistantMessageParamContent{
 								Type:    openai.ChatCompletionAssistantMessageParamContentTypeRefusal,
 								Refusal: ptr.To("I cannot answer that."),
 							},
 						},
+						Role: openai.ChatMessageRoleAssistant,
 					},
 				},
 			},
@@ -455,12 +453,12 @@ func TestMessageTranslation(t *testing.T) {
 			name: "tool message with text content",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleTool,
-					Value: openai.ChatCompletionToolMessageParam{
+					OfTool: &openai.ChatCompletionToolMessageParam{
 						ToolCallID: testTool,
 						Content: openai.StringOrArray{
 							Value: "The weather is 72 degrees and sunny.",
 						},
+						Role: openai.ChatMessageRoleTool,
 					},
 				},
 			},
@@ -489,9 +487,9 @@ func TestMessageTranslation(t *testing.T) {
 		{
 			name: "system and developer messages",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
-				{Type: openai.ChatMessageRoleSystem, Value: openai.ChatCompletionSystemMessageParam{Content: openai.StringOrArray{Value: "System prompt."}}},
-				{Type: openai.ChatMessageRoleUser, Value: openai.ChatCompletionUserMessageParam{Content: openai.StringOrUserRoleContentUnion{Value: "User message."}}},
-				{Type: openai.ChatMessageRoleDeveloper, Value: openai.ChatCompletionDeveloperMessageParam{Content: openai.StringOrArray{Value: "Developer prompt."}}},
+				{OfSystem: &openai.ChatCompletionSystemMessageParam{Content: openai.StringOrArray{Value: "System prompt."}, Role: openai.ChatMessageRoleSystem}},
+				{OfUser: &openai.ChatCompletionUserMessageParam{Content: openai.StringOrUserRoleContentUnion{Value: "User message."}, Role: openai.ChatMessageRoleUser}},
+				{OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{Content: openai.StringOrArray{Value: "Developer prompt."}, Role: openai.ChatMessageRoleDeveloper}},
 			},
 			expectedAnthropicMsgs: []anthropic.MessageParam{
 				{
@@ -508,11 +506,11 @@ func TestMessageTranslation(t *testing.T) {
 			name: "user message with content error",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleUser,
-					Value: openai.ChatCompletionUserMessageParam{
+					OfUser: &openai.ChatCompletionUserMessageParam{
 						Content: openai.StringOrUserRoleContentUnion{
 							Value: 0,
 						},
+						Role: openai.ChatMessageRoleUser,
 					},
 				},
 			},
@@ -522,8 +520,7 @@ func TestMessageTranslation(t *testing.T) {
 			name: "assistant message with tool call error",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleAssistant,
-					Value: openai.ChatCompletionAssistantMessageParam{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 						ToolCalls: []openai.ChatCompletionMessageToolCallParam{
 							{
 								ID:       ptr.To(testTool),
@@ -531,6 +528,7 @@ func TestMessageTranslation(t *testing.T) {
 								Function: openai.ChatCompletionMessageToolCallFunctionParam{Name: "get_weather", Arguments: `{"location":`},
 							},
 						},
+						Role: openai.ChatMessageRoleAssistant,
 					},
 				},
 			},
@@ -540,10 +538,10 @@ func TestMessageTranslation(t *testing.T) {
 			name: "tool message with content error",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleTool,
-					Value: openai.ChatCompletionToolMessageParam{
+					OfTool: &openai.ChatCompletionToolMessageParam{
 						ToolCallID: testTool,
 						Content:    openai.StringOrArray{Value: 123},
+						Role:       openai.ChatMessageRoleTool,
 					},
 				},
 			},
@@ -553,13 +551,12 @@ func TestMessageTranslation(t *testing.T) {
 			name: "tool message with image content",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleTool,
-					Value: openai.ChatCompletionToolMessageParam{
+					OfTool: &openai.ChatCompletionToolMessageParam{
 						ToolCallID: "tool_def",
 						Content: openai.StringOrArray{
 							Value: []openai.ChatCompletionContentPartUserUnionParam{
 								{
-									ImageContent: &openai.ChatCompletionContentPartImageParam{
+									OfImageURL: &openai.ChatCompletionContentPartImageParam{
 										ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 											URL: "data:image/png;base64,dGVzdA==",
 										},
@@ -567,6 +564,7 @@ func TestMessageTranslation(t *testing.T) {
 								},
 							},
 						},
+						Role: openai.ChatMessageRoleTool,
 					},
 				},
 			},
@@ -601,17 +599,17 @@ func TestMessageTranslation(t *testing.T) {
 			name: "multiple tool messages aggregated correctly",
 			inputMessages: []openai.ChatCompletionMessageParamUnion{
 				{
-					Type: openai.ChatMessageRoleTool,
-					Value: openai.ChatCompletionToolMessageParam{
+					OfTool: &openai.ChatCompletionToolMessageParam{
 						ToolCallID: "tool_1",
 						Content:    openai.StringOrArray{Value: `{"temp": "72F"}`},
+						Role:       openai.ChatMessageRoleTool,
 					},
 				},
 				{
-					Type: openai.ChatMessageRoleTool,
-					Value: openai.ChatCompletionToolMessageParam{
+					OfTool: &openai.ChatCompletionToolMessageParam{
 						ToolCallID: "tool_2",
 						Content:    openai.StringOrArray{Value: `{"time": "16:00"}`},
+						Role:       openai.ChatMessageRoleTool,
 					},
 				},
 			},
@@ -1216,7 +1214,7 @@ func TestContentTranslationCoverage(t *testing.T) {
 		{
 			name: "pdf data uri",
 			inputContent: []openai.ChatCompletionContentPartUserUnionParam{
-				{ImageContent: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "data:application/pdf;base64,dGVzdA=="}}},
+				{OfImageURL: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "data:application/pdf;base64,dGVzdA=="}}},
 			},
 			expectedContent: []anthropic.ContentBlockParamUnion{
 				{
@@ -1235,7 +1233,7 @@ func TestContentTranslationCoverage(t *testing.T) {
 		{
 			name: "pdf url",
 			inputContent: []openai.ChatCompletionContentPartUserUnionParam{
-				{ImageContent: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "https://example.com/doc.pdf"}}},
+				{OfImageURL: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "https://example.com/doc.pdf"}}},
 			},
 			expectedContent: []anthropic.ContentBlockParamUnion{
 				{
@@ -1253,7 +1251,7 @@ func TestContentTranslationCoverage(t *testing.T) {
 		{
 			name: "image url",
 			inputContent: []openai.ChatCompletionContentPartUserUnionParam{
-				{ImageContent: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "https://example.com/image.png"}}},
+				{OfImageURL: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "https://example.com/image.png"}}},
 			},
 			expectedContent: []anthropic.ContentBlockParamUnion{
 				{
@@ -1270,7 +1268,7 @@ func TestContentTranslationCoverage(t *testing.T) {
 		},
 		{
 			name:         "audio content error",
-			inputContent: []openai.ChatCompletionContentPartUserUnionParam{{InputAudioContent: &openai.ChatCompletionContentPartInputAudioParam{}}},
+			inputContent: []openai.ChatCompletionContentPartUserUnionParam{{OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{}}},
 			expectErr:    true,
 		},
 	}
@@ -1356,8 +1354,8 @@ func TestSystemPromptExtractionCoverage(t *testing.T) {
 			name: "developer message with content parts",
 			inputMsg: openai.ChatCompletionDeveloperMessageParam{
 				Content: openai.StringOrArray{Value: []openai.ChatCompletionContentPartUserUnionParam{
-					{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "part 1"}},
-					{TextContent: &openai.ChatCompletionContentPartTextParam{Text: " part 2"}},
+					{OfText: &openai.ChatCompletionContentPartTextParam{Text: "part 1"}},
+					{OfText: &openai.ChatCompletionContentPartTextParam{Text: " part 2"}},
 				}},
 			},
 			expectedPrompt: "part 1 part 2",
@@ -1378,7 +1376,7 @@ func TestSystemPromptExtractionCoverage(t *testing.T) {
 			name: "developer message with StringOrArray of parts",
 			inputMsg: openai.ChatCompletionDeveloperMessageParam{
 				Content: openai.StringOrArray{Value: openai.StringOrArray{Value: []openai.ChatCompletionContentPartUserUnionParam{
-					{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "nested part"}},
+					{OfText: &openai.ChatCompletionContentPartTextParam{Text: "nested part"}},
 				}}},
 			},
 			expectedPrompt: "nested part",

--- a/internal/extproc/translator/openai_gcpvertexai_test.go
+++ b/internal/extproc/translator/openai_gcpvertexai_test.go
@@ -185,20 +185,20 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_RequestBody(t *testing.T)
 				Model:  "gemini-pro",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: "You are a helpful assistant",
 							},
+							Role: openai.ChatMessageRoleSystem,
 						},
-						Type: openai.ChatMessageRoleSystem,
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "Tell me about AI Gateways",
 							},
+							Role: openai.ChatMessageRoleUser,
 						},
-						Type: openai.ChatMessageRoleUser,
 					},
 				},
 			},
@@ -234,20 +234,20 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_RequestBody(t *testing.T)
 				Model:  "gemini-pro",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: "You are a helpful assistant",
 							},
+							Role: openai.ChatMessageRoleSystem,
 						},
-						Type: openai.ChatMessageRoleSystem,
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "Tell me about AI Gateways",
 							},
+							Role: openai.ChatMessageRoleUser,
 						},
-						Type: openai.ChatMessageRoleUser,
 					},
 				},
 			},
@@ -284,20 +284,20 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_RequestBody(t *testing.T)
 				Model:  "gemini-pro",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: "You are a helpful assistant",
 							},
+							Role: openai.ChatMessageRoleSystem,
 						},
-						Type: openai.ChatMessageRoleSystem,
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "Tell me about AI Gateways",
 							},
+							Role: openai.ChatMessageRoleUser,
 						},
-						Type: openai.ChatMessageRoleUser,
 					},
 				},
 			},
@@ -333,20 +333,20 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_RequestBody(t *testing.T)
 				Model:  "gemini-pro",
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Value: openai.ChatCompletionSystemMessageParam{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
 							Content: openai.StringOrArray{
 								Value: "You are a helpful assistant",
 							},
+							Role: openai.ChatMessageRoleSystem,
 						},
-						Type: openai.ChatMessageRoleSystem,
 					},
 					{
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Content: openai.StringOrUserRoleContentUnion{
 								Value: "What's the weather in San Francisco?",
 							},
+							Role: openai.ChatMessageRoleUser,
 						},
-						Type: openai.ChatMessageRoleUser,
 					},
 				},
 				Tools: []openai.Tool{
@@ -405,8 +405,7 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_RequestBody(t *testing.T)
 				MaxTokens:   ptr.To(int64(1024)),
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Type: openai.ChatMessageRoleUser,
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Role:    openai.ChatMessageRoleUser,
 							Content: openai.StringOrUserRoleContentUnion{Value: "Test with standard fields"},
 						},
@@ -470,8 +469,7 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_RequestBody(t *testing.T)
 				MaxTokens:   ptr.To(int64(1024)),
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{
-						Type: openai.ChatMessageRoleUser,
-						Value: openai.ChatCompletionUserMessageParam{
+						OfUser: &openai.ChatCompletionUserMessageParam{
 							Role:    openai.ChatMessageRoleUser,
 							Content: openai.StringOrUserRoleContentUnion{Value: "Test with standard fields"},
 						},

--- a/internal/tracing/openinference/openai/chat_completion_config_test.go
+++ b/internal/tracing/openinference/openai/chat_completion_config_test.go
@@ -200,16 +200,15 @@ func TestChatCompletionRecorder_WithConfig_HideImages(t *testing.T) {
 	multimodalReq := &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role: openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
-						{TextContent: &openai.ChatCompletionContentPartTextParam{
+						{OfText: &openai.ChatCompletionContentPartTextParam{
 							Text: "What is in this image?",
 							Type: "text",
 						}},
-						{ImageContent: &openai.ChatCompletionContentPartImageParam{
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
 							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 								URL: "https://example.com/image.jpg",
 							},
@@ -289,12 +288,11 @@ func TestChatCompletionRecorder_WithConfig_Base64ImageMaxLength(t *testing.T) {
 	base64ImageReq := &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role: openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
-						{ImageContent: &openai.ChatCompletionContentPartImageParam{
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
 							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 								URL: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
 							},
@@ -382,8 +380,7 @@ func TestChatCompletionRecorder_WithConfig_NoJSONMarshalWhenHidden(t *testing.T)
 	invalidReq := &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"},
 				Role:    openai.ChatMessageRoleUser,
 			},

--- a/internal/tracing/openinference/openai/request_attrs.go
+++ b/internal/tracing/openinference/openai/request_attrs.go
@@ -52,53 +52,52 @@ func buildRequestAttributes(chatRequest *openai.ChatCompletionRequest, body stri
 	// Note: compound match here is from Python OpenInference OpenAI config.py.
 	if !config.HideInputs && !config.HideInputMessages {
 		for i, msg := range chatRequest.Messages {
-			role := msg.Type
+			role := msg.ExtractMessgaeRole()
 			attrs = append(attrs, attribute.String(openinference.InputMessageAttribute(i, openinference.MessageRole), role))
 
-			switch v := msg.Value.(type) {
-			case openai.ChatCompletionUserMessageParam:
-				if v.Content.Value != nil {
-					switch content := v.Content.Value.(type) {
-					case string:
-						if content != "" {
-							if config.HideInputText {
-								content = openinference.RedactedValue
-							}
-							attrs = append(attrs, attribute.String(openinference.InputMessageAttribute(i, openinference.MessageContent), content))
+			if msg.OfUser != nil {
+				switch content := msg.OfUser.Content.Value.(type) {
+				case string:
+					if content != "" {
+						if config.HideInputText {
+							content = openinference.RedactedValue
 						}
-					case []openai.ChatCompletionContentPartUserUnionParam:
-						for j, part := range content {
-							switch {
-							case part.TextContent != nil:
-								text := part.TextContent.Text
-								if config.HideInputText {
-									text = openinference.RedactedValue
+						attrs = append(attrs, attribute.String(openinference.InputMessageAttribute(i, openinference.MessageContent), content))
+					}
+				case []openai.ChatCompletionContentPartUserUnionParam:
+					for j, part := range content {
+						switch {
+						case part.OfText != nil:
+							text := part.OfText.Text
+							if config.HideInputText {
+								text = openinference.RedactedValue
+							}
+							attrs = append(attrs,
+								attribute.String(openinference.InputMessageContentAttribute(i, j, "text"), text),
+								attribute.String(openinference.InputMessageContentAttribute(i, j, "type"), "text"),
+							)
+						case part.OfImageURL != nil && part.OfImageURL.ImageURL.URL != "":
+							if !config.HideInputImages {
+								urlKey := openinference.InputMessageContentAttribute(i, j, "image.image.url")
+								typeKey := openinference.InputMessageContentAttribute(i, j, "type")
+								url := part.OfImageURL.ImageURL.URL
+								if isBase64URL(url) && len(url) > config.Base64ImageMaxLength {
+									url = openinference.RedactedValue
 								}
 								attrs = append(attrs,
-									attribute.String(openinference.InputMessageContentAttribute(i, j, "text"), text),
-									attribute.String(openinference.InputMessageContentAttribute(i, j, "type"), "text"),
+									attribute.String(urlKey, url),
+									attribute.String(typeKey, "image"),
 								)
-							case part.ImageContent != nil && part.ImageContent.ImageURL.URL != "":
-								if !config.HideInputImages {
-									urlKey := openinference.InputMessageContentAttribute(i, j, "image.image.url")
-									typeKey := openinference.InputMessageContentAttribute(i, j, "type")
-									url := part.ImageContent.ImageURL.URL
-									if isBase64URL(url) && len(url) > config.Base64ImageMaxLength {
-										url = openinference.RedactedValue
-									}
-									attrs = append(attrs,
-										attribute.String(urlKey, url),
-										attribute.String(typeKey, "image"),
-									)
-								}
-							case part.InputAudioContent != nil:
-								// Skip recording audio content attributes to match Python OpenInference behavior.
-								// Audio data is already included in input.value as part of the full request.
 							}
+						case part.OfInputAudio != nil:
+							// Skip recording audio content attributes to match Python OpenInference behavior.
+							// Audio data is already included in input.value as part of the full request.
+						case part.OfFile != nil:
+							// TODO: skip file content for now.
 						}
 					}
 				}
-			default:
+			} else {
 				// For other message types, use the simple extraction.
 				content := extractMessageContent(msg)
 				if content != "" {
@@ -125,44 +124,50 @@ func buildRequestAttributes(chatRequest *openai.ChatCompletionRequest, body stri
 
 // extractMessageContent extracts content from OpenAI message union types.
 func extractMessageContent(msg openai.ChatCompletionMessageParamUnion) string {
-	switch v := msg.Value.(type) {
-	case openai.ChatCompletionUserMessageParam:
-		if v.Content.Value == nil {
+	switch {
+	case msg.OfUser != nil:
+		content := msg.OfUser.Content
+		if content.Value == nil {
 			return ""
 		}
-		if content, ok := v.Content.Value.(string); ok {
+		if content, ok := content.Value.(string); ok {
 			return content
 		}
 		return "[complex content]"
-	case openai.ChatCompletionAssistantMessageParam:
-		if v.Content.Value == nil {
+	case msg.OfAssistant != nil:
+		content := msg.OfAssistant.Content
+
+		if content.Value == nil {
 			return ""
 		}
-		if content, ok := v.Content.Value.(string); ok {
+		if content, ok := content.Value.(string); ok {
 			return content
 		}
 		return "[assistant message]"
-	case openai.ChatCompletionSystemMessageParam:
-		if v.Content.Value == nil {
+	case msg.OfSystem != nil:
+		content := msg.OfSystem.Content
+		if content.Value == nil {
 			return ""
 		}
-		if content, ok := v.Content.Value.(string); ok {
+		if content, ok := content.Value.(string); ok {
 			return content
 		}
 		return "[system message]"
-	case openai.ChatCompletionDeveloperMessageParam:
-		if v.Content.Value == nil {
+	case msg.OfDeveloper != nil:
+		content := msg.OfDeveloper.Content
+		if content.Value == nil {
 			return ""
 		}
-		if content, ok := v.Content.Value.(string); ok {
+		if content, ok := content.Value.(string); ok {
 			return content
 		}
 		return "[developer message]"
-	case openai.ChatCompletionToolMessageParam:
-		if v.Content.Value == nil {
+	case msg.OfTool != nil:
+		content := msg.OfTool.Content
+		if content.Value == nil {
 			return ""
 		}
-		if content, ok := v.Content.Value.(string); ok {
+		if content, ok := content.Value.(string); ok {
 			return content
 		}
 		return "[tool content]"

--- a/internal/tracing/openinference/openai/request_attrs_test.go
+++ b/internal/tracing/openinference/openai/request_attrs_test.go
@@ -19,8 +19,7 @@ var (
 	basicReq = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"},
 				Role:    openai.ChatMessageRoleUser,
 			},
@@ -40,16 +39,15 @@ var (
 		Model:     openai.ModelGPT5Nano,
 		MaxTokens: ptr(int64(100)),
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role: openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
-						{TextContent: &openai.ChatCompletionContentPartTextParam{
+						{OfText: &openai.ChatCompletionContentPartTextParam{
 							Text: "What is in this image?",
 							Type: "text",
 						}},
-						{ImageContent: &openai.ChatCompletionContentPartImageParam{
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
 							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 								URL: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
 							},
@@ -66,8 +64,7 @@ var (
 	toolsReq = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role:    openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{Value: "What is the weather like in Boston today?"},
 			},
@@ -101,16 +98,15 @@ var (
 	audioReq = &openai.ChatCompletionRequest{
 		Model: "gpt-4o-audio-preview",
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role: openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
-						{TextContent: &openai.ChatCompletionContentPartTextParam{
+						{OfText: &openai.ChatCompletionContentPartTextParam{
 							Text: "Answer in up to 5 words: What do you hear in this audio?",
 							Type: "text",
 						}},
-						{InputAudioContent: &openai.ChatCompletionContentPartInputAudioParam{
+						{OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{
 							InputAudio: openai.ChatCompletionContentPartInputAudioInputAudioParam{
 								Data:   "REDACTED_BASE64_AUDIO_DATA",
 								Format: "wav",
@@ -128,8 +124,7 @@ var (
 	jsonModeReq = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role:    openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{Value: "Generate a JSON object with three properties: name, age, and city."},
 			},
@@ -147,15 +142,13 @@ var (
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{
+				OfSystem: &openai.ChatCompletionSystemMessageParam{
 					Role:    openai.ChatMessageRoleSystem,
 					Content: openai.StringOrArray{Value: "You are a helpful assistant."},
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role:    openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"},
 				},
@@ -168,8 +161,7 @@ var (
 	emptyToolsReq = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role:    openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"},
 			},
@@ -183,15 +175,13 @@ var (
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role:    openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{Value: "What's the weather?"},
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleAssistant,
-				Value: openai.ChatCompletionAssistantMessageParam{
+				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 					Role:    openai.ChatMessageRoleAssistant,
 					Content: openai.StringOrAssistantRoleContentUnion{Value: nil},
 					ToolCalls: []openai.ChatCompletionMessageToolCallParam{{
@@ -205,8 +195,7 @@ var (
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleTool,
-				Value: openai.ChatCompletionToolMessageParam{
+				OfTool: &openai.ChatCompletionToolMessageParam{
 					Role:       openai.ChatMessageRoleTool,
 					ToolCallID: "call_123",
 					Content:    openai.StringOrArray{Value: "Sunny, 72°F"},
@@ -220,16 +209,15 @@ var (
 	emptyImageURLReq = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role: openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{
 					Value: []openai.ChatCompletionContentPartUserUnionParam{
-						{TextContent: &openai.ChatCompletionContentPartTextParam{
+						{OfText: &openai.ChatCompletionContentPartTextParam{
 							Text: "What is this?",
 							Type: "text",
 						}},
-						{ImageContent: &openai.ChatCompletionContentPartImageParam{
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
 							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 								URL: "", // Empty URL.
 							},
@@ -246,8 +234,7 @@ var (
 	emptyContentReq = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Role:    openai.ChatMessageRoleUser,
 				Content: openai.StringOrUserRoleContentUnion{Value: ""},
 			},
@@ -510,11 +497,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "user message with string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Hello, how are you?",
 					},
+					Role: openai.ChatMessageRoleUser,
 				},
 			},
 			expected: "Hello, how are you?",
@@ -522,11 +509,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "user message with nil content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: nil,
 					},
+					Role: openai.ChatMessageRoleUser,
 				},
 			},
 			expected: "",
@@ -534,14 +521,14 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "user message with complex content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: []openai.ChatCompletionContentPartUserUnionParam{
-							{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "Part 1"}},
-							{TextContent: &openai.ChatCompletionContentPartTextParam{Text: "Part 2"}},
+							{OfText: &openai.ChatCompletionContentPartTextParam{Text: "Part 1"}},
+							{OfText: &openai.ChatCompletionContentPartTextParam{Text: "Part 2"}},
 						},
 					},
+					Role: openai.ChatMessageRoleUser,
 				},
 			},
 			expected: "[complex content]",
@@ -550,11 +537,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "assistant message with string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleAssistant,
-				Value: openai.ChatCompletionAssistantMessageParam{
+				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 					Content: openai.StringOrAssistantRoleContentUnion{
 						Value: "I'm doing well, thank you!",
 					},
+					Role: openai.ChatMessageRoleAssistant,
 				},
 			},
 			expected: "I'm doing well, thank you!",
@@ -562,11 +549,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "assistant message with nil content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleAssistant,
-				Value: openai.ChatCompletionAssistantMessageParam{
+				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 					Content: openai.StringOrAssistantRoleContentUnion{
 						Value: nil,
 					},
+					Role: openai.ChatMessageRoleAssistant,
 				},
 			},
 			expected: "",
@@ -575,11 +562,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "system message with string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{
+				OfSystem: &openai.ChatCompletionSystemMessageParam{
 					Content: openai.StringOrArray{
 						Value: "You are a helpful assistant.",
 					},
+					Role: openai.ChatMessageRoleSystem,
 				},
 			},
 			expected: "You are a helpful assistant.",
@@ -588,11 +575,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "developer message with string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleDeveloper,
-				Value: openai.ChatCompletionDeveloperMessageParam{
+				OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 					Content: openai.StringOrArray{
 						Value: "Internal developer note",
 					},
+					Role: openai.ChatMessageRoleDeveloper,
 				},
 			},
 			expected: "Internal developer note",
@@ -601,11 +588,11 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "tool message with string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleTool,
-				Value: openai.ChatCompletionToolMessageParam{
+				OfTool: &openai.ChatCompletionToolMessageParam{
 					Content: openai.StringOrArray{
 						Value: "Tool response content",
 					},
+					Role: openai.ChatMessageRoleTool,
 				},
 			},
 			expected: "Tool response content",
@@ -613,9 +600,8 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "assistant message with empty string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: "assistant",
-				Value: openai.ChatCompletionAssistantMessageParam{
-					Role:    "assistant",
+				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+					Role:    openai.ChatMessageRoleAssistant,
 					Content: openai.StringOrAssistantRoleContentUnion{Value: ""},
 				},
 			},
@@ -624,13 +610,13 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "assistant message with non-string content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleAssistant,
-				Value: openai.ChatCompletionAssistantMessageParam{
+				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 					Content: openai.StringOrAssistantRoleContentUnion{
 						Value: []openai.ChatCompletionAssistantMessageParamContent{
 							{Type: "text", Text: ptr("Part 1")},
 						},
 					},
+					Role: openai.ChatMessageRoleAssistant,
 				},
 			},
 			expected: "[assistant message]",
@@ -638,9 +624,9 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "system message with nil content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{
+				OfSystem: &openai.ChatCompletionSystemMessageParam{
 					Content: openai.StringOrArray{Value: nil},
+					Role:    openai.ChatMessageRoleSystem,
 				},
 			},
 			expected: "",
@@ -648,9 +634,9 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "system message with array content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{
+				OfSystem: &openai.ChatCompletionSystemMessageParam{
 					Content: openai.StringOrArray{Value: []string{"instruction1", "instruction2"}},
+					Role:    openai.ChatMessageRoleSystem,
 				},
 			},
 			expected: "[system message]",
@@ -658,9 +644,9 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "developer message with nil content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleDeveloper,
-				Value: openai.ChatCompletionDeveloperMessageParam{
+				OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 					Content: openai.StringOrArray{Value: nil},
+					Role:    openai.ChatMessageRoleDeveloper,
 				},
 			},
 			expected: "",
@@ -668,9 +654,8 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "developer message with array content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: "developer",
-				Value: openai.ChatCompletionDeveloperMessageParam{
-					Role:    "developer",
+				OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
+					Role:    openai.ChatMessageRoleDeveloper,
 					Content: openai.StringOrArray{Value: []string{"instruction1", "instruction2"}},
 				},
 			},
@@ -679,9 +664,9 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "tool message with nil content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: openai.ChatMessageRoleTool,
-				Value: openai.ChatCompletionToolMessageParam{
+				OfTool: &openai.ChatCompletionToolMessageParam{
 					Content: openai.StringOrArray{Value: nil},
+					Role:    openai.ChatMessageRoleTool,
 				},
 			},
 			expected: "",
@@ -689,9 +674,8 @@ func TestExtractMessageContent(t *testing.T) {
 		{
 			name: "tool message with array content",
 			msg: openai.ChatCompletionMessageParamUnion{
-				Type: "tool",
-				Value: openai.ChatCompletionToolMessageParam{
-					Role:       "tool",
+				OfTool: &openai.ChatCompletionToolMessageParam{
+					Role:       openai.ChatMessageRoleTool,
 					ToolCallID: "call_123",
 					Content:    openai.StringOrArray{Value: []string{"result1", "result2"}},
 				},
@@ -700,11 +684,8 @@ func TestExtractMessageContent(t *testing.T) {
 		},
 		// Unknown message type.
 		{
-			name: "unknown message type",
-			msg: openai.ChatCompletionMessageParamUnion{
-				Type:  "unknown",
-				Value: "some unknown value",
-			},
+			name:     "unknown message type",
+			msg:      openai.ChatCompletionMessageParamUnion{},
 			expected: "[unknown message type]",
 		},
 	}

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -32,8 +32,7 @@ var (
 	req = &openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{{
-			Type: openai.ChatMessageRoleUser,
-			Value: openai.ChatCompletionUserMessageParam{
+			OfUser: &openai.ChatCompletionUserMessageParam{
 				Content: openai.StringOrUserRoleContentUnion{Value: "Hello!"},
 				Role:    openai.ChatMessageRoleUser,
 			},

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -283,10 +283,11 @@ func TestNewTracingFromEnv_OpenInferenceRedaction(t *testing.T) {
 			req := &openai.ChatCompletionRequest{
 				Model: openai.ModelGPT5Nano,
 				Messages: []openai.ChatCompletionMessageParamUnion{{
-					Type: openai.ChatMessageRoleUser,
-					Value: openai.ChatCompletionUserMessageParam{
-						Content: openai.StringOrUserRoleContentUnion{Value: "Hello, sensitive data!"},
-						Role:    openai.ChatMessageRoleUser,
+					OfUser: &openai.ChatCompletionUserMessageParam{
+						Content: openai.StringOrUserRoleContentUnion{
+							Value: "Hello, sensitive data!",
+						},
+						Role: openai.ChatMessageRoleUser,
 					},
 				}},
 			}

--- a/tests/internal/testopenai/chat_requests.go
+++ b/tests/internal/testopenai/chat_requests.go
@@ -30,8 +30,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "What is the weather like in Boston today?",
@@ -68,19 +67,18 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: []openai.ChatCompletionContentPartUserUnionParam{
 							{
-								TextContent: &openai.ChatCompletionContentPartTextParam{
+								OfText: &openai.ChatCompletionContentPartTextParam{
 									Type: string(openai.ChatCompletionContentPartTextTypeText),
 									Text: "What is in this image?",
 								},
 							},
 							{
-								ImageContent: &openai.ChatCompletionContentPartImageParam{
+								OfImageURL: &openai.ChatCompletionContentPartImageParam{
 									Type: openai.ChatCompletionContentPartImageTypeImageURL,
 									ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 										URL: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
@@ -98,8 +96,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleDeveloper,
-				Value: openai.ChatCompletionDeveloperMessageParam{
+				OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 					Role: openai.ChatMessageRoleDeveloper,
 					Content: openai.StringOrArray{
 						Value: "You are a helpful assistant.",
@@ -107,8 +104,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Hello!",
@@ -116,8 +112,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleAssistant,
-				Value: openai.ChatCompletionAssistantMessageParam{
+				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 					Role: openai.ChatMessageRoleAssistant,
 					Content: openai.StringOrAssistantRoleContentUnion{
 						Value: "Hello! How can I assist you today?",
@@ -125,8 +120,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Answer in up to 5 words: What's the weather like?",
@@ -140,8 +134,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Generate a JSON object with three properties: name, age, and city.",
@@ -163,8 +156,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "What is the weather like in San Francisco?",
@@ -202,8 +194,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: nil,
@@ -218,19 +209,18 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: []openai.ChatCompletionContentPartUserUnionParam{
 							{
-								TextContent: &openai.ChatCompletionContentPartTextParam{
+								OfText: &openai.ChatCompletionContentPartTextParam{
 									Type: string(openai.ChatCompletionContentPartTextTypeText),
 									Text: "Answer in up to 5 words: What's in this image?",
 								},
 							},
 							{
-								ImageContent: &openai.ChatCompletionContentPartImageParam{
+								OfImageURL: &openai.ChatCompletionContentPartImageParam{
 									Type: openai.ChatCompletionContentPartImageTypeImageURL,
 									ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
 										URL: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAXElEQVR42mNgoAkofv8fBVOkmQyD/sPwn1UlYAzlE6cZpgGmGZlPkgHYDCHKCcia0AwgHlCm+c+f/9gwabajG0CsK+DOxmIA8YZQ6gXkhISG6W8ALj7RtuMTgwMA0WTdqiU1ensAAAAASUVORK5CYII=",
@@ -247,8 +237,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: "gpt-4.1-nano-wrong",
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Hello!",
@@ -261,8 +250,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelO3Mini,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "A bat and ball cost $1.10. Bat costs $1 more than ball. Ball cost?",
@@ -275,19 +263,18 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT4oAudioPreview,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: []openai.ChatCompletionContentPartUserUnionParam{
 							{
-								TextContent: &openai.ChatCompletionContentPartTextParam{
+								OfText: &openai.ChatCompletionContentPartTextParam{
 									Type: string(openai.ChatCompletionContentPartTextTypeText),
 									Text: "Answer in up to 5 words: What do you hear in this audio?",
 								},
 							},
 							{
-								InputAudioContent: &openai.ChatCompletionContentPartInputAudioParam{
+								OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{
 									Type: openai.ChatCompletionContentPartInputAudioTypeInputAudio,
 									InputAudio: openai.ChatCompletionContentPartInputAudioInputAudioParam{
 										Data:   "UklGRlwEAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YTgEAADY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycn2NjY2NjY2NjY2CcnJycnJycnJyfY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycn2NjY2NjY2NjY2CcnJycnJycnJyfY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycn2NjY2NjY2NjY2CcnJycnJycnJyfY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycn2NjY2NjY2NjY2CcnJycnJycnJyfY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycn2NjY2NjY2NjY2NgnJycnJycnJyfY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycn2NjY2NjY2NjY2CcnJycnJycnJyfY2NjY2NjY2NjYJycnJycnJycnJ9jY2NjY2NjY2NgnJycnJycnJycnv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/v0BAQEBAv7+/v79AQEBAQL+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAv7+/v79AQEBAQL+/v7+/QEBAQEC/v7+/v0BAQEBAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIA=", // 8-bit style jump sound, 0.135s, 8kHz mono WAV.
@@ -305,8 +292,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT4oMiniAudioPreview,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Say a single short 'beep' sound, as brief as possible.",
@@ -329,8 +315,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{
+				OfSystem: &openai.ChatCompletionSystemMessageParam{
 					Role: openai.ChatMessageRoleSystem,
 					Content: openai.StringOrArray{
 						Value: "You are an AI assistant that generates simple, sketch-style images with minimal detail. When asked to generate an image, create it with low quality settings for cost efficiency.",
@@ -338,8 +323,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Draw a simple, minimalist image of a cute cat playing with a ball of yarn in a sketch style.",
@@ -380,8 +364,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleSystem,
-				Value: openai.ChatCompletionSystemMessageParam{
+				OfSystem: &openai.ChatCompletionSystemMessageParam{
 					Role: openai.ChatMessageRoleSystem,
 					Content: openai.StringOrArray{
 						Value: "You are a financial research planner. Given a request for financial analysis, produce a set of web searches to gather the context needed. Aim for recent headlines, earnings  calls or 10‑K snippets, analyst commentary, and industry background. Output between 5 and 15 search terms to query for.",
@@ -389,8 +372,7 @@ var chatRequests = map[Cassette]*openai.ChatCompletionRequest{
 				},
 			},
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Query: tell me about acme",
@@ -450,8 +432,7 @@ var (
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "Hello!",
@@ -464,8 +445,7 @@ var (
 		Model: openai.ModelGPT5Nano,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleDeveloper,
-				Value: openai.ChatCompletionDeveloperMessageParam{
+				OfDeveloper: &openai.ChatCompletionDeveloperMessageParam{
 					Role: openai.ChatMessageRoleDeveloper,
 					Content: openai.StringOrArray{
 						Value: "Hello, I'm a developer!",
@@ -480,8 +460,7 @@ var (
 		Model: openai.ModelGPT4oMiniSearchPreview,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
-				Type: openai.ChatMessageRoleUser,
-				Value: openai.ChatCompletionUserMessageParam{
+				OfUser: &openai.ChatCompletionUserMessageParam{
 					Role: openai.ChatMessageRoleUser,
 					Content: openai.StringOrUserRoleContentUnion{
 						Value: "In up to 5 words, tell me what's at https://httpbin.org/base64/dGVzdA== and include citations",


### PR DESCRIPTION
**Description**

changes: 
1 refector `ChatCompletionMessageParamUnion` to use same tagged union implementation as others. This should be able to make the definition more explicit.

2 add `ChatCompletionContentPartFileParam`  inside `ChatCompletionContentPartUserUnionParam`, also changed the names of other fields to make the naming consistent

**Related Issues/PRs (if applicable)**
follow up on https://github.com/envoyproxy/ai-gateway/pull/1178


