### PR TITLE
fix: gcp anthropic streaming usage

### DIFF
--- a/internal/extproc/translator/anthropic_gcpanthropic.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic.go
@@ -99,11 +99,11 @@ func (a *anthropicToGCPAnthropicTranslator) ResponseBody(_ map[string]string, bo
 	// For streaming chunks, parse SSE format to extract token usage.
 	if !endOfStream {
 		// Parse SSE format - split by lines and look for data: lines.
-		lines := bytes.Split(bodyBytes, []byte("\n"))
-		for _, line := range lines {
+		for _, line := range bytes.Lines(bodyBytes) {
 			line = bytes.TrimSpace(line)
-			if bytes.HasPrefix(line, []byte("data: ")) {
-				jsonData := bytes.TrimPrefix(line, []byte("data: "))
+            dataPrefix := []byte("data: ")
+			if bytes.HasPrefix(line, dataPrefix) {
+				jsonData := bytes.TrimPrefix(line, dataPrefix)
 
 				var eventData map[string]any
 				if unmarshalErr := json.Unmarshal(jsonData, &eventData); unmarshalErr != nil {

--- a/internal/extproc/translator/anthropic_gcpanthropic.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic.go
@@ -101,7 +101,7 @@ func (a *anthropicToGCPAnthropicTranslator) ResponseBody(_ map[string]string, bo
 		// Parse SSE format - split by lines and look for data: lines.
 		for line := range bytes.Lines(bodyBytes) {
 			line = bytes.TrimSpace(line)
-            dataPrefix := []byte("data: ")
+			dataPrefix := []byte("data: ")
 			if bytes.HasPrefix(line, dataPrefix) {
 				jsonData := bytes.TrimPrefix(line, dataPrefix)
 

--- a/internal/extproc/translator/anthropic_gcpanthropic.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic.go
@@ -99,7 +99,7 @@ func (a *anthropicToGCPAnthropicTranslator) ResponseBody(_ map[string]string, bo
 	// For streaming chunks, parse SSE format to extract token usage.
 	if !endOfStream {
 		// Parse SSE format - split by lines and look for data: lines.
-		for _, line := range bytes.Lines(bodyBytes) {
+		for line := range bytes.Lines(bodyBytes) {
 			line = bytes.TrimSpace(line)
             dataPrefix := []byte("data: ")
 			if bytes.HasPrefix(line, dataPrefix) {

--- a/internal/extproc/translator/anthropic_gcpanthropic_test.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic_test.go
@@ -509,58 +509,58 @@ func TestAnthropicToGCPAnthropicTranslator_ResponseBody_StreamingTokenUsage(t *t
 	}{
 		{
 			name:        "regular streaming chunk without usage",
-			chunk:       `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" to me."}}`,
+			chunk:       "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to me.\"}}\n\n",
 			endOfStream: false,
 			expectedUsage: LLMTokenUsage{
 				InputTokens:  0,
 				OutputTokens: 0,
 				TotalTokens:  0,
 			},
-			expectedBody: `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" to me."}}`,
+			expectedBody: "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to me.\"}}\n\n",
 		},
 		{
 			name:        "message_delta chunk with token usage",
-			chunk:       `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":84}}`,
+			chunk:       "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":84}}\n\n",
 			endOfStream: false,
 			expectedUsage: LLMTokenUsage{
 				InputTokens:  0,
 				OutputTokens: 84,
 				TotalTokens:  84,
 			},
-			expectedBody: `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":84}}`,
+			expectedBody: "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":84}}\n\n",
 		},
 		{
 			name:        "message_stop chunk without usage",
-			chunk:       `{"type":"message_stop"}`,
+			chunk:       "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
 			endOfStream: false,
 			expectedUsage: LLMTokenUsage{
 				InputTokens:  0,
 				OutputTokens: 0,
 				TotalTokens:  0,
 			},
-			expectedBody: `{"type":"message_stop"}`,
+			expectedBody: "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
 		},
 		{
 			name:        "invalid json chunk",
-			chunk:       `{"invalid": "json"}`,
+			chunk:       "event: invalid\ndata: {\"invalid\": \"json\"}\n\n",
 			endOfStream: false,
 			expectedUsage: LLMTokenUsage{
 				InputTokens:  0,
 				OutputTokens: 0,
 				TotalTokens:  0,
 			},
-			expectedBody: `{"invalid": "json"}`,
+			expectedBody: "event: invalid\ndata: {\"invalid\": \"json\"}\n\n",
 		},
 		{
 			name:        "message_delta with decimal output_tokens",
-			chunk:       `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":42.0}}`,
+			chunk:       "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":42.0}}\n\n",
 			endOfStream: false,
 			expectedUsage: LLMTokenUsage{
 				InputTokens:  0,
 				OutputTokens: 42,
 				TotalTokens:  42,
 			},
-			expectedBody: `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":42.0}}`,
+			expectedBody: "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":42.0}}\n\n",
 		},
 	}
 
@@ -574,7 +574,7 @@ func TestAnthropicToGCPAnthropicTranslator_ResponseBody_StreamingTokenUsage(t *t
 			require.NoError(t, err)
 			require.Nil(t, headerMutation)
 			require.NotNil(t, bodyMutation)
-			require.JSONEq(t, tt.expectedBody, string(bodyMutation.GetBody()))
+			require.Equal(t, tt.expectedBody, string(bodyMutation.GetBody()))
 			require.Equal(t, tt.expectedUsage, tokenUsage)
 		})
 	}

--- a/internal/extproc/translator/anthropic_gcpanthropic_test.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic_test.go
@@ -616,6 +616,15 @@ func TestAnthropicToGCPAnthropicTranslator_ResponseBody_StreamingEdgeCases(t *te
 			},
 		},
 		{
+			name:  "message_start with output_tokens > 0",
+			chunk: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":15,\"output_tokens\":5}}}\n\n",
+			expectedUsage: LLMTokenUsage{
+				InputTokens:  15,
+				OutputTokens: 5,
+				TotalTokens:  20,
+			},
+		},
+		{
 			name:  "message_delta without usage field",
 			chunk: "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n",
 			expectedUsage: LLMTokenUsage{

--- a/internal/extproc/translator/anthropic_gcpanthropic_test.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic_test.go
@@ -579,3 +579,74 @@ func TestAnthropicToGCPAnthropicTranslator_ResponseBody_StreamingTokenUsage(t *t
 		})
 	}
 }
+
+func TestAnthropicToGCPAnthropicTranslator_ResponseBody_StreamingEdgeCases(t *testing.T) {
+	translator := NewAnthropicToGCPAnthropicTranslator("2023-06-01", "")
+
+	tests := []struct {
+		name          string
+		chunk         string
+		expectedUsage LLMTokenUsage
+	}{
+		{
+			name:  "message_start without message field",
+			chunk: "event: message_start\ndata: {\"type\":\"message_start\"}\n\n",
+			expectedUsage: LLMTokenUsage{
+				InputTokens:  0,
+				OutputTokens: 0,
+				TotalTokens:  0,
+			},
+		},
+		{
+			name:  "message_start without usage field",
+			chunk: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\"}}\n\n",
+			expectedUsage: LLMTokenUsage{
+				InputTokens:  0,
+				OutputTokens: 0,
+				TotalTokens:  0,
+			},
+		},
+		{
+			name:  "message_start with output_tokens = 0",
+			chunk: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":20,\"output_tokens\":0}}}\n\n",
+			expectedUsage: LLMTokenUsage{
+				InputTokens:  20,
+				OutputTokens: 0,
+				TotalTokens:  20,
+			},
+		},
+		{
+			name:  "message_delta without usage field",
+			chunk: "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n",
+			expectedUsage: LLMTokenUsage{
+				InputTokens:  0,
+				OutputTokens: 0,
+				TotalTokens:  0,
+			},
+		},
+		{
+			name:  "invalid json in data",
+			chunk: "event: message_start\ndata: {invalid json}\n\n",
+			expectedUsage: LLMTokenUsage{
+				InputTokens:  0,
+				OutputTokens: 0,
+				TotalTokens:  0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyReader := bytes.NewReader([]byte(tt.chunk))
+			respHeaders := map[string]string{"content-type": "application/json"}
+
+			headerMutation, bodyMutation, tokenUsage, err := translator.ResponseBody(respHeaders, bodyReader, false)
+
+			require.NoError(t, err)
+			require.Nil(t, headerMutation)
+			require.NotNil(t, bodyMutation)
+			require.Equal(t, tt.chunk, string(bodyMutation.GetBody()))
+			require.Equal(t, tt.expectedUsage, tokenUsage)
+		})
+	}
+}


### PR DESCRIPTION
**Description**
Usage event were parsed as raw json instead of event type + json.
Example of stream chunks:

```
event: message_start
data: {"type":"message_start","message":{"id":"msg_vrtx_01V4HwqjNGwvFRqBVuhQNCXW","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1}}  }

event: ping
data: {"type": "ping"}

event: content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"There"}}

```

