### PR TITLE
chore: make e2e use less resources

### DIFF
--- a/examples/basic/basic.yaml
+++ b/examples/basic/basic.yaml
@@ -21,6 +21,11 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: envoy-ai-gateway-basic
 ---
 # By default, Envoy Gateway sets the buffer limit to 32kiB which is not sufficient for AI workloads.
 # This ClientTrafficPolicy sets the buffer limit to 50MiB as an example.
@@ -130,3 +135,18 @@ spec:
       port: 80
       targetPort: 8080
   type: ClusterIP
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-ai-gateway-basic
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          # Note: this is to clear the large default memory/cpu requirements for local tests.
+          # In production, you should set these to values that make sense for your environment.
+          resources: {}

--- a/examples/provider_fallback/base.yaml
+++ b/examples/provider_fallback/base.yaml
@@ -21,6 +21,11 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: provider-fallback
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute
@@ -186,3 +191,18 @@ spec:
       port: 443
       targetPort: 8080
   type: ClusterIP
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: provider-fallback
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          # Note: this is to clear the large default memory/cpu requirements for local tests.
+          # In production, you should set these to values that make sense for your environment.
+          resources: {}

--- a/examples/token_ratelimit/token_ratelimit.yaml
+++ b/examples/token_ratelimit/token_ratelimit.yaml
@@ -21,6 +21,11 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: envoy-ai-gateway-token-ratelimit
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute
@@ -213,3 +218,18 @@ spec:
       port: 80
       targetPort: 8080
   type: ClusterIP
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-ai-gateway-token-ratelimit
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          # Note: this is to clear the large default memory/cpu requirements for local tests.
+          # In production, you should set these to values that make sense for your environment.
+          resources: {}

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -25,6 +25,9 @@ func Test_Examples_Basic(t *testing.T) {
 	const manifestDir = "../../examples/basic"
 	const manifest = manifestDir + "/basic.yaml"
 	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(t.Context(), manifest)
+	})
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-basic"
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)

--- a/tests/e2e/provider_fallback_test.go
+++ b/tests/e2e/provider_fallback_test.go
@@ -26,8 +26,6 @@ func Test_Examples_ProviderFallback(t *testing.T) {
 	const baseManifest = "../../examples/provider_fallback/base.yaml"
 	const fallbackManifest = "../../examples/provider_fallback/fallback.yaml"
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=provider-fallback"
-	// Delete the fallback configuration if it exists so that multiple runs of this test do not conflict.
-	_ = e2elib.KubectlDeleteManifest(t.Context(), fallbackManifest)
 
 	// This requires the following environment variables to be set:
 	//   - TEST_AWS_ACCESS_KEY_ID
@@ -47,6 +45,10 @@ func Test_Examples_ProviderFallback(t *testing.T) {
 	replaced = strings.ReplaceAll(replaced, "AWS_SECRET_ACCESS_KEY", cmp.Or(awsSecretAccessKey, "dummy-aws-secret-access-key"))
 	require.NoError(t, e2elib.KubectlApplyManifestStdin(t.Context(), replaced))
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(t.Context(), baseManifest)
+		_ = e2elib.KubectlDeleteManifest(t.Context(), fallbackManifest)
+	})
 
 	const body = `{"model": "us.meta.llama3-2-1b-instruct-v1:0","messages": [{"role": "user", "content": "Say this is a test!"}],"temperature": 0.7}`
 

--- a/tests/e2e/testdata/otel_tracing_console.yaml
+++ b/tests/e2e/testdata/otel_tracing_console.yaml
@@ -27,6 +27,25 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: envoy-ai-gateway-otel-test
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-ai-gateway-otel-test
+  namespace: otel-test-namespace
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          # Clear the default memory/cpu requirements for local tests.
+          resources: {}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/tests/e2e/testdata/testupstream.yaml
+++ b/tests/e2e/testdata/testupstream.yaml
@@ -21,6 +21,25 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: translation-testupstream
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: translation-testupstream
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          # Clear the default memory/cpu requirements for local tests.
+          resources: {}
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute

--- a/tests/e2e/testdata/traffic_splitting_fallback.yaml
+++ b/tests/e2e/testdata/traffic_splitting_fallback.yaml
@@ -21,6 +21,25 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: traffic-splitting-fallback
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: traffic-splitting-fallback
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          # Clear the default memory/cpu requirements for local tests.
+          resources: {}
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: AIGatewayRoute

--- a/tests/e2e/testupstream_test.go
+++ b/tests/e2e/testupstream_test.go
@@ -26,6 +26,9 @@ import (
 func TestWithTestUpstream(t *testing.T) {
 	const manifest = "testdata/testupstream.yaml"
 	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(t.Context(), manifest)
+	})
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=translation-testupstream"
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -31,6 +31,9 @@ const userIDMetricsLabel = "user_id"
 func Test_Examples_TokenRateLimit(t *testing.T) {
 	const manifest = "../../examples/token_ratelimit/token_ratelimit.yaml"
 	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(t.Context(), manifest)
+	})
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-token-ratelimit"
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)

--- a/tests/e2e/traffic_splitting_fallback_test.go
+++ b/tests/e2e/traffic_splitting_fallback_test.go
@@ -22,6 +22,9 @@ import (
 func TestTrafficSplittingFallback(t *testing.T) {
 	const manifest = "testdata/traffic_splitting_fallback.yaml"
 	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(t.Context(), manifest)
+	})
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=traffic-splitting-fallback"
 


### PR DESCRIPTION
**Description**

Previously, all the end-to-end tests didn't configure Envoy container's resource requests. By default, it would use `cpu: 100m` & `memory: 512Mi`, and the more we add tests, the more the memory it would use hence the tests might get stuck in the middle.

