### PR TITLE
feat: per backend header mutations for embeddings and message processors

### DIFF
--- a/internal/extproc/embeddings_processor.go
+++ b/internal/extproc/embeddings_processor.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/headermutator"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/metrics"
@@ -137,6 +138,7 @@ type embeddingsProcessorUpstreamFilter struct {
 	modelNameOverride      string
 	backendName            string
 	handler                backendauth.Handler
+	headerMutator          *headermutator.HeaderMutator
 	originalRequestBodyRaw []byte
 	originalRequestBody    *openai.EmbeddingRequest
 	translator             translator.OpenAIEmbeddingTranslator
@@ -182,10 +184,18 @@ func (e *embeddingsProcessorUpstreamFilter) ProcessRequestHeaders(ctx context.Co
 	}
 	if headerMutation == nil {
 		headerMutation = &extprocv3.HeaderMutation{}
-	} else {
-		for _, h := range headerMutation.SetHeaders {
-			e.requestHeaders[h.Header.Key] = string(h.Header.RawValue)
+	}
+
+	// Apply header mutations from the route and also restore original headers on retry.
+	if h := e.headerMutator; h != nil {
+		if hm := e.headerMutator.Mutate(e.requestHeaders, e.onRetry); hm != nil {
+			headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, hm.RemoveHeaders...)
+			headerMutation.SetHeaders = append(headerMutation.SetHeaders, hm.SetHeaders...)
 		}
+	}
+
+	for _, h := range headerMutation.SetHeaders {
+		e.requestHeaders[h.Header.Key] = string(h.Header.RawValue)
 	}
 	if h := e.handler; h != nil {
 		if err = h.Do(ctx, e.requestHeaders, headerMutation, bodyMutation); err != nil {
@@ -349,6 +359,7 @@ func (e *embeddingsProcessorUpstreamFilter) SetBackend(ctx context.Context, b *f
 		return fmt.Errorf("failed to select translator: %w", err)
 	}
 	e.handler = backendHandler
+	e.headerMutator = headermutator.NewHeaderMutator(b.HeaderMutation, rp.requestHeaders)
 	// Sync header with backend model so header-derived labels/CEL use the actual model.
 	if e.modelNameOverride != "" {
 		e.requestHeaders[e.config.modelNameHeaderKey] = e.modelNameOverride

--- a/internal/extproc/embeddings_processor_test.go
+++ b/internal/extproc/embeddings_processor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/headermutator"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/llmcostcel"
@@ -402,5 +403,289 @@ func TestEmbeddingsProcessorRouterFilter_ProcessResponseHeaders_ProcessResponseB
 		require.NotNil(t, re.ResponseBody.Response)
 		require.IsType(t, &extprocv3.BodyMutation{}, re.ResponseBody.Response.BodyMutation)
 		require.IsType(t, &extprocv3.HeaderMutation{}, re.ResponseBody.Response.HeaderMutation)
+	})
+}
+
+func TestEmbeddingsProcessorUpstreamFilter_ProcessRequestHeaders_WithHeaderMutations(t *testing.T) {
+	const testModelKey = "x-ai-gateway-model-key"
+	t.Run("header mutations applied correctly", func(t *testing.T) {
+		headers := map[string]string{
+			":path":         "/v1/embeddings",
+			testModelKey:    "some-model",
+			"authorization": "bearer token123",
+			"x-api-key":     "secret-key",
+			"x-custom":      "custom-value",
+		}
+		someBody := embeddingBodyFromModel(t, "some-model")
+		var body openai.EmbeddingRequest
+		require.NoError(t, json.Unmarshal(someBody, &body))
+
+		// Create header mutations.
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"authorization", "x-api-key"},
+			Set:    []filterapi.HTTPHeader{{Name: "x-new-header", Value: "new-value"}},
+		}
+
+		mt := &mockEmbeddingTranslator{t: t, expRequestBody: &body}
+		mm := &mockEmbeddingsMetrics{}
+		p := &embeddingsProcessorUpstreamFilter{
+			config:                 &processorConfig{modelNameHeaderKey: testModelKey},
+			requestHeaders:         headers,
+			logger:                 slog.Default(),
+			metrics:                mm,
+			translator:             mt,
+			originalRequestBodyRaw: someBody,
+			originalRequestBody:    &body,
+			handler:                &mockBackendAuthHandler{},
+		}
+
+		// Set header mutator.
+		originalHeaders := map[string]string{
+			"authorization": "bearer original-token",
+			"x-api-key":     "original-secret",
+		}
+		p.headerMutator = headermutator.NewHeaderMutator(headerMutations, originalHeaders)
+
+		resp, err := p.ProcessRequestHeaders(t.Context(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		commonRes := resp.Response.(*extprocv3.ProcessingResponse_RequestHeaders).RequestHeaders.Response
+
+		// Check that header mutations were applied.
+		require.NotNil(t, commonRes.HeaderMutation)
+		require.ElementsMatch(t, []string{"authorization", "x-api-key"}, commonRes.HeaderMutation.RemoveHeaders)
+		require.Len(t, commonRes.HeaderMutation.SetHeaders, 1)
+		require.Equal(t, "x-new-header", commonRes.HeaderMutation.SetHeaders[0].Header.Key)
+		require.Equal(t, []byte("new-value"), commonRes.HeaderMutation.SetHeaders[0].Header.RawValue)
+
+		// Check that headers were modified in the request headers.
+		require.Equal(t, "new-value", headers["x-new-header"])
+		require.NotContains(t, headers, "authorization")
+		require.NotContains(t, headers, "x-api-key")
+		// x-custom remains unchanged since it wasn't in the mutations.
+		require.Equal(t, "custom-value", headers["x-custom"])
+	})
+
+	t.Run("header mutations restored on retry", func(t *testing.T) {
+		headers := map[string]string{
+			":path":      "/v1/embeddings",
+			testModelKey: "some-model",
+			// "x-custom" is not present in current headers, so it can be restored.
+			"x-new-header": "new-value", // Already set from previous mutation.
+		}
+		someBody := embeddingBodyFromModel(t, "some-model")
+		var body openai.EmbeddingRequest
+		require.NoError(t, json.Unmarshal(someBody, &body))
+
+		// Create header mutations that don't remove x-custom (so it can be restored).
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"authorization", "x-api-key"},
+			Set:    []filterapi.HTTPHeader{{Name: "x-new-header", Value: "updated-value"}},
+		}
+
+		mt := &mockEmbeddingTranslator{t: t, expRequestBody: &body}
+		mm := &mockEmbeddingsMetrics{}
+		p := &embeddingsProcessorUpstreamFilter{
+			config:                 &processorConfig{modelNameHeaderKey: testModelKey},
+			requestHeaders:         headers,
+			logger:                 slog.Default(),
+			metrics:                mm,
+			translator:             mt,
+			originalRequestBodyRaw: someBody,
+			originalRequestBody:    &body,
+			handler:                &mockBackendAuthHandler{},
+			onRetry:                true, // This is a retry request.
+		}
+
+		// Use the same headers map as the original headers (this simulates the router filter's requestHeaders).
+		originalHeaders := map[string]string{
+			":path":         "/v1/embeddings",
+			testModelKey:    "some-model",
+			"authorization": "bearer original-token", // This will be removed, so won't be restored.
+			"x-api-key":     "original-secret",       // This will be removed, so won't be restored.
+			"x-custom":      "original-custom",       // This won't be removed, so can be restored.
+			"x-new-header":  "original-value",        // This will be set, so won't be restored.
+		}
+		p.headerMutator = headermutator.NewHeaderMutator(headerMutations, originalHeaders)
+
+		resp, err := p.ProcessRequestHeaders(t.Context(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		commonRes := resp.Response.(*extprocv3.ProcessingResponse_RequestHeaders).RequestHeaders.Response
+
+		// Check that header mutations were applied.
+		require.NotNil(t, commonRes.HeaderMutation)
+		// RemoveHeaders should be empty because authorization/x-api-key don't exist in current headers.
+		require.Empty(t, commonRes.HeaderMutation.RemoveHeaders)
+		require.Len(t, commonRes.HeaderMutation.SetHeaders, 2) // Updated header + restored header.
+
+		// Check that x-custom header was restored on retry (it's not being removed or set).
+		var restoredHeader *corev3.HeaderValueOption
+		var updatedHeader *corev3.HeaderValueOption
+		for _, h := range commonRes.HeaderMutation.SetHeaders {
+			switch h.Header.Key {
+			case "x-custom":
+				restoredHeader = h
+			case "x-new-header":
+				updatedHeader = h
+			}
+		}
+		require.NotNil(t, restoredHeader)
+		require.Equal(t, []byte("original-custom"), restoredHeader.Header.RawValue)
+		require.NotNil(t, updatedHeader)
+		require.Equal(t, []byte("updated-value"), updatedHeader.Header.RawValue)
+
+		// Check that headers were updated in the request headers.
+		require.Equal(t, "updated-value", headers["x-new-header"])
+		require.Equal(t, "original-custom", headers["x-custom"])
+	})
+
+	t.Run("no header mutations when mutator is nil", func(t *testing.T) {
+		headers := map[string]string{
+			":path":         "/v1/embeddings",
+			testModelKey:    "some-model",
+			"authorization": "bearer token123",
+		}
+		someBody := embeddingBodyFromModel(t, "some-model")
+		var body openai.EmbeddingRequest
+		require.NoError(t, json.Unmarshal(someBody, &body))
+
+		mt := &mockEmbeddingTranslator{t: t, expRequestBody: &body}
+		mm := &mockEmbeddingsMetrics{}
+		p := &embeddingsProcessorUpstreamFilter{
+			config:                 &processorConfig{modelNameHeaderKey: testModelKey},
+			requestHeaders:         headers,
+			logger:                 slog.Default(),
+			metrics:                mm,
+			translator:             mt,
+			originalRequestBodyRaw: someBody,
+			originalRequestBody:    &body,
+			handler:                &mockBackendAuthHandler{},
+			headerMutator:          nil, // No header mutator.
+		}
+
+		resp, err := p.ProcessRequestHeaders(t.Context(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		commonRes := resp.Response.(*extprocv3.ProcessingResponse_RequestHeaders).RequestHeaders.Response
+
+		// Check that no header mutations were applied.
+		require.NotNil(t, commonRes.HeaderMutation)
+		require.Empty(t, commonRes.HeaderMutation.RemoveHeaders)
+		require.Empty(t, commonRes.HeaderMutation.SetHeaders)
+
+		// Check that original headers remain unchanged.
+		require.Equal(t, "bearer token123", headers["authorization"])
+	})
+}
+
+func TestEmbeddingsProcessorUpstreamFilter_SetBackend_WithHeaderMutations(t *testing.T) {
+	t.Run("header mutator created correctly", func(t *testing.T) {
+		headers := map[string]string{":path": "/foo"}
+		mm := &mockEmbeddingsMetrics{}
+		p := &embeddingsProcessorUpstreamFilter{
+			config:         &processorConfig{},
+			requestHeaders: headers,
+			logger:         slog.Default(),
+			metrics:        mm,
+		}
+
+		// Create backend with header mutations.
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"x-sensitive"},
+			Set:    []filterapi.HTTPHeader{{Name: "x-backend", Value: "backend-value"}},
+		}
+
+		rp := &embeddingsProcessorRouterFilter{
+			requestHeaders: headers,
+		}
+
+		err := p.SetBackend(t.Context(), &filterapi.Backend{
+			Name:           "test-backend",
+			Schema:         filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
+			HeaderMutation: headerMutations,
+		}, nil, rp)
+		require.NoError(t, err)
+
+		// Verify header mutator was created.
+		require.NotNil(t, p.headerMutator)
+
+		// Test that the header mutator works correctly.
+		testHeaders := map[string]string{
+			"x-sensitive": "secret",
+			"x-existing":  "value",
+		}
+		mutation := p.headerMutator.Mutate(testHeaders, false) // onRetry = false.
+
+		require.NotNil(t, mutation)
+		require.ElementsMatch(t, []string{"x-sensitive"}, mutation.RemoveHeaders)
+		require.Len(t, mutation.SetHeaders, 1)
+		require.Equal(t, "x-backend", mutation.SetHeaders[0].Header.Key)
+		require.Equal(t, []byte("backend-value"), mutation.SetHeaders[0].Header.RawValue)
+	})
+
+	t.Run("header mutator with original headers", func(t *testing.T) {
+		headers := map[string]string{":path": "/foo"}
+		mm := &mockEmbeddingsMetrics{}
+		p := &embeddingsProcessorUpstreamFilter{
+			config:         &processorConfig{},
+			requestHeaders: headers,
+			logger:         slog.Default(),
+			metrics:        mm,
+		}
+
+		// Create backend with header mutations that don't remove x-custom.
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"authorization"},
+		}
+
+		// Original headers from router filter (simulate what would be in rp.requestHeaders).
+		originalHeaders := map[string]string{
+			":path":         "/foo",
+			"authorization": "bearer original-token", // This will be removed, so won't be restored.
+			"x-custom":      "original-value",        // This won't be removed, so can be restored.
+			"x-existing":    "existing-value",        // This won't be removed, so can be restored.
+		}
+
+		rp := &embeddingsProcessorRouterFilter{
+			requestHeaders: originalHeaders,
+		}
+
+		err := p.SetBackend(t.Context(), &filterapi.Backend{
+			Name:           "test-backend",
+			Schema:         filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
+			HeaderMutation: headerMutations,
+		}, nil, rp)
+		require.NoError(t, err)
+
+		// Verify header mutator was created with original headers.
+		require.NotNil(t, p.headerMutator)
+
+		// Test retry scenario - original headers should be restored.
+		testHeaders := map[string]string{
+			"x-existing": "current-value", // This exists, so won't be restored.
+		}
+		mutation := p.headerMutator.Mutate(testHeaders, true) // onRetry = true.
+
+		require.NotNil(t, mutation)
+		// RemoveHeaders should be empty because authorization doesn't exist in testHeaders.
+		require.Empty(t, mutation.RemoveHeaders)
+
+		// Should restore x-custom header (not being removed and not already present).
+		var restoredHeader *corev3.HeaderValueOption
+		for _, h := range mutation.SetHeaders {
+			if h.Header.Key == "x-custom" {
+				restoredHeader = h
+				break
+			}
+		}
+		require.NotNil(t, restoredHeader)
+		require.Equal(t, []byte("original-value"), restoredHeader.Header.RawValue)
+		require.Equal(t, "original-value", testHeaders["x-custom"])
+		// x-existing should not be restored because it already exists.
+		require.Equal(t, "current-value", testHeaders["x-existing"])
 	})
 }

--- a/internal/extproc/messages_processor.go
+++ b/internal/extproc/messages_processor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/headermutator"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
@@ -137,6 +138,7 @@ type messagesProcessorUpstreamFilter struct {
 	modelNameOverride      string
 	backendName            string
 	handler                backendauth.Handler
+	headerMutator          *headermutator.HeaderMutator
 	originalRequestBody    *anthropic.MessagesRequest
 	originalRequestBodyRaw []byte
 	translator             translator.AnthropicMessagesTranslator
@@ -180,10 +182,18 @@ func (c *messagesProcessorUpstreamFilter) ProcessRequestHeaders(ctx context.Cont
 	}
 	if headerMutation == nil {
 		headerMutation = &extprocv3.HeaderMutation{}
-	} else {
-		for _, h := range headerMutation.SetHeaders {
-			c.requestHeaders[h.Header.Key] = string(h.Header.RawValue)
+	}
+
+	// Apply header mutations from the route and also restore original headers on retry.
+	if h := c.headerMutator; h != nil {
+		if hm := c.headerMutator.Mutate(c.requestHeaders, c.onRetry); hm != nil {
+			headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, hm.RemoveHeaders...)
+			headerMutation.SetHeaders = append(headerMutation.SetHeaders, hm.SetHeaders...)
 		}
+	}
+
+	for _, h := range headerMutation.SetHeaders {
+		c.requestHeaders[h.Header.Key] = string(h.Header.RawValue)
 	}
 	if h := c.handler; h != nil {
 		if err = h.Do(ctx, c.requestHeaders, headerMutation, bodyMutation); err != nil {
@@ -314,6 +324,7 @@ func (c *messagesProcessorUpstreamFilter) SetBackend(ctx context.Context, b *fil
 		return fmt.Errorf("failed to select translator: %w", err)
 	}
 	c.handler = backendHandler
+	c.headerMutator = headermutator.NewHeaderMutator(b.HeaderMutation, rp.requestHeaders)
 	// Sync header with backend model so header-derived labels/CEL use the actual model.
 	if c.modelNameOverride != "" {
 		c.requestHeaders[c.config.modelNameHeaderKey] = c.modelNameOverride

--- a/internal/extproc/messages_processor_test.go
+++ b/internal/extproc/messages_processor_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	anthropicschema "github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/headermutator"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/metrics"
@@ -597,4 +598,367 @@ func Test_messagesProcessorUpstreamFilter_SetBackend_Success(t *testing.T) {
 	require.Equal(t, "claude-vertex", p.requestHeaders[modelKey])
 	require.True(t, p.stream)
 	require.NotNil(t, p.translator)
+}
+
+func TestMessagesProcessorUpstreamFilter_ProcessRequestHeaders_WithHeaderMutations(t *testing.T) {
+	t.Run("header mutations applied correctly", func(t *testing.T) {
+		headers := map[string]string{
+			":path":         "/anthropic/v1/messages",
+			"x-model-name":  "claude-3-sonnet",
+			"authorization": "bearer token123",
+			"x-api-key":     "secret-key",
+			"x-custom":      "custom-value",
+		}
+
+		// Create request body.
+		requestBody := &anthropicschema.MessagesRequest{
+			"model":      "claude-3-sonnet",
+			"max_tokens": 1000,
+			"messages":   []any{map[string]any{"role": "user", "content": "Hello"}},
+		}
+		requestBodyRaw := []byte(`{"model": "claude-3-sonnet", "max_tokens": 1000, "messages": [{"role": "user", "content": "Hello"}]}`)
+
+		// Create header mutations.
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"authorization", "x-api-key"},
+			Set:    []filterapi.HTTPHeader{{Name: "x-new-header", Value: "new-value"}},
+		}
+
+		// Create mock translator.
+		mockTranslator := mockAnthropicTranslator{
+			t:                           t,
+			expRequestBody:              requestBody,
+			expForceRequestBodyMutation: false,
+			retHeaderMutation:           &extprocv3.HeaderMutation{},
+			retBodyMutation:             &extprocv3.BodyMutation{},
+			retErr:                      nil,
+		}
+
+		// Create mock metrics.
+		chatMetrics := metrics.NewChatCompletion(noop.NewMeterProvider().Meter("test"), map[string]string{})
+
+		// Create processor.
+		processor := &messagesProcessorUpstreamFilter{
+			config: &processorConfig{
+				modelNameHeaderKey: "x-model-name",
+			},
+			requestHeaders:         headers,
+			logger:                 slog.Default(),
+			metrics:                chatMetrics,
+			translator:             mockTranslator,
+			originalRequestBody:    requestBody,
+			originalRequestBodyRaw: requestBodyRaw,
+			handler:                &mockBackendAuthHandler{},
+		}
+
+		// Set header mutator.
+		originalHeaders := map[string]string{
+			"authorization": "bearer original-token",
+			"x-api-key":     "original-secret",
+		}
+		processor.headerMutator = headermutator.NewHeaderMutator(headerMutations, originalHeaders)
+
+		ctx := context.Background()
+		response, err := processor.ProcessRequestHeaders(ctx, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+
+		commonRes := response.Response.(*extprocv3.ProcessingResponse_RequestHeaders).RequestHeaders.Response
+
+		// Check that header mutations were applied.
+		require.NotNil(t, commonRes.HeaderMutation)
+		require.ElementsMatch(t, []string{"authorization", "x-api-key"}, commonRes.HeaderMutation.RemoveHeaders)
+		require.Len(t, commonRes.HeaderMutation.SetHeaders, 1)
+		require.Equal(t, "x-new-header", commonRes.HeaderMutation.SetHeaders[0].Header.Key)
+		require.Equal(t, []byte("new-value"), commonRes.HeaderMutation.SetHeaders[0].Header.RawValue)
+
+		// Check that headers were modified in the request headers.
+		require.Equal(t, "new-value", headers["x-new-header"])
+		require.NotContains(t, headers, "authorization")
+		require.NotContains(t, headers, "x-api-key")
+		// x-custom remains unchanged since it wasn't in the mutations.
+		require.Equal(t, "custom-value", headers["x-custom"])
+	})
+
+	t.Run("header mutations restored on retry", func(t *testing.T) {
+		headers := map[string]string{
+			":path":        "/anthropic/v1/messages",
+			"x-model-name": "claude-3-sonnet",
+			// "x-custom" is not present in current headers, so it can be restored.
+			"x-new-header": "new-value", // Already set from previous mutation.
+		}
+
+		// Create request body.
+		requestBody := &anthropicschema.MessagesRequest{
+			"model":      "claude-3-sonnet",
+			"max_tokens": 1000,
+			"messages":   []any{map[string]any{"role": "user", "content": "Hello"}},
+		}
+		requestBodyRaw := []byte(`{"model": "claude-3-sonnet", "max_tokens": 1000, "messages": [{"role": "user", "content": "Hello"}]}`)
+
+		// Create header mutations that don't remove x-custom (so it can be restored).
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"authorization", "x-api-key"},
+			Set:    []filterapi.HTTPHeader{{Name: "x-new-header", Value: "updated-value"}},
+		}
+
+		// Create mock translator.
+		mockTranslator := mockAnthropicTranslator{
+			t:                           t,
+			expRequestBody:              requestBody,
+			expForceRequestBodyMutation: true, // This is a retry request.
+			retHeaderMutation:           &extprocv3.HeaderMutation{},
+			retBodyMutation:             &extprocv3.BodyMutation{},
+			retErr:                      nil,
+		}
+
+		// Create mock metrics.
+		chatMetrics := metrics.NewChatCompletion(noop.NewMeterProvider().Meter("test"), map[string]string{})
+
+		// Create processor.
+		processor := &messagesProcessorUpstreamFilter{
+			config: &processorConfig{
+				modelNameHeaderKey: "x-model-name",
+			},
+			requestHeaders:         headers,
+			logger:                 slog.Default(),
+			metrics:                chatMetrics,
+			translator:             mockTranslator,
+			originalRequestBody:    requestBody,
+			originalRequestBodyRaw: requestBodyRaw,
+			handler:                &mockBackendAuthHandler{},
+			onRetry:                true, // This is a retry request.
+		}
+
+		// Use the same headers map as the original headers (this simulates the router filter's requestHeaders).
+		originalHeaders := map[string]string{
+			":path":         "/anthropic/v1/messages",
+			"x-model-name":  "claude-3-sonnet",
+			"authorization": "bearer original-token", // This will be removed, so won't be restored.
+			"x-api-key":     "original-secret",       // This will be removed, so won't be restored.
+			"x-custom":      "original-custom",       // This won't be removed, so can be restored.
+			"x-new-header":  "original-value",        // This will be set, so won't be restored.
+		}
+		processor.headerMutator = headermutator.NewHeaderMutator(headerMutations, originalHeaders)
+
+		ctx := context.Background()
+		response, err := processor.ProcessRequestHeaders(ctx, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+
+		commonRes := response.Response.(*extprocv3.ProcessingResponse_RequestHeaders).RequestHeaders.Response
+
+		// Check that header mutations were applied.
+		require.NotNil(t, commonRes.HeaderMutation)
+		// RemoveHeaders should be empty because authorization/x-api-key don't exist in current headers.
+		require.Empty(t, commonRes.HeaderMutation.RemoveHeaders)
+		require.Len(t, commonRes.HeaderMutation.SetHeaders, 2) // Updated header + restored header.
+
+		// Check that x-custom header was restored on retry (it's not being removed or set).
+		var restoredHeader *corev3.HeaderValueOption
+		var updatedHeader *corev3.HeaderValueOption
+		for _, h := range commonRes.HeaderMutation.SetHeaders {
+			switch h.Header.Key {
+			case "x-custom":
+				restoredHeader = h
+			case "x-new-header":
+				updatedHeader = h
+			}
+		}
+		require.NotNil(t, restoredHeader)
+		require.Equal(t, []byte("original-custom"), restoredHeader.Header.RawValue)
+		require.NotNil(t, updatedHeader)
+		require.Equal(t, []byte("updated-value"), updatedHeader.Header.RawValue)
+
+		// Check that headers were updated in the request headers.
+		require.Equal(t, "updated-value", headers["x-new-header"])
+		require.Equal(t, "original-custom", headers["x-custom"])
+	})
+
+	t.Run("no header mutations when mutator is nil", func(t *testing.T) {
+		headers := map[string]string{
+			":path":         "/anthropic/v1/messages",
+			"x-model-name":  "claude-3-sonnet",
+			"authorization": "bearer token123",
+		}
+
+		// Create request body.
+		requestBody := &anthropicschema.MessagesRequest{
+			"model":      "claude-3-sonnet",
+			"max_tokens": 1000,
+			"messages":   []any{map[string]any{"role": "user", "content": "Hello"}},
+		}
+		requestBodyRaw := []byte(`{"model": "claude-3-sonnet", "max_tokens": 1000, "messages": [{"role": "user", "content": "Hello"}]}`)
+
+		// Create mock translator.
+		mockTranslator := mockAnthropicTranslator{
+			t:                           t,
+			expRequestBody:              requestBody,
+			expForceRequestBodyMutation: false,
+			retHeaderMutation:           &extprocv3.HeaderMutation{},
+			retBodyMutation:             &extprocv3.BodyMutation{},
+			retErr:                      nil,
+		}
+
+		// Create mock metrics.
+		chatMetrics := metrics.NewChatCompletion(noop.NewMeterProvider().Meter("test"), map[string]string{})
+
+		// Create processor.
+		processor := &messagesProcessorUpstreamFilter{
+			config: &processorConfig{
+				modelNameHeaderKey: "x-model-name",
+			},
+			requestHeaders:         headers,
+			logger:                 slog.Default(),
+			metrics:                chatMetrics,
+			translator:             mockTranslator,
+			originalRequestBody:    requestBody,
+			originalRequestBodyRaw: requestBodyRaw,
+			handler:                &mockBackendAuthHandler{},
+			headerMutator:          nil, // No header mutator.
+		}
+
+		ctx := context.Background()
+		response, err := processor.ProcessRequestHeaders(ctx, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+
+		commonRes := response.Response.(*extprocv3.ProcessingResponse_RequestHeaders).RequestHeaders.Response
+
+		// Check that no header mutations were applied.
+		require.NotNil(t, commonRes.HeaderMutation)
+		require.Empty(t, commonRes.HeaderMutation.RemoveHeaders)
+		require.Empty(t, commonRes.HeaderMutation.SetHeaders)
+
+		// Check that original headers remain unchanged.
+		require.Equal(t, "bearer token123", headers["authorization"])
+	})
+}
+
+func TestMessagesProcessorUpstreamFilter_SetBackend_WithHeaderMutations(t *testing.T) {
+	t.Run("header mutator created correctly", func(t *testing.T) {
+		headers := map[string]string{":path": "/anthropic/v1/messages"}
+		chatMetrics := metrics.NewChatCompletion(noop.NewMeterProvider().Meter("test"), map[string]string{})
+		p := &messagesProcessorUpstreamFilter{
+			config:         &processorConfig{},
+			requestHeaders: headers,
+			logger:         slog.Default(),
+			metrics:        chatMetrics,
+		}
+
+		// Create backend with header mutations.
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"x-sensitive"},
+			Set:    []filterapi.HTTPHeader{{Name: "x-backend", Value: "backend-value"}},
+		}
+
+		// Original headers from router filter.
+		originalHeaders := map[string]string{
+			":path":       "/anthropic/v1/messages",
+			"x-sensitive": "original-secret",
+			"x-existing":  "original-value",
+		}
+
+		rp := &messagesProcessorRouterFilter{
+			requestHeaders: originalHeaders,
+			originalRequestBody: &anthropicschema.MessagesRequest{
+				"model":  "claude-3-sonnet",
+				"stream": false,
+			},
+			upstreamFilterCount: 0,
+		}
+
+		err := p.SetBackend(t.Context(), &filterapi.Backend{
+			Name:           "test-backend",
+			Schema:         filterapi.VersionedAPISchema{Name: filterapi.APISchemaGCPAnthropic, Version: "vertex-2023-10-16"},
+			HeaderMutation: headerMutations,
+		}, nil, rp)
+		require.NoError(t, err)
+
+		// Verify header mutator was created.
+		require.NotNil(t, p.headerMutator)
+
+		// Test that the header mutator works correctly.
+		testHeaders := map[string]string{
+			"x-sensitive": "current-secret",
+			"x-existing":  "current-value",
+		}
+		mutation := p.headerMutator.Mutate(testHeaders, false)
+
+		require.NotNil(t, mutation)
+		require.ElementsMatch(t, []string{"x-sensitive"}, mutation.RemoveHeaders)
+		require.Len(t, mutation.SetHeaders, 1)
+		require.Equal(t, "x-backend", mutation.SetHeaders[0].Header.Key)
+		require.Equal(t, []byte("backend-value"), mutation.SetHeaders[0].Header.RawValue)
+	})
+
+	t.Run("header mutator with original headers", func(t *testing.T) {
+		headers := map[string]string{":path": "/anthropic/v1/messages"}
+		chatMetrics := metrics.NewChatCompletion(noop.NewMeterProvider().Meter("test"), map[string]string{})
+		p := &messagesProcessorUpstreamFilter{
+			config:         &processorConfig{},
+			requestHeaders: headers,
+			logger:         slog.Default(),
+			metrics:        chatMetrics,
+		}
+
+		// Create backend with header mutations that don't remove x-custom.
+		headerMutations := &filterapi.HTTPHeaderMutation{
+			Remove: []string{"authorization"},
+		}
+
+		// Original headers from router filter (simulate what would be in rp.requestHeaders).
+		originalHeaders := map[string]string{
+			":path":         "/anthropic/v1/messages",
+			"authorization": "bearer original-token", // This will be removed, so won't be restored.
+			"x-custom":      "original-value",        // This won't be removed, so can be restored.
+			"x-existing":    "existing-value",        // This won't be removed, so can be restored.
+		}
+
+		rp := &messagesProcessorRouterFilter{
+			requestHeaders: originalHeaders,
+			originalRequestBody: &anthropicschema.MessagesRequest{
+				"model":  "claude-3-sonnet",
+				"stream": false,
+			},
+			upstreamFilterCount: 0,
+		}
+
+		err := p.SetBackend(t.Context(), &filterapi.Backend{
+			Name:           "test-backend",
+			Schema:         filterapi.VersionedAPISchema{Name: filterapi.APISchemaGCPAnthropic, Version: "vertex-2023-10-16"},
+			HeaderMutation: headerMutations,
+		}, nil, rp)
+		require.NoError(t, err)
+
+		// Verify header mutator was created with original headers.
+		require.NotNil(t, p.headerMutator)
+
+		// Test retry scenario - original headers should be restored.
+		testHeaders := map[string]string{
+			"x-existing": "current-value", // This exists, so won't be restored.
+		}
+		mutation := p.headerMutator.Mutate(testHeaders, true) // onRetry = true.
+
+		require.NotNil(t, mutation)
+		// RemoveHeaders should be empty because authorization doesn't exist in testHeaders.
+		require.Empty(t, mutation.RemoveHeaders)
+
+		// Should restore x-custom header (not being removed and not already present).
+		var restoredHeader *corev3.HeaderValueOption
+		for _, h := range mutation.SetHeaders {
+			if h.Header.Key == "x-custom" {
+				restoredHeader = h
+				break
+			}
+		}
+		require.NotNil(t, restoredHeader)
+		require.Equal(t, []byte("original-value"), restoredHeader.Header.RawValue)
+		require.Equal(t, "original-value", testHeaders["x-custom"])
+		// x-existing should not be restored because it already exists.
+		require.Equal(t, "current-value", testHeaders["x-existing"])
+	})
 }


### PR DESCRIPTION
**Description**

This PR adds header mutation support to the embeddings and messages processors, bringing them to feature parity with the existing chat completion processor. Header mutations allow users to remove sensitive headers (like authorization tokens) and set custom headers when routing requests to different backend services.

**Changes**
Embeddings Processor: Added headerMutator field and header mutation logic in ProcessRequestHeaders() method
Messages Processor: Added headerMutator field and header mutation logic in ProcessRequestHeaders() method
Retry Support: Both processors now support restoring original headers on retry requests
Backend Integration: Header mutators are created in SetBackend() methods using the backend's HeaderMutation configuration
Comprehensive Tests: Added extensive test coverage for header mutation scenarios including:
Header removal and addition
Retry header restoration
Edge cases (nil mutator, missing headers)

**Key Features**
Security: Remove sensitive headers (auth tokens, API keys) before forwarding to backends
Customization: Set custom headers for specific backend requirements
Retry Resilience: Original headers are automatically restored on retry attempts
Consistency: Maintains the same header mutation API across all processors

**Usage**
`aiservicebackend:
  - name: my-backend
    schema:
      name: openai
    headerMutation:
      remove: ["foo", "bar"]
      set:
        - name: "x-custom-header"
          value: "header-value"`
          
 
**Related Issues/PRs (if applicable)**
Related #1138 
Close #1165 
