### PR TITLE
feat(metrics): support otel and console metric export

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -37,5 +37,6 @@ header:
     - tests/extproc/testdata/server.key
     - tests/extproc/testdata/server.crt
     - .env.ollama
+    - '**/.env*'
     - tests/internal/testopenai/cassettes
     - .github/codecov.yml

--- a/cmd/aigw/.env.otel.console
+++ b/cmd/aigw/.env.otel.console
@@ -1,6 +1,8 @@
 # Console export - outputs telemetry to stdout/stderr
 OTEL_TRACES_EXPORTER=console
 OTEL_METRICS_EXPORTER=console
+# Console traces are synchronous, but metrics are periodic, so shorten it.
+OTEL_METRIC_EXPORT_INTERVAL=100
 
 # Below are default values for span redaction in OpenInference.
 # See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md

--- a/cmd/aigw/.env.otel.console
+++ b/cmd/aigw/.env.otel.console
@@ -1,0 +1,8 @@
+# Console export - outputs telemetry to stdout/stderr
+OTEL_TRACES_EXPORTER=console
+OTEL_METRICS_EXPORTER=console
+
+# Below are default values for span redaction in OpenInference.
+# See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
+OPENINFERENCE_HIDE_INPUTS=false
+OPENINFERENCE_HIDE_OUTPUTS=false

--- a/cmd/aigw/.env.otel.otel-tui
+++ b/cmd/aigw/.env.otel.otel-tui
@@ -1,0 +1,13 @@
+# otel-tui configuration - Terminal UI for OpenTelemetry
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-tui:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# Reduce trace and metrics export delay for demo purposes
+OTEL_BSP_SCHEDULE_DELAY=100
+OTEL_METRIC_EXPORT_INTERVAL=100
+# Only export when there are changes (delta) to reduce noise
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
+
+# Below are default values for span redaction in OpenInference.
+# See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
+OPENINFERENCE_HIDE_INPUTS=false
+OPENINFERENCE_HIDE_OUTPUTS=false

--- a/cmd/aigw/.env.otel.phoenix
+++ b/cmd/aigw/.env.otel.phoenix
@@ -1,0 +1,13 @@
+# Phoenix configuration - LLM-specific observability
+# Phoenix uses port 6006 for OTLP
+OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# Phoenix only supports traces, not metrics
+OTEL_METRICS_EXPORTER=none
+# Reduce trace export delay for demo purposes
+OTEL_BSP_SCHEDULE_DELAY=100
+
+# Below are default values for span redaction in OpenInference.
+# See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
+OPENINFERENCE_HIDE_INPUTS=false
+OPENINFERENCE_HIDE_OUTPUTS=false

--- a/cmd/aigw/README.md
+++ b/cmd/aigw/README.md
@@ -35,19 +35,19 @@
 
    `down` stops the containers and removes the volumes used by the stack.
    ```bash
-   docker compose down -v
+   docker compose down -v --remove-orphans
    ```
 
 ## Quick Start with OpenTelemetry
 
 [docker-compose-otel.yaml](docker-compose-otel.yaml) includes OpenTelemetry
-tracing, visualized with [Arize Phoenix][phoenix], an open-source LLM tracing
-and evaluation system. It has UX features for LLM spans formatted with
-[OpenInference semantics][openinference].
+support for observability of the AI Gateway and client applications.
 
-- **aigw** (port 1975): Envoy AI Gateway CLI (standalone mode) with OTEL tracing
-- **Phoenix** (port 6006): OpenTelemetry trace viewer UI for LLM observability
+- **aigw** (port 1975): Envoy AI Gateway CLI (standalone mode) with OTEL support
 - **chat-completion**: OpenAI Python client instrumented with OpenTelemetry
+- **Phoenix** (port 6006): Optional OpenTelemetry trace viewer for LLM observability
+
+### Prerequisites
 
 1. **Start Ollama** on your host machine:
 
@@ -57,54 +57,120 @@ and evaluation system. It has UX features for LLM spans formatted with
    OLLAMA_CONTEXT_LENGTH=131072 OLLAMA_HOST=0.0.0.0 ollama serve
    ```
 
-2. **Run the example OpenTelemetry stack**:
+### Configure OpenTelemetry Export
 
-   `up` builds `aigw` from source and starts the stack, awaiting health checks.
+Choose how you want to export telemetry data (traces and metrics). We provide
+pre-configured `.env` files for common scenarios:
+
+<details>
+<summary>Console (Default - no external dependencies)</summary>
+
+Export telemetry directly to the console for debugging. The `.env.otel.console`
+file is already provided and will be used by default when no profile is specified
+or when you set `COMPOSE_PROFILES=console`.
+
+This outputs traces and metrics to stdout/stderr. Useful for debugging without
+requiring any external services.
+</details>
+
+<details>
+<summary>Arize Phoenix (LLM-specific observability)</summary>
+
+[Arize Phoenix][phoenix] is an open-source LLM tracing and evaluation system
+with UX features for spans formatted with [OpenInference semantics][openinference].
+
+The `.env.otel.phoenix` file is already provided and will be used automatically
+when you set `COMPOSE_PROFILES=phoenix`. This also starts the Phoenix service.
+
+This configures:
+- OTLP endpoint to Phoenix on port 6006
+- Metrics disabled (Phoenix only supports traces)
+- Reduced batch delay for demo purposes
+</details>
+
+<details>
+<summary>otel-tui (Terminal UI for OpenTelemetry)</summary>
+
+[otel-tui][otel-tui] provides a terminal-based UI for viewing OpenTelemetry
+traces and metrics in real-time.
+
+The `.env.otel.otel-tui` file is already provided and will be used automatically
+when you set `COMPOSE_PROFILES=otel-tui`. This also starts the otel-tui service.
+
+This configures the OTLP endpoint to otel-tui on port 4318.
+</details>
+
+### Run the Stack
+
+1. **Start the services**:
    ```bash
-   docker compose -f docker-compose-otel.yaml up --wait -d
+   COMPOSE_PROFILES=<profile> docker compose -f docker-compose-otel.yaml up --wait -d
    ```
 
-3. **Create a simple OpenAI chat completion**:
+   Where `<profile>` is:
+   - `console` - Export to console for debugging (default if omitted)
+   - `otel-tui` - Export to otel-tui Terminal UI (also starts otel-tui service)
+   - `phoenix` - Export to Phoenix (also starts Phoenix service)
 
-   `chat-completion` uses the OpenAI Python CLI to send a simple chat completion
-   to the AI Gateway CLI (aigw) which routes it to Ollama. Notably, this app
-   uses [OpenTelemetry Python][otel-python] to send traces transparently.
+2. **Send a test request**:
    ```bash
-   # Invoke the OpenTelemetry instrumented chat completion
    docker compose -f docker-compose-otel.yaml run --build --rm chat-completion
-
-   # Now check you have logs, metrics and traces!
-
-   # Logs: access logging has GenAI fields
-   docker compose -f docker-compose-otel.yaml logs aigw | grep "genai_model_name"
-
-   # Metrics: Prometheus endpoint has GenAI Metrics
-   curl -s localhost:1064/metrics | grep gen_ai_client_token_usage_token_sum
-
-   # Traces: Phoenix received spans sent in OpenInference format
-   docker compose -f docker-compose-otel.yaml logs phoenix | grep "POST /v1/traces"
    ```
 
-4. **View traces in Phoenix**:
+3. **Check telemetry output**:
 
-   Open your browser and navigate to the Phoenix UI to view the traces.
+   <details>
+   <summary>For Console export</summary>
+
    ```bash
+   # View traces and metrics in aigw logs
+   docker compose -f docker-compose-otel.yaml logs aigw | grep -E "(SpanContext|gen_ai)"
+   ```
+   </details>
+
+   <details>
+   <summary>For Phoenix export</summary>
+
+   ```bash
+   # Verify Phoenix is receiving traces
+   docker compose -f docker-compose-otel.yaml logs phoenix | grep "POST /v1/traces"
+
+   # Open Phoenix UI
    open http://localhost:6006
    ```
+   </details>
 
-   You should see a trace like this, which shows the OpenAI CLI (Python)
-   joining a trace with the Envoy AI Gateway CLI (aigw), showing LLM inputs
-   and outputs to the LLM (served by Ollama). The Phoenix screenshot is
-   annotated to highlight the key parts of the trace:
+   <details>
+   <summary>For otel-tui export</summary>
 
-   ![Phoenix Screenshot](phoenix.webp)
-
-5. **Shutdown the example stack**:
-
-   `down` stops the containers and removes the volumes used by the stack.
    ```bash
-   docker compose -f docker-compose-otel.yaml down -v
+   # Show TUI in your current terminal session
+   docker compose -f docker-compose-otel.yaml attach otel-tui
+
+   # Detach by pressing Ctrl+p -> Ctrl+q
    ```
+   </details>
+
+   **Access logs with GenAI fields** (always available):
+   ```bash
+   docker compose -f docker-compose-otel.yaml logs aigw | grep "genai_model_name"
+   ```
+
+### Phoenix UI (when using Phoenix export)
+
+If you configured Phoenix as your OTLP endpoint, you can view detailed traces
+showing the OpenAI CLI (Python) joining a trace with the Envoy AI Gateway CLI
+(aigw), including LLM inputs and outputs served by Ollama:
+
+![Phoenix Screenshot](phoenix.webp)
+
+### Shutdown
+
+**Stop the services**:
+
+```bash
+docker compose -f docker-compose-otel.yaml down -v --remove-orphans
+```
 
 ---
 [ollama]: https://ollama.com/
@@ -112,4 +178,5 @@ and evaluation system. It has UX features for LLM spans formatted with
 [openinference]: https://github.com/Arize-ai/openinference/tree/main/spec
 [phoenix]: https://docs.arize.com/phoenix
 [otel-python]: https://opentelemetry.io/docs/zero-code/python/
+[otel-tui]: https://github.com/ymtdzzz/otel-tui
 

--- a/cmd/aigw/README.md
+++ b/cmd/aigw/README.md
@@ -114,7 +114,7 @@ This configures the OTLP endpoint to otel-tui on port 4318.
 
 2. **Send a test request**:
    ```bash
-   docker compose -f docker-compose-otel.yaml run --build --rm chat-completion
+   COMPOSE_PROFILES=<profile> docker compose -f docker-compose-otel.yaml run --build --rm chat-completion
    ```
 
 3. **Check telemetry output**:

--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -8,6 +8,28 @@ volumes:
   envoy-cache:  # Stores downloaded Envoy versions
 
 services:
+  # otel-tui is a terminal UI for viewing OpenTelemetry traces and metrics
+  otel-tui:
+    image: ymtdzzz/otel-tui:latest
+    container_name: otel-tui
+    profiles: ["otel-tui"]
+    ports:
+      - "4318:4318"
+    stdin_open: true
+    tty: true
+
+  # phoenix is an OpenTelemetry compatible LLM eval system which accepts trace
+  # spans and has special handling for OpenInference LLM semantic conventions.
+  # See https://arize.com/docs/phoenix
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    container_name: phoenix
+    profiles: ["phoenix"]  # Only start when explicitly requested
+    ports:
+      - "6006:6006"
+    environment:
+      PHOENIX_ENABLE_AUTH: "false"
+
   # aigw-build builds the Envoy AI Gateway CLI binary, so you can use main code.
   aigw-build:
     image: golang:1.25
@@ -17,17 +39,6 @@ services:
       - ../..:/workspace
       - aigw-target:/workspace/out
     command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
-
-  # phoenix is an OpenTelemetry compatible LLM eval system which accepts trace
-  # spans and has special handling for OpenInference LLM semantic conventions.
-  # See https://arize.com/docs/phoenix
-  phoenix:
-    image: arizephoenix/phoenix:latest
-    container_name: phoenix
-    ports:
-      - "6006:6006"
-    environment:
-      PHOENIX_ENABLE_AUTH: "false"
 
   # ollama-pull pulls the models defined in .env.ollama, to avoid 404s.
   ollama-pull:
@@ -42,27 +53,18 @@ services:
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
       - "localhost:host-gateway"
 
-  # aigw is the Envoy AI Gateway CLI a.k.a standlane mode.
+  # aigw is the Envoy AI Gateway CLI a.k.a standalone mode.
   aigw:
     image: debian:trixie-slim
     container_name: aigw
     depends_on:
       aigw-build:
         condition: service_completed_successfully
-      phoenix:
-        condition: service_started
       ollama-pull:
         condition: service_completed_successfully
+    env_file:
+      - .env.otel.${COMPOSE_PROFILES:-console}
     environment:
-      # Below sets the OTLP collector to Phoenix, using a shorter span delay.
-      # See https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_BSP_SCHEDULE_DELAY=100
-      # Below are default values for span redaction in OpenInference.
-      # See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
-      - OPENINFERENCE_HIDE_INPUTS=false
-      - OPENINFERENCE_HIDE_OUTPUTS=false
       - OPENAI_HOST=host.docker.internal
     ports:
       - "1975:1975"  # OpenAI compatible endpoint at /v1
@@ -85,15 +87,12 @@ services:
       context: ../../tests/internal/testopeninference
       dockerfile: Dockerfile.openai_client
     container_name: chat-completion
-    profiles: ["test"]
     env_file:
       - ../../.env.ollama
+      - .env.otel.${COMPOSE_PROFILES:-console}
     environment:
       - OPENAI_BASE_URL=http://aigw:1975/v1
       - OPENAI_API_KEY=unused
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_BSP_SCHEDULE_DELAY=100
     depends_on:
       aigw:
         condition: service_started

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/contrib/propagators/autoprop v0.62.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.59.1
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.37.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.37.0
 	go.opentelemetry.io/otel/metric v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
@@ -229,7 +230,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.13.0 // indirect
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.37.0 // indirect
 	go.opentelemetry.io/otel/log v0.13.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.13.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/openai/openai-go/v2 v2.2.2
 	github.com/prometheus/client_golang v1.23.0
+	github.com/prometheus/common v0.65.0
 	github.com/stretchr/testify v1.11.0
 	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/tidwall/gjson v1.18.0
@@ -187,7 +188,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/otlptranslator v0.0.0-20250717125610-8549f4ab4f8f // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -50,6 +50,10 @@ const (
 // The input format is "header1:label1,header2:label2" where header names are HTTP request
 // headers and label names are Prometheus metric labels.
 // Example: "x-team-id:team_id,x-user-id:user_id".
+//
+// Note: This serves a different purpose than OTEL's OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
+// which captures headers as span attributes for tracing. This function creates Prometheus metric labels
+// from headers with custom naming (e.g., x-team-id → team_id) for proper Prometheus conventions.
 func ParseRequestHeaderLabelMapping(s string) (map[string]string, error) {
 	if s == "" {
 		return nil, nil

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,168 +7,87 @@ package metrics
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"os"
 
-	promregistry "github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
-	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
-// Metrics is the interface for OpenTelemetry metrics configuration.
-type Metrics interface {
-	// Meter returns the meter for creating metrics.
-	Meter() metric.Meter
-	// Registry returns the Prometheus registry if metrics are exported to Prometheus, nil otherwise.
-	Registry() *promregistry.Registry
-	// Shutdown shuts down the metrics provider.
-	Shutdown(context.Context) error
-}
+// NewMetricsFromEnv configures an OpenTelemetry MeterProvider based on environment variables,
+// always incorporating the provided Prometheus reader. It optionally includes additional exporters
+// (e.g., console or OTLP) if enabled via environment variables. The function returns a metric.Meter
+// for instrumentation and a shutdown function to gracefully close the provider.
+//
+// The stdout parameter directs output for the console exporter (use os.Stdout in production).
+// Environment variables checked directly include:
+//   - OTEL_SDK_DISABLED: If "true", disables OTEL exporters.
+//   - OTEL_METRICS_EXPORTER: Supported values are "none", "console", "prometheus", "otlp".
+//   - OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: Enables OTLP if set.
+//
+// Prometheus is always enabled via the provided promReader; other exporters are added conditionally.
+func NewMetricsFromEnv(ctx context.Context, stdout io.Writer, promReader sdkmetric.Reader) (metric.Meter, func(context.Context) error, error) {
+	// Initialize options for the MeterProvider, starting with the required Prometheus reader.
+	var options []sdkmetric.Option
+	options = append(options, sdkmetric.WithReader(promReader))
 
-var _ Metrics = (*metricsImpl)(nil)
-
-type metricsImpl struct {
-	meter    metric.Meter
-	registry *promregistry.Registry
-	// shutdown is nil when we didn't create mp.
-	shutdown func(context.Context) error
-}
-
-// Meter implements the same method as documented on Metrics.
-func (m *metricsImpl) Meter() metric.Meter {
-	return m.meter
-}
-
-// Registry implements the same method as documented on Metrics.
-func (m *metricsImpl) Registry() *promregistry.Registry {
-	return m.registry
-}
-
-// Shutdown implements the same method as documented on Metrics.
-func (m *metricsImpl) Shutdown(ctx context.Context) error {
-	if m.shutdown != nil {
-		return m.shutdown(ctx)
-	}
-	return nil
-}
-
-// NoopMetrics returns a no-op metrics implementation.
-type NoopMetrics struct{}
-
-// Meter returns a no-op meter.
-func (NoopMetrics) Meter() metric.Meter { return noop.NewMeterProvider().Meter("noop") }
-
-// Registry returns nil for no-op metrics.
-func (NoopMetrics) Registry() *promregistry.Registry { return nil }
-
-// Shutdown is a no-op.
-func (NoopMetrics) Shutdown(context.Context) error { return nil }
-
-// NewMetricsFromEnv configures OpenTelemetry metrics based on environment
-// variables. Returns a metrics graph that is noop when disabled.
-func NewMetricsFromEnv(ctx context.Context) (Metrics, error) {
-	// Return no-op metrics if disabled.
-	if os.Getenv("OTEL_SDK_DISABLED") == "true" {
-		return NoopMetrics{}, nil
-	}
-
-	// Check for metrics-specific exporter first, then fall back to generic.
-	exporter := os.Getenv("OTEL_METRICS_EXPORTER")
-	if exporter == "none" {
-		return NoopMetrics{}, nil
-	}
-
-	// If no metrics-specific exporter is set, check if OTLP endpoints are configured.
-	// According to OTEL spec, we should use OTLP if any endpoint is configured.
-	// The autoexport library will handle the endpoint precedence correctly:
-	// 1. OTEL_EXPORTER_OTLP_METRICS_ENDPOINT (metrics-specific)
-	// 2. OTEL_EXPORTER_OTLP_ENDPOINT (generic base endpoint).
-	if exporter == "" {
-		// Check if any OTLP endpoint is configured for metrics.
+	// Add OTEL exporters only if the SDK is not disabled.
+	if os.Getenv("OTEL_SDK_DISABLED") != "true" {
+		exporter := os.Getenv("OTEL_METRICS_EXPORTER")
 		hasOTLPEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" ||
 			os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") != ""
 
-		if !hasOTLPEndpoint {
-			// Default to prometheus for backward compatibility when no OTLP is configured.
-			exporter = "prometheus"
+		// Proceed if exporter is "console" or if OTLP is implied (not "none" or "prometheus" with endpoint set).
+		if exporter == "console" || (exporter != "none" && exporter != "prometheus" && hasOTLPEndpoint) {
+			// Configure resource with default attributes, fallback service name, and environment overrides.
+			defaultRes := resource.Default()
+			envRes, err := resource.New(ctx,
+				resource.WithFromEnv(),
+				resource.WithTelemetrySDK(),
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+			// Ensure a service name is set if not provided via environment.
+			fallbackRes := resource.NewSchemaless(
+				semconv.ServiceName("ai-gateway"),
+			)
+			res, err := resource.Merge(defaultRes, fallbackRes)
+			if err != nil {
+				return nil, nil, err
+			}
+			res, err = resource.Merge(res, envRes)
+			if err != nil {
+				return nil, nil, err
+			}
+			options = append(options, sdkmetric.WithResource(res))
+
+			if exporter == "console" {
+				// Configure console exporter with a PeriodicReader for aggregated metric export.
+				exp, err := stdoutmetric.New(
+					stdoutmetric.WithWriter(stdout),
+				)
+				if err != nil {
+					return nil, nil, err
+				}
+				reader := sdkmetric.NewPeriodicReader(exp)
+				options = append(options, sdkmetric.WithReader(reader))
+			} else {
+				// Use autoexport for OTLP, which internally handles PeriodicReader for aggregation.
+				otelReader, err := autoexport.NewMetricReader(ctx)
+				if err != nil {
+					return nil, nil, err
+				}
+				options = append(options, sdkmetric.WithReader(otelReader))
+			}
 		}
-		// Fall through to handle configuration.
 	}
 
-	// Create resource with service name, defaulting to "ai-gateway" if not set.
-	// First create default resource, then one from env, then our fallback.
-	// The merge order ensures env vars override our default.
-	defaultRes := resource.Default()
-	envRes, err := resource.New(ctx,
-		resource.WithFromEnv(),      // Read OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES.
-		resource.WithTelemetrySDK(), // Add telemetry SDK info.
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource from env: %w", err)
-	}
-
-	// Only set our default if service.name wasn't set via env
-	fallbackRes := resource.NewSchemaless(
-		semconv.ServiceName("ai-gateway"),
-	)
-
-	// Merge in order: default -> fallback -> env (env takes precedence).
-	res, err := resource.Merge(defaultRes, fallbackRes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge default resources: %w", err)
-	}
-	res, err = resource.Merge(res, envRes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge env resource: %w", err)
-	}
-
-	// Create the meter provider.
-	var mp *sdkmetric.MeterProvider
-	var registry *promregistry.Registry
-
-	// Special case prometheus to serve on our own HTTP server instead of autoexport's.
-	if exporter == "prometheus" {
-		registry = promregistry.NewRegistry()
-		promExporter, err := prometheus.New(prometheus.WithRegisterer(registry))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create prometheus exporter: %w", err)
-		}
-		// We don't add sdkmetric.WithResource(res) to ensure we remain compat with aigw 0.3.x
-		mp = sdkmetric.NewMeterProvider(sdkmetric.WithReader(promExporter))
-	} else {
-		// Use autoexport for everything else (console, otlp, etc.).
-		// This handles OTEL_METRICS_EXPORTER values like "console", "otlp", "none".
-		autoExporter, err := autoexport.NewMetricReader(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create exporter: %w", err)
-		}
-		mp = sdkmetric.NewMeterProvider(
-			sdkmetric.WithReader(autoExporter),
-			sdkmetric.WithResource(res),
-		)
-	}
-
-	return &metricsImpl{
-		meter:    mp.Meter("envoyproxy/ai-gateway"),
-		registry: registry,
-		shutdown: mp.Shutdown, // we have to shut down what we create.
-	}, nil
-}
-
-// NewMetrics configures OpenTelemetry metrics based on the configuration.
-// Returns a metrics graph that is noop when the meter is no-op.
-func NewMetrics(meter metric.Meter, registry *promregistry.Registry) Metrics {
-	if _, ok := meter.(noop.Meter); ok {
-		return NoopMetrics{}
-	}
-	return &metricsImpl{
-		meter:    meter,
-		registry: registry,
-		shutdown: nil, // shutdown is nil when we didn't create mp.
-	}
+	// Create and return the MeterProvider with all configured options.
+	mp := sdkmetric.NewMeterProvider(options...)
+	return mp.Meter("envoyproxy/ai-gateway"), mp.Shutdown, nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,174 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	promregistry "github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+)
+
+// Metrics is the interface for OpenTelemetry metrics configuration.
+type Metrics interface {
+	// Meter returns the meter for creating metrics.
+	Meter() metric.Meter
+	// Registry returns the Prometheus registry if metrics are exported to Prometheus, nil otherwise.
+	Registry() *promregistry.Registry
+	// Shutdown shuts down the metrics provider.
+	Shutdown(context.Context) error
+}
+
+var _ Metrics = (*metricsImpl)(nil)
+
+type metricsImpl struct {
+	meter    metric.Meter
+	registry *promregistry.Registry
+	// shutdown is nil when we didn't create mp.
+	shutdown func(context.Context) error
+}
+
+// Meter implements the same method as documented on Metrics.
+func (m *metricsImpl) Meter() metric.Meter {
+	return m.meter
+}
+
+// Registry implements the same method as documented on Metrics.
+func (m *metricsImpl) Registry() *promregistry.Registry {
+	return m.registry
+}
+
+// Shutdown implements the same method as documented on Metrics.
+func (m *metricsImpl) Shutdown(ctx context.Context) error {
+	if m.shutdown != nil {
+		return m.shutdown(ctx)
+	}
+	return nil
+}
+
+// NoopMetrics returns a no-op metrics implementation.
+type NoopMetrics struct{}
+
+// Meter returns a no-op meter.
+func (NoopMetrics) Meter() metric.Meter { return noop.NewMeterProvider().Meter("noop") }
+
+// Registry returns nil for no-op metrics.
+func (NoopMetrics) Registry() *promregistry.Registry { return nil }
+
+// Shutdown is a no-op.
+func (NoopMetrics) Shutdown(context.Context) error { return nil }
+
+// NewMetricsFromEnv configures OpenTelemetry metrics based on environment
+// variables. Returns a metrics graph that is noop when disabled.
+func NewMetricsFromEnv(ctx context.Context) (Metrics, error) {
+	// Return no-op metrics if disabled.
+	if os.Getenv("OTEL_SDK_DISABLED") == "true" {
+		return NoopMetrics{}, nil
+	}
+
+	// Check for metrics-specific exporter first, then fall back to generic.
+	exporter := os.Getenv("OTEL_METRICS_EXPORTER")
+	if exporter == "none" {
+		return NoopMetrics{}, nil
+	}
+
+	// If no metrics-specific exporter is set, check if OTLP endpoints are configured.
+	// According to OTEL spec, we should use OTLP if any endpoint is configured.
+	// The autoexport library will handle the endpoint precedence correctly:
+	// 1. OTEL_EXPORTER_OTLP_METRICS_ENDPOINT (metrics-specific)
+	// 2. OTEL_EXPORTER_OTLP_ENDPOINT (generic base endpoint).
+	if exporter == "" {
+		// Check if any OTLP endpoint is configured for metrics.
+		hasOTLPEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" ||
+			os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") != ""
+
+		if !hasOTLPEndpoint {
+			// Default to prometheus for backward compatibility when no OTLP is configured.
+			exporter = "prometheus"
+		}
+		// Fall through to handle configuration.
+	}
+
+	// Create resource with service name, defaulting to "ai-gateway" if not set.
+	// First create default resource, then one from env, then our fallback.
+	// The merge order ensures env vars override our default.
+	defaultRes := resource.Default()
+	envRes, err := resource.New(ctx,
+		resource.WithFromEnv(),      // Read OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES.
+		resource.WithTelemetrySDK(), // Add telemetry SDK info.
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource from env: %w", err)
+	}
+
+	// Only set our default if service.name wasn't set via env
+	fallbackRes := resource.NewSchemaless(
+		semconv.ServiceName("ai-gateway"),
+	)
+
+	// Merge in order: default -> fallback -> env (env takes precedence).
+	res, err := resource.Merge(defaultRes, fallbackRes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge default resources: %w", err)
+	}
+	res, err = resource.Merge(res, envRes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge env resource: %w", err)
+	}
+
+	// Create the meter provider.
+	var mp *sdkmetric.MeterProvider
+	var registry *promregistry.Registry
+
+	// Special case prometheus to serve on our own HTTP server instead of autoexport's.
+	if exporter == "prometheus" {
+		registry = promregistry.NewRegistry()
+		promExporter, err := prometheus.New(prometheus.WithRegisterer(registry))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create prometheus exporter: %w", err)
+		}
+		// We don't add sdkmetric.WithResource(res) to ensure we remain compat with aigw 0.3.x
+		mp = sdkmetric.NewMeterProvider(sdkmetric.WithReader(promExporter))
+	} else {
+		// Use autoexport for everything else (console, otlp, etc.).
+		// This handles OTEL_METRICS_EXPORTER values like "console", "otlp", "none".
+		autoExporter, err := autoexport.NewMetricReader(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create exporter: %w", err)
+		}
+		mp = sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(autoExporter),
+			sdkmetric.WithResource(res),
+		)
+	}
+
+	return &metricsImpl{
+		meter:    mp.Meter("envoyproxy/ai-gateway"),
+		registry: registry,
+		shutdown: mp.Shutdown, // we have to shut down what we create.
+	}, nil
+}
+
+// NewMetrics configures OpenTelemetry metrics based on the configuration.
+// Returns a metrics graph that is noop when the meter is no-op.
+func NewMetrics(meter metric.Meter, registry *promregistry.Registry) Metrics {
+	if _, ok := meter.(noop.Meter); ok {
+		return NoopMetrics{}
+	}
+	return &metricsImpl{
+		meter:    meter,
+		registry: registry,
+		shutdown: nil, // shutdown is nil when we didn't create mp.
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,326 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	promregistry "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// TestNewMetricsFromEnv_DefaultServiceName tests that the service name.
+// defaults to "ai-gateway" when OTEL_SERVICE_NAME is not set.
+func TestNewMetricsFromEnv_DefaultServiceName(t *testing.T) {
+	tests := []struct {
+		name              string
+		env               map[string]string
+		expectServiceName string
+		expectNoop        bool
+	}{
+		{
+			name: "default service name when OTEL_SERVICE_NAME not set",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER": "console",
+			},
+			expectServiceName: "ai-gateway",
+		},
+		{
+			name: "OTEL_SERVICE_NAME overrides default",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER": "console",
+				"OTEL_SERVICE_NAME":     "custom-service",
+			},
+			expectServiceName: "custom-service",
+		},
+		{
+			name:              "prometheus default when no metrics exporter set",
+			env:               map[string]string{},
+			expectServiceName: "ai-gateway",
+		},
+		{
+			name: "disabled when OTEL_SDK_DISABLED is true",
+			env: map[string]string{
+				"OTEL_SDK_DISABLED":     "true",
+				"OTEL_METRICS_EXPORTER": "console",
+			},
+			expectNoop: true,
+		},
+		{
+			name: "disabled when OTEL_METRICS_EXPORTER is none",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER": "none",
+			},
+			expectNoop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			result, err := NewMetricsFromEnv(t.Context())
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = result.Shutdown(context.Background())
+			})
+
+			if tt.expectNoop {
+				_, ok := result.(NoopMetrics)
+				require.True(t, ok, "expected NoopMetrics")
+			} else {
+				_, ok := result.(NoopMetrics)
+				require.False(t, ok, "expected non-noop metrics")
+
+				// For console exporter, we should see output containing service name.
+				if tt.env["OTEL_METRICS_EXPORTER"] == "console" {
+					meter := result.Meter()
+					require.NotNil(t, meter)
+					_, ok := meter.(noop.Meter)
+					require.False(t, ok, "expected non-noop meter")
+				}
+
+				// For prometheus, check registry exists.
+				if tt.env["OTEL_METRICS_EXPORTER"] == "" || tt.env["OTEL_METRICS_EXPORTER"] == "prometheus" {
+					registry := result.Registry()
+					require.NotNil(t, registry, "expected prometheus registry")
+				}
+			}
+		})
+	}
+}
+
+// TestNewMetricsFromEnv_ExporterPrecedence tests that metrics-specific.
+// exporter configuration takes precedence over generic OTLP configuration.
+func TestNewMetricsFromEnv_ExporterPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		env            map[string]string
+		expectExporter string
+		expectNoop     bool
+	}{
+		{
+			name: "metrics-specific exporter takes precedence over generic OTLP",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER":       "console",
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+			},
+			expectExporter: "console",
+		},
+		{
+			name: "uses OTLP when generic endpoint is configured",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+			},
+			expectExporter: "otlp",
+		},
+		{
+			name: "uses metrics-specific OTLP endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4318",
+			},
+			expectExporter: "otlp",
+		},
+		{
+			name: "metrics-specific endpoint takes precedence over generic",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "http://localhost:4317",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4318",
+			},
+			expectExporter: "otlp",
+		},
+		{
+			name:           "defaults to prometheus when no configuration",
+			env:            map[string]string{},
+			expectExporter: "prometheus",
+		},
+		{
+			name: "respects none exporter",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER":       "none",
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+			},
+			expectNoop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			result, err := NewMetricsFromEnv(t.Context())
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = result.Shutdown(context.Background())
+			})
+
+			if tt.expectNoop {
+				_, ok := result.(NoopMetrics)
+				require.True(t, ok, "expected NoopMetrics")
+			} else {
+				_, ok := result.(NoopMetrics)
+				require.False(t, ok, "expected non-noop metrics")
+
+				// Verify the correct exporter type is configured.
+				switch tt.expectExporter {
+				case "console":
+					// Console writes to stdout.
+					meter := result.Meter()
+					require.NotNil(t, meter)
+				case "prometheus":
+					// Prometheus provides a registry.
+					registry := result.Registry()
+					require.NotNil(t, registry, "expected prometheus registry")
+				case "otlp":
+					// OTLP doesn't provide a registry.
+					registry := result.Registry()
+					require.Nil(t, registry, "expected no registry for OTLP")
+				}
+			}
+		})
+	}
+}
+
+// TestNewMetricsFromEnv_ConsoleExporter tests that console exporter works.
+// without requiring OTLP endpoints and doesn't make network calls.
+func TestNewMetricsFromEnv_ConsoleExporter(t *testing.T) {
+	tests := []struct {
+		name                string
+		env                 map[string]string
+		expectNoop          bool
+		expectRegistry      bool
+		expectConsoleOutput bool
+	}{
+		{
+			name: "console exporter without any endpoints",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER": "console",
+			},
+			expectConsoleOutput: true,
+			expectRegistry:      false,
+		},
+		{
+			name: "console exporter ignores OTLP endpoints",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER":               "console",
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "http://should-be-ignored:4317",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://should-be-ignored:4318",
+			},
+			expectConsoleOutput: true,
+			expectRegistry:      false,
+		},
+		{
+			name: "console exporter with custom service name",
+			env: map[string]string{
+				"OTEL_METRICS_EXPORTER": "console",
+				"OTEL_SERVICE_NAME":     "test-console-service",
+			},
+			expectConsoleOutput: true,
+			expectRegistry:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			result, err := NewMetricsFromEnv(t.Context())
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = result.Shutdown(context.Background())
+			})
+
+			if tt.expectNoop {
+				_, ok := result.(NoopMetrics)
+				require.True(t, ok, "expected NoopMetrics")
+				return
+			}
+
+			// Verify it's not noop.
+			_, ok := result.(NoopMetrics)
+			require.False(t, ok, "expected non-noop metrics")
+
+			// Check registry expectation.
+			registry := result.Registry()
+			if tt.expectRegistry {
+				require.NotNil(t, registry, "expected prometheus registry")
+			} else {
+				require.Nil(t, registry, "expected no registry for console exporter")
+			}
+
+			// For console exporter, verify it has a valid meter.
+			meter := result.Meter()
+			require.NotNil(t, meter)
+
+			// Create a test counter to verify console output works.
+			if tt.expectConsoleOutput {
+				counter, err := meter.Int64Counter("test.counter")
+				require.NoError(t, err)
+				counter.Add(t.Context(), 1)
+
+				// Console exporter is periodic, but we can verify the meter was created.
+				// The actual output would appear after the export interval.
+				_, ok := meter.(noop.Meter)
+				require.False(t, ok, "console exporter should provide real meter, not noop")
+			}
+		})
+	}
+}
+
+// TestNewMetrics tests the NewMetrics function with provided meter and registry.
+func TestNewMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		meter      func() metric.Meter
+		registry   *promregistry.Registry
+		expectNoop bool
+	}{
+		{
+			name: "non-noop meter",
+			meter: func() metric.Meter {
+				mp := sdkmetric.NewMeterProvider()
+				return mp.Meter("test")
+			},
+			registry:   promregistry.NewRegistry(),
+			expectNoop: false,
+		},
+		{
+			name: "noop meter",
+			meter: func() metric.Meter {
+				return noop.NewMeterProvider().Meter("test")
+			},
+			registry:   nil,
+			expectNoop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewMetrics(tt.meter(), tt.registry)
+
+			if tt.expectNoop {
+				_, ok := result.(NoopMetrics)
+				require.True(t, ok, "expected NoopMetrics")
+			} else {
+				impl, ok := result.(*metricsImpl)
+				require.True(t, ok, "expected metricsImpl")
+				require.NotNil(t, impl.meter)
+				require.Equal(t, tt.registry, impl.registry)
+				require.Nil(t, impl.shutdown, "shutdown should be nil when meter is provided")
+			}
+		})
+	}
+}

--- a/internal/testing/testotel/collector.go
+++ b/internal/testing/testotel/collector.go
@@ -3,7 +3,7 @@
 // The full text of the Apache license is available in the LICENSE file at
 // the root of the repo.
 
-// Package testotel provides test utilities for OpenTelemetry tracing tests.
+// Package testotel provides test utilities for OpenTelemetry tracing and metrics tests.
 // This is not internal for use in cmd/extproc/mainlib/main_test.go.
 package testotel
 
@@ -15,7 +15,9 @@ import (
 	"strings"
 	"time"
 
+	collectmetricsv1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collecttracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 )
@@ -23,10 +25,12 @@ import (
 // otlpTimeout is the timeout for spans to read back.
 const otlpTimeout = 1 * time.Second // OTEL_BSP_SCHEDULE_DELAY + overhead..
 
-// StartOTLPCollector starts a test OTLP collector server that receives trace data.
+// StartOTLPCollector starts a test OTLP collector server that receives trace and metrics data.
 func StartOTLPCollector() *OTLPCollector {
 	spanCh := make(chan *tracev1.ResourceSpans, 10)
+	metricsCh := make(chan *metricsv1.ResourceMetrics, 10)
 	mux := http.NewServeMux()
+
 	mux.HandleFunc("/v1/traces", func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -46,20 +50,45 @@ func StartOTLPCollector() *OTLPCollector {
 
 		w.WriteHeader(http.StatusOK)
 	})
+
+	mux.HandleFunc("/v1/metrics", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+
+		var metrics collectmetricsv1.ExportMetricsServiceRequest
+		if err := proto.Unmarshal(body, &metrics); err != nil {
+			http.Error(w, "Failed to parse metrics", http.StatusBadRequest)
+			return
+		}
+
+		for _, resourceMetrics := range metrics.ResourceMetrics {
+			metricsCh <- resourceMetrics
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
 	s := httptest.NewServer(mux)
 	env := []string{
 		fmt.Sprintf("OTEL_EXPORTER_OTLP_ENDPOINT=%s", s.URL),
 		"OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
 		"OTEL_SERVICE_NAME=ai-gateway-extproc",
 		"OTEL_BSP_SCHEDULE_DELAY=100",
+		"OTEL_METRIC_EXPORT_INTERVAL=100",
+		// Use delta temporality to prevent metric accumulation across subtests.
+		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta",
 	}
-	return &OTLPCollector{s, env, spanCh}
+	return &OTLPCollector{s, env, spanCh, metricsCh}
 }
 
 type OTLPCollector struct {
-	s      *httptest.Server
-	env    []string
-	spanCh chan *tracev1.ResourceSpans
+	s         *httptest.Server
+	env       []string
+	spanCh    chan *tracev1.ResourceSpans
+	metricsCh chan *metricsv1.ResourceMetrics
 }
 
 // Env returns the environment variables needed to configure the OTLP collector.
@@ -87,6 +116,31 @@ func (o *OTLPCollector) TakeSpan() *tracev1.Span {
 		return resourceSpans.ScopeSpans[0].Spans[0]
 	case <-time.After(otlpTimeout):
 		return nil
+	}
+}
+
+// TakeMetrics returns metrics or nil if none were recorded.
+func (o *OTLPCollector) TakeMetrics() *metricsv1.ResourceMetrics {
+	select {
+	case resourceMetrics := <-o.metricsCh:
+		return resourceMetrics
+	case <-time.After(otlpTimeout):
+		return nil
+	}
+}
+
+// TakeAllMetrics returns all metrics received within the timeout period.
+func (o *OTLPCollector) TakeAllMetrics() []*metricsv1.ResourceMetrics {
+	var metrics []*metricsv1.ResourceMetrics
+	deadline := time.After(otlpTimeout)
+
+	for {
+		select {
+		case resourceMetrics := <-o.metricsCh:
+			metrics = append(metrics, resourceMetrics)
+		case <-deadline:
+			return metrics
+		}
 	}
 }
 

--- a/site/docs/capabilities/observability/tracing.md
+++ b/site/docs/capabilities/observability/tracing.md
@@ -49,8 +49,11 @@ helm upgrade ai-eg oci://docker.io/envoyproxy/ai-gateway-helm \
   --version v0.0.0-latest \
   --namespace envoy-ai-gateway-system \
   --set "extProc.extraEnvVars[0].name=OTEL_EXPORTER_OTLP_ENDPOINT" \
-  --set "extProc.extraEnvVars[0].value=http://phoenix-svc:6006"
+  --set "extProc.extraEnvVars[0].value=http://phoenix-svc:6006" \
+  --set "extProc.extraEnvVars[1].name=OTEL_METRICS_EXPORTER" \
+  --set "extProc.extraEnvVars[1].value=none"
 # OTEL_SERVICE_NAME defaults to "ai-gateway" if not set
+# OTEL_METRICS_EXPORTER=none because Phoenix only supports traces, not metrics
 ```
 
 Wait for the gateway pod to be ready:

--- a/site/docs/cli/run.md
+++ b/site/docs/cli/run.md
@@ -153,9 +153,14 @@ requests captured in OpenTelemetry spans.
 `aigw run` supports OpenTelemetry tracing via environment variables:
 
 - **[OTEL SDK][otel-env]**: OTLP exporter configuration that controls span
-  export such as:
+  and metrics export such as:
     - `OTEL_EXPORTER_OTLP_ENDPOINT`: Collector endpoint (e.g., `http://phoenix:6006`)
+    - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: Override traces endpoint separately
+    - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`: Override metrics endpoint separately
+    - `OTEL_TRACES_EXPORTER`: Traces exporter type (e.g., `console`, `otlp`, `none`)
+    - `OTEL_METRICS_EXPORTER`: Metrics exporter type (e.g., `console`, `otlp`, `none`)
     - `OTEL_BSP_SCHEDULE_DELAY`: Batch span processor delay (default: 5000ms)
+    - `OTEL_METRIC_EXPORT_INTERVAL`: Metrics export interval (default: 60000ms)
 
 - **[OpenInference][openinference-config]**: Control sensitive data redaction,
   such as:

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -61,7 +61,6 @@ func TestWithTestUpstream(t *testing.T) {
 	env := startTestEnvironment(t, string(configBytes), true, false)
 
 	listenerPort := env.EnvoyListenerPort()
-	metricsPort := env.ExtProcMetricsPort()
 
 	expectedModels := openai.ModelList{
 		Object: "list",
@@ -910,40 +909,6 @@ data: {"type": "message_stop"}
 		}
 		require.True(t, asserted)
 		require.NoError(t, stream.Err())
-	})
-	t.Run("metrics", func(t *testing.T) {
-		// Generate metrics by making a request - use openai backend for simplicity
-		client := openaigo.NewClient(
-			option.WithBaseURL(fmt.Sprintf("http://localhost:%d/v1", listenerPort)),
-			option.WithAPIKey("unused"),
-			option.WithHeader("x-test-backend", "openai"),
-		)
-		// Use streaming to generate time_per_output_token metric
-		stream := client.Chat.Completions.NewStreaming(t.Context(), openaigo.ChatCompletionNewParams{
-			Messages: []openaigo.ChatCompletionMessageParamUnion{
-				openaigo.UserMessage("Hello"),
-			},
-			Model: "gpt-4",
-		})
-		for stream.Next() {
-			// consume stream
-		}
-		require.NoError(t, stream.Err())
-
-		// Now check the metrics endpoint
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://localhost:%d/metrics", metricsPort), nil)
-		require.NoError(t, err)
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		// Check for basic GenAI metrics with correct labels
-		require.Containsf(t, string(body),
-			`gen_ai_server_request_duration_seconds_bucket{gen_ai_operation_name="chat",gen_ai_provider_name="openai",gen_ai_request_model="gpt-4",otel_scope_name="envoyproxy/ai-gateway"`,
-			"expected metrics in response body:\n%s", string(body),
-		)
 	})
 }
 

--- a/tests/extproc/vcr/docker-compose-otel.yaml
+++ b/tests/extproc/vcr/docker-compose-otel.yaml
@@ -38,6 +38,7 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006
       - OTEL_BSP_SCHEDULE_DELAY=100
+      - OTEL_METRIC_EXPORT_INTERVAL=100
     # ExtProc ports (internal to Docker network, consumed by Envoy):
     # - 1063: gRPC service
     # - 1064: metrics
@@ -89,6 +90,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
       - OTEL_BSP_SCHEDULE_DELAY=100
+      - OTEL_METRIC_EXPORT_INTERVAL=100
     depends_on:
       envoy:
         condition: service_started

--- a/tests/extproc/vcr/otel_chat_completions_test.go
+++ b/tests/extproc/vcr/otel_chat_completions_test.go
@@ -52,11 +52,14 @@ func TestOtelOpenAIChatCompletions(t *testing.T) {
 
 			span := env.collector.TakeSpan()
 			testopeninference.RequireSpanEqual(t, expected, span)
+
+			// Also drain any metrics that might have been sent.
+			_ = env.collector.TakeAllMetrics()
 		})
 	}
 }
 
-// TestOtelOpenAIChatCompletions_propagation tests that the LLM span continues
+// TestOtelOpenAIChatCompletions_propagation tests that the LLM span continues.
 // the trace in headers.
 func TestOtelOpenAIChatCompletions_propagation(t *testing.T) {
 	env := setupOtelTestEnvironment(t)

--- a/tests/extproc/vcr/otel_metrics_test.go
+++ b/tests/extproc/vcr/otel_metrics_test.go
@@ -1,0 +1,184 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package vcr
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/envoyproxy/ai-gateway/tests/internal/testopenai"
+)
+
+// metricsTestCase defines the expected behavior for each cassette.
+type metricsTestCase struct {
+	cassette    testopenai.Cassette
+	isStreaming bool // whether this is a streaming response.
+	isError     bool // whether this is an error response.
+}
+
+// buildMetricsTestCases returns all test cases with their expected behaviors.
+func buildMetricsTestCases() []metricsTestCase {
+	var cases []metricsTestCase
+
+	// Iterate through ALL chat cassettes.
+	for _, cassette := range testopenai.ChatCassettes() {
+		tc := metricsTestCase{
+			cassette: cassette,
+		}
+
+		// Set special case flags.
+		switch cassette {
+		case testopenai.CassetteChatBadRequest,
+			testopenai.CassetteChatUnknownModel,
+			testopenai.CassetteChatNoMessages:
+			tc.isError = true
+
+		case testopenai.CassetteChatStreaming,
+			testopenai.CassetteChatStreamingWebSearch,
+			testopenai.CassetteChatStreamingDetailedUsage:
+			tc.isStreaming = true
+		}
+
+		cases = append(cases, tc)
+	}
+
+	return cases
+}
+
+// TestOtelMetrics_ChatCompletions tests that metrics are properly exported via OTLP.
+// when processing chat completion requests.
+func TestOtelMetrics_ChatCompletions(t *testing.T) {
+	env := setupOtelTestEnvironment(t, "OTEL_METRICS_EXPORTER=otlp")
+
+	listenerPort := env.EnvoyListenerPort()
+
+	wasBadGateway := false
+	for _, tc := range buildMetricsTestCases() {
+		if wasBadGateway {
+			return // rather than also failing subsequent tests, which confuses root cause.
+		}
+
+		t.Run(tc.cassette.String(), func(t *testing.T) {
+			// Send request.
+			req, err := testopenai.NewRequest(t.Context(), fmt.Sprintf("http://localhost:%d/v1", listenerPort), tc.cassette)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			if failIfBadGateway(t, resp) {
+				wasBadGateway = true
+				return // stop further tests if we got a bad gateway.
+			}
+
+			// Always read the content.
+			_, err = io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			// Get the span to extract actual token counts and duration.
+			span := env.collector.TakeSpan()
+
+			// Collect all metrics within the timeout period.
+			allMetrics := env.collector.TakeAllMetrics()
+
+			// Filter out empty metric resources (OTEL sends periodic empty batches).
+			var metrics []*metricsv1.ResourceMetrics
+			for _, rm := range allMetrics {
+				if len(rm.ScopeMetrics) > 0 {
+					metrics = append(metrics, rm)
+				}
+			}
+			require.NotEmpty(t, metrics)
+
+			verifyMetrics(t, metrics, span, tc.isStreaming, tc.isError)
+		})
+	}
+}
+
+func verifyMetrics(t *testing.T, metrics []*metricsv1.ResourceMetrics, span *tracev1.Span, isStreaming bool, isError bool) {
+	require.NotNil(t, span)
+
+	require.Equal(t,
+		getSpanAttributeInt(span.Attributes, "llm.token_count.prompt"),
+		getMetricValueByAttribute(metrics, "gen_ai.client.token.usage", "gen_ai.token.type", "input"))
+
+	require.Equal(t,
+		getSpanAttributeInt(span.Attributes, "llm.token_count.completion"),
+		getMetricValueByAttribute(metrics, "gen_ai.client.token.usage", "gen_ai.token.type", "output"))
+
+	spanDurationSec := float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / 1e9
+	metricDurationSec := getMetricHistogramSum(metrics, "gen_ai.server.request.duration")
+	require.Greater(t, metricDurationSec, 0.0)
+	require.InDelta(t, spanDurationSec, metricDurationSec, 0.3)
+
+	if isStreaming && !isError {
+		ttft := getMetricHistogramSum(metrics, "gen_ai.server.time_to_first_token")
+		require.Greater(t, ttft, 0.0)
+		require.Less(t, ttft, metricDurationSec)
+
+		outputTokens := getSpanAttributeInt(span.Attributes, "llm.token_count.completion")
+		if outputTokens > 0 {
+			tpot := getMetricHistogramSum(metrics, "gen_ai.server.time_per_output_token")
+			require.Greater(t, tpot, 0.0)
+			require.Less(t, tpot, metricDurationSec)
+		}
+	}
+}
+
+func getSpanAttributeInt(attrs []*commonv1.KeyValue, key string) int64 {
+	for _, attr := range attrs {
+		if attr.Key == key {
+			return attr.Value.GetIntValue()
+		}
+	}
+	return 0
+}
+
+func getMetricValueByAttribute(metrics []*metricsv1.ResourceMetrics, metricName string, attrKey string, attrValue string) int64 {
+	for _, resourceMetrics := range metrics {
+		for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+			for _, metric := range scopeMetrics.Metrics {
+				if metric.Name == metricName {
+					histogram := metric.GetHistogram()
+					if histogram != nil {
+						for _, dp := range histogram.DataPoints {
+							for _, attr := range dp.Attributes {
+								if attr.Key == attrKey && attr.Value.GetStringValue() == attrValue {
+									return int64(dp.GetSum())
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func getMetricHistogramSum(metrics []*metricsv1.ResourceMetrics, metricName string) float64 {
+	for _, resourceMetrics := range metrics {
+		for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+			for _, metric := range scopeMetrics.Metrics {
+				if metric.Name == metricName {
+					histogram := metric.GetHistogram()
+					if histogram != nil && len(histogram.DataPoints) > 0 {
+						return histogram.DataPoints[0].GetSum()
+					}
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/tests/extproc/vcr/otel_metrics_test.go
+++ b/tests/extproc/vcr/otel_metrics_test.go
@@ -58,7 +58,7 @@ func buildMetricsTestCases() []metricsTestCase {
 // TestOtelMetrics_ChatCompletions tests that metrics are properly exported via OTLP.
 // when processing chat completion requests.
 func TestOtelMetrics_ChatCompletions(t *testing.T) {
-	env := setupOtelTestEnvironment(t, "OTEL_METRICS_EXPORTER=otlp")
+	env := setupOtelTestEnvironment(t)
 
 	listenerPort := env.EnvoyListenerPort()
 

--- a/tests/extproc/vcr/prometheus_metrics_test.go
+++ b/tests/extproc/vcr/prometheus_metrics_test.go
@@ -1,0 +1,117 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package vcr
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/tests/internal/testopenai"
+)
+
+// TestPrometheusMetrics verifies that metrics are properly exported via Prometheus
+// when processing a chat completion request. This test uses the default configuration
+// which exposes metrics on the /metrics endpoint.
+func TestPrometheusMetrics(t *testing.T) {
+	// Start test environment with default configuration.
+	env := startTestEnvironment(t, extprocBin, extprocConfig, nil, envoyConfig)
+
+	listenerPort := env.EnvoyListenerPort()
+	metricsPort := env.ExtProcMetricsPort()
+
+	// Use the basic chat cassette for this test.
+	cassette := testopenai.CassetteChatBasic
+
+	// Send the chat request.
+	req, err := testopenai.NewRequest(t.Context(), fmt.Sprintf("http://localhost:%d/v1", listenerPort), cassette)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Always consume the body to ensure the request completes.
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Wait for metrics to be available with exponential backoff.
+	var metricsBody []byte
+	require.Eventually(t, func() bool {
+		metricsReq, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://localhost:%d/metrics", metricsPort), nil)
+		if reqErr != nil {
+			return false
+		}
+
+		metricsResp, respErr := http.DefaultClient.Do(metricsReq)
+		if respErr != nil {
+			return false
+		}
+		defer metricsResp.Body.Close()
+
+		metricsBody, respErr = io.ReadAll(metricsResp.Body)
+		if respErr != nil {
+			return false
+		}
+
+		// Check if we have the expected metrics.
+		bodyStr := string(metricsBody)
+		return strings.Contains(bodyStr, "gen_ai_server_request_duration_seconds") &&
+			strings.Contains(bodyStr, "gen_ai_client_token_usage_token")
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Parse the Prometheus metrics.
+	parser := expfmt.TextParser{}
+	metricFamilies, err := parser.TextToMetricFamilies(strings.NewReader(string(metricsBody)))
+	require.NoError(t, err)
+
+	// Verify expected GenAI metrics are present.
+	require.Contains(t, metricFamilies, "gen_ai_server_request_duration_seconds")
+	require.Contains(t, metricFamilies, "gen_ai_client_token_usage_token")
+
+	// Verify specific labels for request duration metric.
+	requestDuration := metricFamilies["gen_ai_server_request_duration_seconds"]
+	require.NotEmpty(t, requestDuration.Metric)
+
+	// Extract labels from the first metric (assuming consistent labels across all).
+	labels := make(map[string]string)
+	for _, label := range requestDuration.Metric[0].Label {
+		labels[*label.Name] = *label.Value
+	}
+	require.Equal(t, "chat", labels["gen_ai_operation_name"])
+	require.Equal(t, "openai", labels["gen_ai_provider_name"])
+	require.Equal(t, "gpt-5-nano", labels["gen_ai_request_model"])
+	require.Equal(t, "envoyproxy/ai-gateway", labels["otel_scope_name"])
+
+	// Verify token usage metrics for both input and output tokens.
+	tokenUsage := metricFamilies["gen_ai_client_token_usage_token"]
+	require.NotEmpty(t, tokenUsage.Metric)
+
+	// Check for input and output token metrics.
+	var hasInput, hasOutput bool
+	for _, metric := range tokenUsage.Metric {
+		for _, label := range metric.Label {
+			if *label.Name == "gen_ai_token_type" {
+				switch *label.Value {
+				case "input":
+					hasInput = true
+				case "output":
+					hasOutput = true
+				}
+			}
+		}
+	}
+	require.True(t, hasInput)
+	require.True(t, hasOutput)
+}

--- a/tests/internal/testopeninference/Dockerfile.openai_client
+++ b/tests/internal/testopeninference/Dockerfile.openai_client
@@ -17,4 +17,4 @@ RUN pip install openai \
 
 ENTRYPOINT ["sh", "-c"]
 # OpenInference only uses spans, not metrics or logs - disable them via CLI args
-CMD ["opentelemetry-instrument --metrics_exporter none --logs_exporter none openai api chat.completions.create -t 0 -m ${CHAT_MODEL} --message user 'Answer in up to 3 words: Which ocean contains Bouvet Island?'"]
+CMD ["opentelemetry-instrument --service_name openai-cli --metrics_exporter none --logs_exporter none openai api chat.completions.create -t 0 -m ${CHAT_MODEL} --message user 'Answer in up to 3 words: Which ocean contains Bouvet Island?'"]

--- a/tests/internal/testopeninference/Dockerfile.openai_client
+++ b/tests/internal/testopeninference/Dockerfile.openai_client
@@ -15,9 +15,6 @@ RUN pip install openai \
     opentelemetry-instrumentation-httpx \
     openinference-instrumentation-openai
 
-# OpenInference only uses spans, not metrics or logs
-ENV OTEL_METRICS_EXPORTER=none
-ENV OTEL_LOGS_EXPORTER=none
-
 ENTRYPOINT ["sh", "-c"]
-CMD ["opentelemetry-instrument openai api chat.completions.create -t 0 -m ${CHAT_MODEL} --message user 'Answer in up to 3 words: Which ocean contains Bouvet Island?'"]
+# OpenInference only uses spans, not metrics or logs - disable them via CLI args
+CMD ["opentelemetry-instrument --metrics_exporter none --logs_exporter none openai api chat.completions.create -t 0 -m ${CHAT_MODEL} --message user 'Answer in up to 3 words: Which ocean contains Bouvet Island?'"]


### PR DESCRIPTION
**Description**

This extends otel ENV config to metrics, when enabled exports instead of a prometheus listener. This allows metrics in otel native systems like elastic stack, otel tui and otherwise, without a prometheus pump. This also allows you to do ad-hoc configuration by using `console` config.

Here's an example of standalone using otel-tui https://github.com/ymtdzzz/otel-tui:
<img width="720" height="296" alt="tui-metrics" src="https://github.com/user-attachments/assets/6640e6ee-c87c-4586-bce7-13d6ca837c96" />
<img width="2096" height="1014" alt="tui-trace" src="https://github.com/user-attachments/assets/0feb6ed2-87e0-4b43-9c96-7f09493ec365" />

Updated cmd/aigw examples:
- Add otel-tui service to show native otel w/o prometheus
- Use profile-based env file selection (.env.otel.${COMPOSE_PROFILES:-console})
- Set console as default for immediate debugging without external dependencies

Documentation:
- Document separate OTLP endpoints for traces/metrics and exporter types

Phoenix users: Set OTEL_METRICS_EXPORTER=none as Phoenix only supports traces

Fixes #1100