### PR TITLE
init

### DIFF
--- a/internal/metrics/base_metrics.go
+++ b/internal/metrics/base_metrics.go
@@ -17,7 +17,7 @@ import (
 
 // baseMetrics provides shared functionality for AI Gateway metrics implementations.
 type baseMetrics struct {
-	metrics                   *genAI
+	metrics                   *apiMetrics
 	operation                 string
 	requestStart              time.Time
 	model                     string
@@ -26,9 +26,9 @@ type baseMetrics struct {
 }
 
 // newBaseMetrics creates a new baseMetrics instance with the specified operation.
-func newBaseMetrics(meter metric.Meter, operation string, requestHeaderLabelMapping map[string]string) baseMetrics {
+func newBaseMetrics(meter metric.Meter, operation string, requestHeaderLabelMapping map[string]string, isGen bool) baseMetrics {
 	return baseMetrics{
-		metrics:                   newGenAI(meter),
+		metrics:                   newAPIMetrics(meter, isGen),
 		operation:                 operation,
 		model:                     "unknown",
 		backend:                   "unknown",

--- a/internal/metrics/chat_completion_metrics.go
+++ b/internal/metrics/chat_completion_metrics.go
@@ -49,7 +49,7 @@ type ChatCompletionMetrics interface {
 // NewChatCompletion creates a new x.ChatCompletionMetrics instance.
 func NewChatCompletion(meter metric.Meter, requestHeaderLabelMapping map[string]string) ChatCompletionMetrics {
 	return &chatCompletion{
-		baseMetrics: newBaseMetrics(meter, genaiOperationChat, requestHeaderLabelMapping),
+		baseMetrics: newBaseMetrics(meter, genaiOperationChat, requestHeaderLabelMapping, true),
 	}
 }
 

--- a/internal/metrics/embeddings_metrics.go
+++ b/internal/metrics/embeddings_metrics.go
@@ -38,7 +38,7 @@ type EmbeddingsMetrics interface {
 // NewEmbeddings creates a new Embeddings instance.
 func NewEmbeddings(meter metric.Meter, requestHeaderLabelMapping map[string]string) EmbeddingsMetrics {
 	return &embeddings{
-		baseMetrics: newBaseMetrics(meter, genaiOperationEmbedding, requestHeaderLabelMapping),
+		baseMetrics: newBaseMetrics(meter, genaiOperationEmbedding, requestHeaderLabelMapping, false),
 	}
 }
 


### PR DESCRIPTION
**Description**

It does not make sense to include `firstTokenLatency` and `outputTokenLatency` metrics for embedding models. Actually, embedding models are not generative models, thus need to separate them.
