### PR TITLE
feat(metrics): fix console metrics and make aigw examples use official images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,34 @@
 # the root of the repo.
 
 # Variant to use as the base image. By default 'static' is used, but the 'aigw' image
-# needs to use 'base-nossl' because it needs 'glibc' to use func-e to pull the Envoy binaries.
-ARG VARIANT
+# needs to use 'base-nossl' because it needs 'glibc' for running Envoy.
+ARG VARIANT=static
+ARG COMMAND_NAME
+
+# Pre-download Envoy for aigw using func-e. This reduces latency and avoids
+# needing to declare a volume for the Envoy binary, which is tricky in Docker
+# Compose v2 because volumes end up owned by root.
+FROM golang:1.25 AS envoy-downloader
+ARG TARGETOS
+ARG TARGETARCH
+ARG COMMAND_NAME
+# Hard-coded directory for envoy-gateway resources
+# See https://github.com/envoyproxy/gateway/blob/d95ce4ce564cfff47ed1fd6c97e29c1058aa4a61/internal/infrastructure/host/proxy_infra.go#L16
+WORKDIR /tmp/envoy-gateway
+RUN if [ "$COMMAND_NAME" = "aigw" ]; then \
+      go install github.com/tetratelabs/func-e/cmd/func-e@latest && \
+      func-e --platform ${TARGETOS}/${TARGETARCH} --home-dir . run --version; \
+    fi \
+    && mkdir -p certs \
+    && chown -R 65532:65532 . \
+    && chmod -R 755 .
 
 FROM gcr.io/distroless/${VARIANT}-debian12:nonroot
 ARG COMMAND_NAME
 ARG TARGETOS
 ARG TARGETARCH
 
+COPY --from=envoy-downloader /tmp/envoy-gateway /tmp/envoy-gateway
 COPY ./out/${COMMAND_NAME}-${TARGETOS}-${TARGETARCH} /app
 
 USER nonroot:nonroot

--- a/cmd/aigw/.env.otel.console
+++ b/cmd/aigw/.env.otel.console
@@ -3,6 +3,8 @@ OTEL_TRACES_EXPORTER=console
 OTEL_METRICS_EXPORTER=console
 # Console traces are synchronous, but metrics are periodic, so shorten it.
 OTEL_METRIC_EXPORT_INTERVAL=100
+# Only export when there are changes (delta) to reduce noise
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
 
 # Below are default values for span redaction in OpenInference.
 # See https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md

--- a/cmd/aigw/README.md
+++ b/cmd/aigw/README.md
@@ -28,24 +28,24 @@
    The `chat-completion` service uses `curl` to send a simple chat completion
    request to the AI Gateway CLI (aigw) which routes it to Ollama.
    ```bash
-   docker compose run --rm chat-completion
+   docker compose run --rm --no-deps chat-completion
    ```
 
 4. **Shutdown the example stack**:
 
    `down` stops the containers and removes the volumes used by the stack.
    ```bash
-   docker compose down -v --remove-orphans
+   docker compose down --remove-orphans
    ```
 
 ## Quick Start with OpenTelemetry
 
 [docker-compose-otel.yaml](docker-compose-otel.yaml) includes OpenTelemetry
-support for observability of the AI Gateway and client applications.
+metrics and tracing.
 
-- **aigw** (port 1975): Envoy AI Gateway CLI (standalone mode) with OTEL support
+All profiles below use at least these two Docker services:
+- **aigw** (port 1975): Envoy AI Gateway CLI (standalone mode) with OTEL tracing
 - **chat-completion**: OpenAI Python client instrumented with OpenTelemetry
-- **Phoenix** (port 6006): Optional OpenTelemetry trace viewer for LLM observability
 
 ### Prerequisites
 
@@ -104,7 +104,7 @@ This configures the OTLP endpoint to otel-tui on port 4318.
 
 1. **Start the services**:
    ```bash
-   COMPOSE_PROFILES=<profile> docker compose -f docker-compose-otel.yaml up --wait -d
+   COMPOSE_PROFILES=<profile> docker compose -f docker-compose-otel.yaml up --build --wait -d
    ```
 
    Where `<profile>` is:
@@ -114,7 +114,7 @@ This configures the OTLP endpoint to otel-tui on port 4318.
 
 2. **Send a test request**:
    ```bash
-   COMPOSE_PROFILES=<profile> docker compose -f docker-compose-otel.yaml run --build --rm chat-completion
+   COMPOSE_PROFILES=<profile> docker compose -f docker-compose-otel.yaml run --build --rm --no-deps chat-completion
    ```
 
 3. **Check telemetry output**:
@@ -130,6 +130,12 @@ This configures the OTLP endpoint to otel-tui on port 4318.
 
    <details>
    <summary>For Phoenix export</summary>
+
+   If you configured Phoenix as your OTLP endpoint, you can view detailed traces
+   showing the OpenAI CLI (Python) joining a trace with the Envoy AI Gateway CLI
+   (aigw), including LLM inputs and outputs served by Ollama:
+
+   ![Phoenix Screenshot](phoenix.webp)
 
    ```bash
    # Verify Phoenix is receiving traces
@@ -156,20 +162,12 @@ This configures the OTLP endpoint to otel-tui on port 4318.
    docker compose -f docker-compose-otel.yaml logs aigw | grep "genai_model_name"
    ```
 
-### Phoenix UI (when using Phoenix export)
-
-If you configured Phoenix as your OTLP endpoint, you can view detailed traces
-showing the OpenAI CLI (Python) joining a trace with the Envoy AI Gateway CLI
-(aigw), including LLM inputs and outputs served by Ollama:
-
-![Phoenix Screenshot](phoenix.webp)
-
 ### Shutdown
 
 **Stop the services**:
 
 ```bash
-docker compose -f docker-compose-otel.yaml down -v --remove-orphans
+docker compose -f docker-compose-otel.yaml down --remove-orphans
 ```
 
 ---

--- a/cmd/aigw/ai-gateway-default-resources.yaml
+++ b/cmd/aigw/ai-gateway-default-resources.yaml
@@ -105,7 +105,6 @@ spec:
               genai_model_name: "%REQ(X-AI-EG-MODEL)%"
               genai_model_name_override: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
               genai_backend_name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
-              genai_tokens_total: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
               genai_tokens_input: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               genai_tokens_output: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               # Default fields
@@ -150,8 +149,6 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
-    - metadataKey: llm_total_token
-      type: TotalToken
   rules:
     # Special rule to unconditionally route to the Tetrate Agent Router Service (TARS) backend regardless of the model.
     - matches:

--- a/cmd/aigw/ai-gateway-local.yaml
+++ b/cmd/aigw/ai-gateway-local.yaml
@@ -56,7 +56,6 @@ spec:
               genai_model_name: "%REQ(X-AI-EG-MODEL)%"
               genai_model_name_override: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
               genai_backend_name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
-              genai_tokens_total: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
               genai_tokens_input: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               genai_tokens_output: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               # A few default fields
@@ -105,8 +104,6 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
-    - metadataKey: llm_total_token
-      type: TotalToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend
@@ -139,6 +136,7 @@ spec:
 # By default, Envoy Gateway sets the buffer limit to 32kiB which is not
 # sufficient for AI workloads. This ClientTrafficPolicy sets the buffer limit
 # to 50MiB as an example.
+# TODO: Remove after https://github.com/envoyproxy/ai-gateway/issues/1212
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:

--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -3,10 +3,6 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-volumes:
-  aigw-target:  # Stores the binary between aigw-build and aigw
-  envoy-cache:  # Stores downloaded Envoy versions
-
 services:
   # otel-tui is a terminal UI for viewing OpenTelemetry traces and metrics
   otel-tui:
@@ -30,16 +26,6 @@ services:
     environment:
       PHOENIX_ENABLE_AUTH: "false"
 
-  # aigw-build builds the Envoy AI Gateway CLI binary, so you can use main code.
-  aigw-build:
-    image: golang:1.25
-    container_name: aigw-build
-    working_dir: /workspace
-    volumes:
-      - ../..:/workspace
-      - aigw-target:/workspace/out
-    command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
-
   # ollama-pull pulls the models defined in .env.ollama, to avoid 404s.
   ollama-pull:
     image: alpine/ollama
@@ -54,12 +40,19 @@ services:
       - "localhost:host-gateway"
 
   # aigw is the Envoy AI Gateway CLI a.k.a standalone mode.
+  # Uses the official image by default, or builds from source with --build flag.
   aigw:
-    image: debian:trixie-slim
+    image: envoyproxy/ai-gateway-cli:latest
+    # Note: Run `make build.aigw GOOS_LIST=linux` from the project root prior
+    # to `docker compose -f docker-compose-otel.yaml up --build --wait -d` here.
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        VARIANT: base-nossl
+        COMMAND_NAME: aigw
     container_name: aigw
     depends_on:
-      aigw-build:
-        condition: service_completed_successfully
       ollama-pull:
         condition: service_completed_successfully
     env_file:
@@ -72,11 +65,8 @@ services:
     extra_hosts:  # localhost:host-gateway trick doesn't work with aigw
       - "host.docker.internal:host-gateway"
     volumes:
-      - aigw-target:/app
       - ./ai-gateway-local.yaml:/config.yaml:ro
-      - envoy-cache:/tmp/envoy-gateway
-    working_dir: /app
-    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /config.yaml"]
+    command: ["run", "/config.yaml"]
 
   # chat-completion is the standard OpenAI client (`openai` in pip), instrumented
   # with the following OpenTelemetry instrumentation libraries:

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -4,21 +4,7 @@
 # the root of the repo.
 
 
-volumes:
-  aigw-target:  # Stores the binary between aigw-build and aigw
-  envoy-cache:  # Stores downloaded Envoy versions
-
 services:
-  # aigw-build builds the Envoy AI Gateway CLI binary, so you can use main code.
-  aigw-build:
-    image: golang:1.25
-    container_name: aigw-build
-    working_dir: /workspace
-    volumes:
-      - ../..:/workspace
-      - aigw-target:/workspace/out
-    command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
-
   # ollama-pull pulls the models defined in .env.ollama, to avoid 404s.
   ollama-pull:
     image: alpine/ollama
@@ -34,11 +20,17 @@ services:
 
   # aigw is the Envoy AI Gateway CLI a.k.a standalone mode.
   aigw:
-    image: debian:trixie-slim
+    image: envoyproxy/ai-gateway-cli:latest
+    # Note: Run `make build.aigw GOOS_LIST=linux` from the project root prior
+    # to `docker compose up --build --wait -d` here.
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        VARIANT: base-nossl
+        COMMAND_NAME: aigw
     container_name: aigw
     depends_on:
-      aigw-build:
-        condition: service_completed_successfully
       ollama-pull:
         condition: service_completed_successfully
     environment:
@@ -49,11 +41,8 @@ services:
     extra_hosts:  # localhost:host-gateway trick doesn't work with aigw
       - "host.docker.internal:host-gateway"
     volumes:
-      - aigw-target:/app
       - ./ai-gateway-local.yaml:/config.yaml:ro
-      - envoy-cache:/tmp/envoy-gateway
-    working_dir: /app
-    command: ["sh", "-c", "apt-get update && apt-get install -y ca-certificates && ./aigw run /config.yaml"]
+    command: ["run", "/config.yaml"]
 
   # chat-completion is a simple curl-based test client for sending requests to aigw.
   chat-completion:

--- a/internal/metrics/nonempty_exporter.go
+++ b/internal/metrics/nonempty_exporter.go
@@ -1,0 +1,117 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// nonEmptyExporter wraps a stdout metric exporter to suppress empty metrics exports.
+type nonEmptyExporter struct {
+	delegate metric.Exporter
+}
+
+// temporalityExporter wraps nonEmptyExporter to support configurable temporality.
+type temporalityExporter struct {
+	nonEmptyExporter
+	temporality metricdata.Temporality
+}
+
+// newNonEmptyConsoleExporter creates a console exporter that only exports when there are metrics
+// and respects the OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE environment variable.
+// Supported values are "cumulative" (default) and "delta".
+func newNonEmptyConsoleExporter(writer io.Writer) (metric.Exporter, error) {
+	delegate, err := stdoutmetric.New(
+		stdoutmetric.WithWriter(writer),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse temporality preference from environment
+	temporality, err := parseTemporalityPreference()
+	if err != nil {
+		return nil, err
+	}
+
+	return &temporalityExporter{
+		nonEmptyExporter: nonEmptyExporter{delegate: delegate},
+		temporality:      temporality,
+	}, nil
+}
+
+// parseTemporalityPreference reads OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+// and returns the corresponding temporality. Defaults to cumulative.
+func parseTemporalityPreference() (metricdata.Temporality, error) {
+	pref := strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"))
+
+	switch pref {
+	case "", "cumulative":
+		return metricdata.CumulativeTemporality, nil
+	case "delta":
+		return metricdata.DeltaTemporality, nil
+	default:
+		return metricdata.CumulativeTemporality, fmt.Errorf("unsupported OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE value: %q (supported values: cumulative, delta)", pref)
+	}
+}
+
+// newNonEmptyExporter creates a new exporter that only exports when there are metrics.
+// This is kept for backward compatibility and testing.
+func newNonEmptyExporter(writer io.Writer) (metric.Exporter, error) {
+	delegate, err := stdoutmetric.New(
+		stdoutmetric.WithWriter(writer),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &nonEmptyExporter{delegate: delegate}, nil
+}
+
+// Export only delegates to the underlying exporter if there are actual metrics to export.
+func (e *nonEmptyExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	if rm == nil {
+		return nil
+	}
+	for _, sm := range rm.ScopeMetrics {
+		if len(sm.Metrics) > 0 {
+			return e.delegate.Export(ctx, rm)
+		}
+	}
+	return nil
+}
+
+// Temporality returns the temporality of the underlying exporter.
+func (e *nonEmptyExporter) Temporality(kind metric.InstrumentKind) metricdata.Temporality {
+	return e.delegate.Temporality(kind)
+}
+
+// Aggregation returns the aggregation of the underlying exporter.
+func (e *nonEmptyExporter) Aggregation(kind metric.InstrumentKind) metric.Aggregation {
+	return e.delegate.Aggregation(kind)
+}
+
+// Shutdown shuts down the underlying exporter.
+func (e *nonEmptyExporter) Shutdown(ctx context.Context) error {
+	return e.delegate.Shutdown(ctx)
+}
+
+// ForceFlush flushes the underlying exporter.
+func (e *nonEmptyExporter) ForceFlush(ctx context.Context) error {
+	return e.delegate.ForceFlush(ctx)
+}
+
+// Temporality returns the configured temporality for all instrument kinds.
+func (e *temporalityExporter) Temporality(metric.InstrumentKind) metricdata.Temporality {
+	return e.temporality
+}

--- a/internal/metrics/nonempty_exporter_test.go
+++ b/internal/metrics/nonempty_exporter_test.go
@@ -1,0 +1,252 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestNewNonEmptyConsoleExporter(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		expectedTemp metricdata.Temporality
+		expectError  bool
+	}{
+		{
+			name:         "defaults to cumulative",
+			envValue:     "",
+			expectedTemp: metricdata.CumulativeTemporality,
+			expectError:  false,
+		},
+		{
+			name:         "explicit cumulative",
+			envValue:     "cumulative",
+			expectedTemp: metricdata.CumulativeTemporality,
+			expectError:  false,
+		},
+		{
+			name:         "explicit delta",
+			envValue:     "delta",
+			expectedTemp: metricdata.DeltaTemporality,
+			expectError:  false,
+		},
+		{
+			name:         "unsupported value",
+			envValue:     "unsupported",
+			expectedTemp: metricdata.CumulativeTemporality,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", tt.envValue)
+
+			var buf bytes.Buffer
+			exp, err := newNonEmptyConsoleExporter(&buf)
+			if tt.expectError {
+				require.ErrorContains(t, err, "unsupported")
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expectedTemp, exp.Temporality(sdkmetric.InstrumentKindCounter))
+			require.NoError(t, exp.Shutdown(t.Context()))
+		})
+	}
+}
+
+func TestParseTemporalityPreference(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		expected    metricdata.Temporality
+		expectError bool
+	}{
+		{
+			name:        "empty defaults to cumulative",
+			envValue:    "",
+			expected:    metricdata.CumulativeTemporality,
+			expectError: false,
+		},
+		{
+			name:        "explicit cumulative",
+			envValue:    "cumulative",
+			expected:    metricdata.CumulativeTemporality,
+			expectError: false,
+		},
+		{
+			name:        "explicit delta",
+			envValue:    "delta",
+			expected:    metricdata.DeltaTemporality,
+			expectError: false,
+		},
+		{
+			name:        "unsupported value",
+			envValue:    "unsupported",
+			expected:    metricdata.CumulativeTemporality,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", tt.envValue)
+
+			temporality, err := parseTemporalityPreference()
+			if tt.expectError {
+				require.ErrorContains(t, err, "unsupported")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, temporality)
+		})
+	}
+}
+
+func TestNonEmptyExporter_Export(t *testing.T) {
+	tests := []struct {
+		name            string
+		resourceMetrics *metricdata.ResourceMetrics
+		expectOutput    bool
+	}{
+		{
+			name:            "nil resource metrics",
+			resourceMetrics: nil,
+			expectOutput:    false,
+		},
+		{
+			name: "empty scope metrics",
+			resourceMetrics: &metricdata.ResourceMetrics{
+				Resource:     resource.Default(),
+				ScopeMetrics: []metricdata.ScopeMetrics{},
+			},
+			expectOutput: false,
+		},
+		{
+			name: "scope with no metrics",
+			resourceMetrics: &metricdata.ResourceMetrics{
+				Resource: resource.Default(),
+				ScopeMetrics: []metricdata.ScopeMetrics{
+					{
+						Scope:   instrumentation.Scope{Name: "test-scope"},
+						Metrics: []metricdata.Metrics{},
+					},
+				},
+			},
+			expectOutput: false,
+		},
+		{
+			name: "scope with metrics",
+			resourceMetrics: &metricdata.ResourceMetrics{
+				Resource: resource.Default(),
+				ScopeMetrics: []metricdata.ScopeMetrics{
+					{
+						Scope: instrumentation.Scope{Name: "test-scope"},
+						Metrics: []metricdata.Metrics{
+							{
+								Name: "test.counter",
+								Data: metricdata.Sum[int64]{
+									DataPoints: []metricdata.DataPoint[int64]{
+										{
+											Attributes: attribute.NewSet(),
+											Value:      42,
+										},
+									},
+									Temporality: metricdata.CumulativeTemporality,
+									IsMonotonic: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectOutput: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			exp, err := newNonEmptyExporter(&buf)
+			require.NoError(t, err)
+
+			err = exp.Export(t.Context(), tt.resourceMetrics)
+			require.NoError(t, err)
+
+			output := strings.TrimSpace(buf.String())
+			if tt.expectOutput {
+				require.NotEmpty(t, output)
+			} else {
+				require.Empty(t, output)
+			}
+		})
+	}
+}
+
+func TestNonEmptyExporter_TemporalityAndAggregation(t *testing.T) {
+	var buf bytes.Buffer
+	exp, err := newNonEmptyExporter(&buf)
+	require.NoError(t, err)
+
+	// Check one representative kind
+	kind := sdkmetric.InstrumentKindCounter
+	require.Equal(t, metricdata.CumulativeTemporality, exp.Temporality(kind))
+	require.NotNil(t, exp.Aggregation(kind))
+}
+
+func TestNonEmptyExporter_ShutdownAndForceFlush(t *testing.T) {
+	var buf bytes.Buffer
+	exp, err := newNonEmptyExporter(&buf)
+	require.NoError(t, err)
+
+	require.NoError(t, exp.ForceFlush(t.Context()))
+	require.NoError(t, exp.Shutdown(t.Context()))
+}
+
+func TestNonEmptyExporter_Integration(t *testing.T) {
+	var buf bytes.Buffer
+	exp, err := newNonEmptyExporter(&buf)
+	require.NoError(t, err)
+
+	reader := sdkmetric.NewPeriodicReader(exp)
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(resource.NewSchemaless(
+			attribute.String("service.name", "test-service"),
+		)),
+	)
+	defer func() {
+		_ = mp.Shutdown(context.Background())
+	}()
+
+	meter := mp.Meter("test-meter")
+
+	// No metrics recorded
+	buf.Reset()
+	require.NoError(t, mp.ForceFlush(t.Context()))
+	require.Empty(t, strings.TrimSpace(buf.String()))
+
+	// Metrics recorded
+	counter, err := meter.Int64Counter("test.counter")
+	require.NoError(t, err)
+	counter.Add(t.Context(), 1)
+
+	buf.Reset()
+	require.NoError(t, mp.ForceFlush(t.Context()))
+	require.NotEmpty(t, strings.TrimSpace(buf.String()))
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -13,10 +13,10 @@ import (
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/contrib/propagators/autoprop"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
@@ -87,8 +87,9 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer) (tracing.Tracing, 
 	}
 
 	// Only set our default if service.name wasn't set via env
+	// We hardcode "service.name" to avoid pinning semconv version.
 	fallbackRes := resource.NewSchemaless(
-		semconv.ServiceName("ai-gateway"),
+		attribute.String("service.name", "ai-gateway"),
 	)
 
 	// Merge in order: default -> fallback -> env (env takes precedence).

--- a/site/docs/cli/installation.md
+++ b/site/docs/cli/installation.md
@@ -23,9 +23,9 @@ The following example runs the AI Gateway with the default configuration for the
 
 ```shell
 $ docker run --rm -p 1975:1975 -e OPENAI_API_KEY=OPENAI_API_KEY envoyproxy/ai-gateway-cli run
-looking up the latest Envoy version
-downloading https://archive.tetratelabs.io/envoy/download/v1.35.0/envoy-v1.35.0-linux-arm64.tar.xz
-starting: /tmp/envoy-gateway/versions/1.35.0/bin/envoy in run directory /tmp/envoy-gateway/runs/1756912322973222887
+looking up the latest patch for Envoy version 1.35
+1.35.3 is already downloaded
+starting: /tmp/envoy-gateway/versions/1.35.3/bin/envoy in run directory /tmp/envoy-gateway/runs/1758086300246501521
 ```
 
 ## Building the latest version


### PR DESCRIPTION
**Description**

This combines a fix of console metrics with a drift fix of our docker setup.

Notably, this sorts out console metrics which formerly ignored temporality and
also emitted updates to the console regardless of if there were any data points.
This is a problem upstream as the console reporter isn't very sophisticated. The
behavior desired was easy enough, so I sorted it out here.

Next, our docker examples weren't using our docker images, yet. So, this uses
them and is careful about `--build` so that people know if they do that, how to
make sure the image is indeed fresh.

Together, these changes make the console example quite reasonable as a debugging tool.

```bash
$ docker logs aigw -f
looking up the latest patch for Envoy version 1.35
1.35.3 is already downloaded
starting: /tmp/envoy-gateway/versions/1.35.3/bin/envoy in run directory /tmp/envoy-gateway/runs/1758094103988916388
{"Name":"ChatCompletion","SpanContext":{"TraceID":"5450d3297f9ee876e03ce0ebcc78c73b","SpanID":"4be4d3f88ada3a95","TraceFlags":"01","TraceState":"","Remote":false},"Parent":{"TraceID":"5450d3297f9ee876e03ce0ebcc78c73b","SpanID":"ffa9cea44613f704","TraceFlags":"01","TraceState":"","Remote":true},"SpanKind":1,"StartTime":"2025-09-17T07:28:41.390574615Z","EndTime":"2025-09-17T07:28:41.497301121Z","Attributes":[{"Key":"openinference.span.kind","Value":{"Type":"STRING","Value":"LLM"}},{"Key":"llm.system","Value":{"Type":"STRING","Value":"openai"}},{"Key":"llm.model_name","Value":{"Type":"STRING","Value":"qwen2.5:0.5b"}},{"Key":"input.value","Value":{"Type":"STRING","Value":"{\"messages\":[{\"role\":\"user\",\"content\":\"Answer in up to 3 words: Which ocean contains Bouvet Island?\"}],\"model\":\"qwen2.5:0.5b\",\"stream\":false,\"temperature\":0.0}"}},{"Key":"input.mime_type","Value":{"Type":"STRING","Value":"application/json"}},{"Key":"llm.invocation_parameters","Value":{"Type":"STRING","Value":"{\"model\":\"qwen2.5:0.5b\",\"temperature\":0}"}},{"Key":"llm.input_messages.0.message.role","Value":{"Type":"STRING","Value":"user"}},{"Key":"llm.input_messages.0.message.content","Value":{"Type":"STRING","Value":"Answer in up to 3 words: Which ocean contains Bouvet Island?"}},{"Key":"output.mime_type","Value":{"Type":"STRING","Value":"application/json"}},{"Key":"llm.output_messages.0.message.role","Value":{"Type":"STRING","Value":"assistant"}},{"Key":"llm.output_messages.0.message.content","Value":{"Type":"STRING","Value":"Bouvet Island is located in the Atlantic Ocean."}},{"Key":"llm.token_count.prompt","Value":{"Type":"INT64","Value":44}},{"Key":"llm.token_count.completion","Value":{"Type":"INT64","Value":12}},{"Key":"llm.token_count.total","Value":{"Type":"INT64","Value":56}},{"Key":"output.value","Value":{"Type":"STRING","Value":"{\"id\":\"chatcmpl-794\",\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"content\":\"Bouvet Island is located in the Atlantic Ocean.\",\"role\":\"assistant\"}}],\"created\":1758094121,\"model\":\"qwen2.5:0.5b\",\"system_fingerprint\":\"fp_ollama\",\"object\":\"chat.completion\",\"usage\":{\"completion_tokens\":12,\"prompt_tokens\":44,\"total_tokens\":56}}"}}],"Events":null,"Links":null,"Status":{"Code":"Ok","Description":""},"DroppedAttributes":0,"DroppedEvents":0,"DroppedLinks":0,"ChildSpanCount":0,"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"ai-gateway"}},{"Key":"telemetry.sdk.language","Value":{"Type":"STRING","Value":"go"}},{"Key":"telemetry.sdk.name","Value":{"Type":"STRING","Value":"opentelemetry"}},{"Key":"telemetry.sdk.version","Value":{"Type":"STRING","Value":"1.37.0"}}],"InstrumentationScope":{"Name":"envoyproxy/ai-gateway","Version":"","SchemaURL":"","Attributes":null},"InstrumentationLibrary":{"Name":"envoyproxy/ai-gateway","Version":"","SchemaURL":"","Attributes":null}}
{"bytes_received":159,"bytes_sent":334,"connection_termination_details":null,"downstream_local_address":"172.18.0.2:1975","downstream_remote_address":"172.18.0.3:35022","duration":108,"genai_backend_name":"default/ollama/route/aigw-run/rule/0/ref/0","genai_model_name":"qwen2.5:0.5b","genai_model_name_override":null,"genai_tokens_input":44,"genai_tokens_output":12,"method":"POST","response_code":200,"start_time":"2025-09-17T07:28:41.389Z","upstream_cluster":"httproute/default/aigw-run/rule/0","upstream_host":"192.168.5.2:11434","upstream_local_address":"172.18.0.2:38370","upstream_transport_failure_reason":null,"user-agent":"_ModuleClient/Python 1.107.3","x-envoy-origin-path":"/v1/chat/completions","x-request-id":"4ded087c-c899-4e42-a50d-39a4ef70e863"}
{"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"ai-gateway"}},{"Key":"telemetry.sdk.language","Value":{"Type":"STRING","Value":"go"}},{"Key":"telemetry.sdk.name","Value":{"Type":"STRING","Value":"opentelemetry"}},{"Key":"telemetry.sdk.version","Value":{"Type":"STRING","Value":"1.37.0"}}],"ScopeMetrics":[{"Scope":{"Name":"envoyproxy/ai-gateway","Version":"","SchemaURL":"","Attributes":null},"Metrics":[{"Name":"gen_ai.client.token.usage","Description":"Number of tokens processed.","Unit":"token","Data":{"DataPoints":[{"Attributes":[{"Key":"gen_ai.operation.name","Value":{"Type":"STRING","Value":"chat"}},{"Key":"gen_ai.provider.name","Value":{"Type":"STRING","Value":"openai"}},{"Key":"gen_ai.request.model","Value":{"Type":"STRING","Value":"qwen2.5:0.5b"}},{"Key":"gen_ai.token.type","Value":{"Type":"STRING","Value":"input"}}],"StartTime":"2025-09-17T07:28:41.496749062Z","Time":"2025-09-17T07:28:41.595879539Z","Count":1,"Bounds":[1,4,16,64,256,1024,4096,16384,65536,262144,1048576,4194304,16777216,67108864],"BucketCounts":[0,0,0,1,0,0,0,0,0,0,0,0,0,0,0],"Min":44,"Max":44,"Sum":44},{"Attributes":[{"Key":"gen_ai.operation.name","Value":{"Type":"STRING","Value":"chat"}},{"Key":"gen_ai.provider.name","Value":{"Type":"STRING","Value":"openai"}},{"Key":"gen_ai.request.model","Value":{"Type":"STRING","Value":"qwen2.5:0.5b"}},{"Key":"gen_ai.token.type","Value":{"Type":"STRING","Value":"output"}}],"StartTime":"2025-09-17T07:28:41.496749062Z","Time":"2025-09-17T07:28:41.595879539Z","Count":1,"Bounds":[1,4,16,64,256,1024,4096,16384,65536,262144,1048576,4194304,16777216,67108864],"BucketCounts":[0,0,1,0,0,0,0,0,0,0,0,0,0,0,0],"Min":12,"Max":12,"Sum":12}],"Temporality":"DeltaTemporality"}},{"Name":"gen_ai.server.request.duration","Description":"Generative AI server request duration such as time-to-last byte or last output token.","Unit":"s","Data":{"DataPoints":[{"Attributes":[{"Key":"gen_ai.operation.name","Value":{"Type":"STRING","Value":"chat"}},{"Key":"gen_ai.provider.name","Value":{"Type":"STRING","Value":"openai"}},{"Key":"gen_ai.request.model","Value":{"Type":"STRING","Value":"qwen2.5:0.5b"}}],"StartTime":"2025-09-17T07:28:41.496750521Z","Time":"2025-09-17T07:28:41.59591604Z","Count":1,"Bounds":[0.01,0.02,0.04,0.08,0.16,0.32,0.64,1.28,2.56,5.12,10.24,20.48,40.96,81.92],"BucketCounts":[0,0,0,0,1,0,0,0,0,0,0,0,0,0,0],"Min":0.106552042,"Max":0.106552042,"Sum":0.106552042}],"Temporality":"DeltaTemporality"}}]}]}
```