### PR TITLE
fix: add the MaxRecvMsgSize for grpc.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,6 +45,8 @@ type flags struct {
 	metricsRequestHeaderLabels string
 	rootPrefix                 string
 	extProcExtraEnvVars        string
+	// extProcMaxRecvMsgSize is the maximum message size in bytes that the gRPC server can receive.
+	extProcMaxRecvMsgSize int
 }
 
 // parsePullPolicy parses string into a k8s PullPolicy.
@@ -127,6 +129,11 @@ func parseAndValidateFlags(args []string) (flags, error) {
 		"",
 		"Semicolon-separated key=value pairs for extra environment variables in extProc container. Format: OTEL_SERVICE_NAME=ai-gateway;OTEL_TRACES_EXPORTER=otlp",
 	)
+	extProcMaxRecvMsgSize := fs.Int(
+		"extProcMaxRecvMsgSize",
+		512*1024*1024,
+		"Maximum message size in bytes that the gRPC server can receive for extProc. Default is 512MB.",
+	)
 
 	if err := fs.Parse(args); err != nil {
 		err = fmt.Errorf("failed to parse flags: %w", err)
@@ -180,6 +187,7 @@ func parseAndValidateFlags(args []string) (flags, error) {
 		metricsRequestHeaderLabels: *metricsRequestHeaderLabels,
 		rootPrefix:                 *rootPrefix,
 		extProcExtraEnvVars:        *extProcExtraEnvVars,
+		extProcMaxRecvMsgSize:      *extProcMaxRecvMsgSize,
 	}, nil
 }
 
@@ -255,6 +263,7 @@ func main() {
 		MetricsRequestHeaderLabels: flags.metricsRequestHeaderLabels,
 		RootPrefix:                 flags.rootPrefix,
 		ExtProcExtraEnvVars:        flags.extProcExtraEnvVars,
+		ExtProcMaxRecvMsgSize:      flags.extProcMaxRecvMsgSize,
 	}); err != nil {
 		setupLog.Error(err, "failed to start controller")
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -75,6 +75,8 @@ type Options struct {
 	RootPrefix string
 	// ExtProcExtraEnvVars is the semicolon-separated key=value pairs for extra environment variables in extProc container.
 	ExtProcExtraEnvVars string
+	// ExtProcMaxRecvMsgSize is the maximum message size in bytes that the gRPC server can receive for extProc.
+	ExtProcMaxRecvMsgSize int
 }
 
 // StartControllers starts the controllers for the AI Gateway.
@@ -185,6 +187,7 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 			options.MetricsRequestHeaderLabels,
 			options.RootPrefix,
 			options.ExtProcExtraEnvVars,
+			options.ExtProcMaxRecvMsgSize,
 		))
 		mgr.GetWebhookServer().Register("/mutate", &webhook.Admission{Handler: h})
 	}

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -39,11 +39,12 @@ type gatewayMutator struct {
 	metricsRequestHeaderLabels string
 	rootPrefix                 string
 	extProcExtraEnvVars        []corev1.EnvVar
+	extProcMaxRecvMsgSize      int
 }
 
 func newGatewayMutator(c client.Client, kube kubernetes.Interface, logger logr.Logger,
 	extProcImage string, extProcImagePullPolicy corev1.PullPolicy, extProcLogLevel,
-	udsPath, metricsRequestHeaderLabels, rootPrefix, extProcExtraEnvVars string,
+	udsPath, metricsRequestHeaderLabels, rootPrefix, extProcExtraEnvVars string, extProcMaxRecvMsgSize int,
 ) *gatewayMutator {
 	var parsedEnvVars []corev1.EnvVar
 	if extProcExtraEnvVars != "" {
@@ -65,6 +66,7 @@ func newGatewayMutator(c client.Client, kube kubernetes.Interface, logger logr.L
 		metricsRequestHeaderLabels: metricsRequestHeaderLabels,
 		rootPrefix:                 rootPrefix,
 		extProcExtraEnvVars:        parsedEnvVars,
+		extProcMaxRecvMsgSize:      extProcMaxRecvMsgSize,
 	}
 }
 
@@ -96,6 +98,7 @@ func (g *gatewayMutator) buildExtProcArgs(filterConfigFullPath string, extProcMe
 		"-metricsPort", fmt.Sprintf("%d", extProcMetricsPort),
 		"-healthPort", fmt.Sprintf("%d", extProcHealthPort),
 		"-rootPrefix", g.rootPrefix,
+		"-maxRecvMsgSize", fmt.Sprintf("%d", g.extProcMaxRecvMsgSize),
 	}
 
 	// Add metrics header label mapping if configured.

--- a/internal/controller/gateway_mutator_test.go
+++ b/internal/controller/gateway_mutator_test.go
@@ -148,7 +148,7 @@ func newTestGatewayMutator(fakeClient client.Client, fakeKube *fake2.Clientset, 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
 	return newGatewayMutator(
 		fakeClient, fakeKube, ctrl.Log, "docker.io/envoyproxy/ai-gateway-extproc:latest", corev1.PullIfNotPresent,
-		"info", "/tmp/extproc.sock", metricsRequestHeaderLabels, "/v1", extProcExtraEnvVars,
+		"info", "/tmp/extproc.sock", metricsRequestHeaderLabels, "/v1", extProcExtraEnvVars, 512*1024*1024,
 	)
 }
 

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -54,6 +54,7 @@ func TestStartControllers(t *testing.T) {
 		EnableLeaderElection:   false,
 		DisableMutatingWebhook: true,
 		RootPrefix:             "/root-prefix",
+		ExtProcMaxRecvMsgSize:  512 * 1024 * 1024, // 512MB
 	}
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{


### PR DESCRIPTION
**Description**

This PR is fixed grpc MaxRecvMsgSize default limit.

**Related Issues/PRs (if applicable)**

Fixes #1209