### PR TITLE
Makefile build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,10 +258,10 @@ docker-build.%: ## Build a docker image for a given command.
 	$(eval IMAGE_NAME := $(if $(filter aigw,$(*)),cli,$(*)))
 	$(eval VARIANT := $(if $(filter aigw,$(*)),base-nossl,static))
 	@$(MAKE) build.$(*) GOOS_LIST="linux" GOARCH_LIST="$(GOARCH_LIST)"
-	docker buildx build . -t $(OCI_REPOSITORY_PREFIX)-$(IMAGE_NAME):$(TAG) \
+	docker buildx build -t $(OCI_REPOSITORY_PREFIX)-$(IMAGE_NAME):$(TAG) \
 		--build-arg VARIANT=$(VARIANT) \
 		--build-arg COMMAND_NAME=$(*) \
-		$(PLATFORMS) $(DOCKER_BUILD_ARGS)
+		$(PLATFORMS) $(DOCKER_BUILD_ARGS) .
 
 # This builds docker images for all commands under cmd/ directory. All options for `docker-build.%` apply.
 #


### PR DESCRIPTION
docker build context is the last argument as per doc. Current command does not work in all cli versions