### PR TITLE
ci: fix e2e metrics flake and better handle ports in aigw tests

### DIFF
--- a/cmd/aigw/README.md
+++ b/cmd/aigw/README.md
@@ -31,23 +31,22 @@ Here are values we use for Ollama:
    docker compose up --wait -d
    ```
 
-3. **Create a simple OpenAI chat completion**:
+3. **Make requests to Envoy AI Gateway**:
 
-   The `chat-completion` service uses `curl` to send a simple chat completion
-   request to the AI Gateway CLI (aigw) which routes it to Ollama.
-   ```bash
-   docker compose run --rm chat-completion
-   ```
+   The following services use `curl` to send requests to the AI Gateway CLI
+   (aigw) which routes them to Ollama:
 
-4. **Create embeddings**:
+   - Chat completion:
+     ```bash
+     docker compose run --rm chat-completion
+     ```
 
-   The `create-embeddings` service uses `curl` to send an embeddings request
-   to the AI Gateway CLI (aigw) which routes it to Ollama.
-   ```bash
-   docker compose run --rm create-embeddings
-   ```
+   - Embeddings:
+     ```bash
+     docker compose run --rm embeddings
+     ```
 
-5. **Shutdown the example stack**:
+4. **Shutdown the example stack**:
 
    `down` stops the containers and removes the volumes used by the stack.
    ```bash

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -62,10 +62,10 @@ services:
     extra_hosts:  # localhost:host-gateway trick doesn't work with aigw
       - "host.docker.internal:host-gateway"
 
-  # create-embeddings is a simple curl-based test client for sending embeddings requests to aigw.
-  create-embeddings:
+  # embeddings is a simple curl-based test client for sending embeddings requests to aigw.
+  embeddings:
     image: golang:1.25
-    container_name: create-embeddings
+    container_name: embeddings
     profiles: ["test"]
     env_file:
       - ../../.env.ollama

--- a/internal/testing/ports.go
+++ b/internal/testing/ports.go
@@ -1,0 +1,32 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package internaltesting
+
+import (
+	"context"
+	"net"
+
+	"github.com/stretchr/testify/require"
+)
+
+// RequireRandomPorts returns random available ports.
+func RequireRandomPorts(t require.TestingT, count int) []int {
+	ports := make([]int, count)
+
+	var listeners []net.Listener
+	for i := range count {
+		lc := net.ListenConfig{}
+		lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err, "failed to listen on random port %d", i)
+		listeners = append(listeners, lis)
+		addr := lis.Addr().(*net.TCPAddr)
+		ports[i] = addr.Port
+	}
+	for _, lis := range listeners {
+		require.NoError(t, lis.Close())
+	}
+	return ports
+}

--- a/tests/internal/testenvironment/test_environment.go
+++ b/tests/internal/testenvironment/test_environment.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
+	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
 )
 
 // TestEnvironment holds all the services needed for tests.
@@ -83,7 +84,7 @@ func StartTestEnvironment(t TestingT,
 	extprocBin, extprocConfig string, extprocEnv []string, envoyConfig string, okToDumpLogOnFailure, extProcInProcess bool,
 ) *TestEnvironment {
 	// Get random ports for all services.
-	ports := requireRandomPorts(t, 5)
+	ports := internaltesting.RequireRandomPorts(t, 5)
 
 	env := &TestEnvironment{
 		upstreamPortDefault: upstreamPortDefault,
@@ -187,25 +188,6 @@ func (e *TestEnvironment) checkConnection(t TestingT, port int, name string) err
 	}
 	t.Logf("Successfully connected to %s on port %d", name, port)
 	return nil
-}
-
-// requireRandomPorts returns random available ports.
-func requireRandomPorts(t require.TestingT, count int) []int {
-	ports := make([]int, count)
-
-	var listeners []net.Listener
-	for i := range count {
-		lc := net.ListenConfig{}
-		lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-		require.NoError(t, err, "failed to listen on random port %d", i)
-		listeners = append(listeners, lis)
-		addr := lis.Addr().(*net.TCPAddr)
-		ports[i] = addr.Port
-	}
-	for _, lis := range listeners {
-		require.NoError(t, lis.Close())
-	}
-	return ports
 }
 
 func waitForReadyMessage(ctx context.Context, outReader io.Reader, readyMessage string) {


### PR DESCRIPTION
**Description**

This fixes a flake in e2e where we used require.XXX assertion inside an Eventually block which failed when there were no metrics, yet, causing the loop to not proceed again. Instead, we loop on no metrics yet.

This also addresses a configuration issue where we passed 0 as the admin port causing an unknown ephemeral one to be used. This changes the test to pick one for the admin, so that later assertions can be made against it.

A later change will attempt to make all aigw tests assertable ports, but for now this fixes the admin one.