### PR TITLE
feat: update cached token usage stats from cloud providers  

### DIFF
--- a/internal/apischema/awsbedrock/awsbedrock.go
+++ b/internal/apischema/awsbedrock/awsbedrock.go
@@ -396,9 +396,11 @@ type ConverseOutput struct {
 // TokenUsage is defined in the AWS Bedrock API:
 // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_TokenUsage.html
 type TokenUsage struct {
-	InputTokens  int `json:"inputTokens"`
-	OutputTokens int `json:"outputTokens"`
-	TotalTokens  int `json:"totalTokens"`
+	InputTokens           int  `json:"inputTokens"`
+	OutputTokens          int  `json:"outputTokens"`
+	TotalTokens           int  `json:"totalTokens"`
+	CacheReadInputTokens  *int `json:"cacheReadInputTokens,omitempty"`
+	CacheWriteInputTokens *int `json:"cacheWriteInputTokens,omitempty"`
 }
 
 // ConverseStreamEvent is the union of all possible event types in the AWS Bedrock API:

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1240,10 +1240,6 @@ type ChatCompletionResponseChoiceMessageAudio struct {
 	Transcript string `json:"transcript"`
 }
 
-// ChatCompletionResponseUsage is deprecated. Use Usage instead.
-// Deprecated: Use Usage type which now includes all fields from ChatCompletionResponseUsage.
-type ChatCompletionResponseUsage = Usage
-
 // CompletionTokensDetails breakdown of tokens used in a completion.
 type CompletionTokensDetails struct {
 	// Text input tokens present in the prompt.

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -929,7 +929,7 @@ func TestChatCompletionResponse(t *testing.T) {
 						},
 					},
 				},
-				Usage: ChatCompletionResponseUsage{
+				Usage: Usage{
 					CompletionTokens: 1,
 					PromptTokens:     5,
 					TotalTokens:      6,
@@ -984,7 +984,7 @@ func TestChatCompletionResponse(t *testing.T) {
 						},
 					},
 				},
-				Usage: ChatCompletionResponseUsage{
+				Usage: Usage{
 					CompletionTokens: 192,
 					PromptTokens:     14,
 					TotalTokens:      206,
@@ -1622,12 +1622,12 @@ func TestPromptTokensDetails(t *testing.T) {
 func TestChatCompletionResponseUsage(t *testing.T) {
 	testCases := []struct {
 		name     string
-		usage    ChatCompletionResponseUsage
+		usage    Usage
 		expected string
 	}{
 		{
 			name: "with zero values omitted",
-			usage: ChatCompletionResponseUsage{
+			usage: Usage{
 				CompletionTokens: 9,
 				PromptTokens:     19,
 				TotalTokens:      28,
@@ -1646,7 +1646,7 @@ func TestChatCompletionResponseUsage(t *testing.T) {
 		},
 		{
 			name: "with non-zero values",
-			usage: ChatCompletionResponseUsage{
+			usage: Usage{
 				CompletionTokens: 11,
 				PromptTokens:     37,
 				TotalTokens:      48,
@@ -1677,7 +1677,7 @@ func TestChatCompletionResponseUsage(t *testing.T) {
 		},
 		{
 			name: "with text tokens",
-			usage: ChatCompletionResponseUsage{
+			usage: Usage{
 				CompletionTokens: 11,
 				PromptTokens:     37,
 				TotalTokens:      48,
@@ -1720,7 +1720,7 @@ func TestChatCompletionResponseUsage(t *testing.T) {
 			require.JSONEq(t, tc.expected, string(jsonData))
 
 			// Unmarshal and verify
-			var decoded ChatCompletionResponseUsage
+			var decoded Usage
 			err = json.Unmarshal(jsonData, &decoded)
 			require.NoError(t, err)
 			require.Equal(t, tc.usage, decoded)

--- a/internal/extproc/translator/anthropic_gcpanthropic.go
+++ b/internal/extproc/translator/anthropic_gcpanthropic.go
@@ -162,6 +162,7 @@ func (a *anthropicToGCPAnthropicTranslator) ResponseBody(_ map[string]string, bo
 		InputTokens:  uint32(anthropicResp.Usage.InputTokens),                                    //nolint:gosec
 		OutputTokens: uint32(anthropicResp.Usage.OutputTokens),                                   //nolint:gosec
 		TotalTokens:  uint32(anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens), //nolint:gosec
+		CachedTokens: uint32(anthropicResp.Usage.CacheReadInputTokens),                           //nolint:gosec
 	}
 
 	// Pass through the response body unchanged since both input and output are Anthropic format.

--- a/internal/extproc/translator/gemini_helper.go
+++ b/internal/extproc/translator/gemini_helper.go
@@ -568,15 +568,21 @@ func extractToolCallsFromGeminiParts(parts []*genai.Part) ([]openai.ChatCompleti
 }
 
 // geminiUsageToOpenAIUsage converts Gemini usage metadata to OpenAI usage.
-func geminiUsageToOpenAIUsage(metadata *genai.GenerateContentResponseUsageMetadata) openai.ChatCompletionResponseUsage {
+func geminiUsageToOpenAIUsage(metadata *genai.GenerateContentResponseUsageMetadata) openai.Usage {
 	if metadata == nil {
-		return openai.ChatCompletionResponseUsage{}
+		return openai.Usage{}
 	}
 
-	return openai.ChatCompletionResponseUsage{
+	return openai.Usage{
 		CompletionTokens: int(metadata.CandidatesTokenCount),
 		PromptTokens:     int(metadata.PromptTokenCount),
 		TotalTokens:      int(metadata.TotalTokenCount),
+		PromptTokensDetails: &openai.PromptTokensDetails{
+			CachedTokens: int(metadata.CachedContentTokenCount),
+		},
+		CompletionTokensDetails: &openai.CompletionTokensDetails{
+			ReasoningTokens: int(metadata.ThoughtsTokenCount),
+		},
 	}
 }
 

--- a/internal/extproc/translator/openai_awsbedrock.go
+++ b/internal/extproc/translator/openai_awsbedrock.go
@@ -605,7 +605,7 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(_ map[string
 					TotalTokens:  uint32(usage.TotalTokens),  //nolint:gosec
 				}
 				if usage.CacheReadInputTokens != nil {
-					tokenUsage.CachedTokens = uint32(*usage.CacheReadInputTokens)
+					tokenUsage.CachedTokens = uint32(*usage.CacheReadInputTokens) //nolint:gosec
 				}
 			}
 			oaiEvent, ok := o.convertEvent(event)
@@ -652,7 +652,7 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(_ map[string
 			CompletionTokens: bedrockResp.Usage.OutputTokens,
 		}
 		if bedrockResp.Usage.CacheReadInputTokens != nil {
-			tokenUsage.CachedTokens = uint32(*bedrockResp.Usage.CacheReadInputTokens)
+			tokenUsage.CachedTokens = uint32(*bedrockResp.Usage.CacheReadInputTokens) //nolint:gosec
 			openAIResp.Usage.PromptTokensDetails = &openai.PromptTokensDetails{
 				CachedTokens: *bedrockResp.Usage.CacheReadInputTokens,
 			}

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -1440,9 +1440,10 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 			name: "basic_testing",
 			input: awsbedrock.ConverseResponse{
 				Usage: &awsbedrock.TokenUsage{
-					InputTokens:  10,
-					OutputTokens: 20,
-					TotalTokens:  30,
+					InputTokens:          10,
+					OutputTokens:         20,
+					TotalTokens:          30,
+					CacheReadInputTokens: ptr.To(5),
 				},
 				Output: &awsbedrock.ConverseOutput{
 					Message: awsbedrock.Message{
@@ -1457,10 +1458,13 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 			},
 			output: openai.ChatCompletionResponse{
 				Object: "chat.completion",
-				Usage: openai.ChatCompletionResponseUsage{
+				Usage: openai.Usage{
 					TotalTokens:      30,
 					PromptTokens:     10,
 					CompletionTokens: 20,
+					PromptTokensDetails: &openai.PromptTokensDetails{
+						CachedTokens: 5,
+					},
 				},
 				Choices: []openai.ChatCompletionResponseChoice{
 					{
@@ -1494,7 +1498,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 			},
 			output: openai.ChatCompletionResponse{
 				Object: "chat.completion",
-				Usage: openai.ChatCompletionResponseUsage{
+				Usage: openai.Usage{
 					TotalTokens:      30,
 					PromptTokens:     10,
 					CompletionTokens: 20,
@@ -1582,7 +1586,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 			},
 			output: openai.ChatCompletionResponse{
 				Object: "chat.completion",
-				Usage: openai.ChatCompletionResponseUsage{
+				Usage: openai.Usage{
 					TotalTokens:      30,
 					PromptTokens:     10,
 					CompletionTokens: 20,
@@ -1678,12 +1682,15 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 			expectedBody, err := json.Marshal(tt.output)
 			require.NoError(t, err)
 			require.JSONEq(t, string(expectedBody), string(newBody))
-			require.Equal(t,
-				LLMTokenUsage{
-					InputTokens:  uint32(tt.output.Usage.PromptTokens),     //nolint:gosec
-					OutputTokens: uint32(tt.output.Usage.CompletionTokens), //nolint:gosec
-					TotalTokens:  uint32(tt.output.Usage.TotalTokens),      //nolint:gosec
-				}, usedToken)
+			expectedUsage := LLMTokenUsage{
+				InputTokens:  uint32(tt.output.Usage.PromptTokens),     //nolint:gosec
+				OutputTokens: uint32(tt.output.Usage.CompletionTokens), //nolint:gosec
+				TotalTokens:  uint32(tt.output.Usage.TotalTokens),      //nolint:gosec
+			}
+			if tt.input.Usage != nil && tt.input.Usage.CacheReadInputTokens != nil {
+				expectedUsage.CachedTokens = uint32(tt.output.Usage.PromptTokensDetails.CachedTokens)
+			}
+			require.Equal(t, expectedUsage, usedToken)
 		})
 	}
 }
@@ -1781,17 +1788,21 @@ func TestOpenAIToAWSBedrockTranslator_convertEvent(t *testing.T) {
 			name: "usage",
 			in: awsbedrock.ConverseStreamEvent{
 				Usage: &awsbedrock.TokenUsage{
-					InputTokens:  10,
-					OutputTokens: 20,
-					TotalTokens:  30,
+					InputTokens:          10,
+					OutputTokens:         20,
+					TotalTokens:          30,
+					CacheReadInputTokens: ptr.To(5),
 				},
 			},
 			out: &openai.ChatCompletionResponseChunk{
 				Object: "chat.completion.chunk",
-				Usage: &openai.ChatCompletionResponseUsage{
+				Usage: &openai.Usage{
 					TotalTokens:      30,
 					PromptTokens:     10,
 					CompletionTokens: 20,
+					PromptTokensDetails: &openai.PromptTokensDetails{
+						CachedTokens: 5,
+					},
 				},
 			},
 		},

--- a/internal/extproc/translator/openai_awsbedrock_test.go
+++ b/internal/extproc/translator/openai_awsbedrock_test.go
@@ -1688,7 +1688,7 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 				TotalTokens:  uint32(tt.output.Usage.TotalTokens),      //nolint:gosec
 			}
 			if tt.input.Usage != nil && tt.input.Usage.CacheReadInputTokens != nil {
-				expectedUsage.CachedTokens = uint32(tt.output.Usage.PromptTokensDetails.CachedTokens)
+				expectedUsage.CachedTokens = uint32(tt.output.Usage.PromptTokensDetails.CachedTokens) //nolint:gosec
 			}
 			require.Equal(t, expectedUsage, usedToken)
 		})

--- a/internal/extproc/translator/openai_completions.go
+++ b/internal/extproc/translator/openai_completions.go
@@ -182,6 +182,9 @@ func (o *openAIToOpenAITranslatorV1Completion) extractUsageFromBufferEvent() (to
 			tokenUsage.InputTokens = uint32(usage.PromptTokens)      //nolint:gosec
 			tokenUsage.OutputTokens = uint32(usage.CompletionTokens) //nolint:gosec
 			tokenUsage.TotalTokens = uint32(usage.TotalTokens)       //nolint:gosec
+			if usage.PromptTokensDetails != nil {
+				tokenUsage.CachedTokens = uint32(usage.PromptTokensDetails.CachedTokens) //nolint:gosec
+			}
 			// Do not mark buffering done; keep scanning to return the latest usage in this batch.
 		}
 	}

--- a/internal/extproc/translator/openai_gcpanthropic.go
+++ b/internal/extproc/translator/openai_gcpanthropic.go
@@ -681,11 +681,15 @@ func (o *openAIToGCPAnthropicTranslatorV1ChatCompletion) ResponseBody(_ map[stri
 		InputTokens:  uint32(anthropicResp.Usage.InputTokens),                                    //nolint:gosec
 		OutputTokens: uint32(anthropicResp.Usage.OutputTokens),                                   //nolint:gosec
 		TotalTokens:  uint32(anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens), //nolint:gosec
+		CachedTokens: uint32(anthropicResp.Usage.CacheReadInputTokens),                           //nolint:gosec
 	}
-	openAIResp.Usage = openai.ChatCompletionResponseUsage{
+	openAIResp.Usage = openai.Usage{
 		CompletionTokens: int(anthropicResp.Usage.OutputTokens),
 		PromptTokens:     int(anthropicResp.Usage.InputTokens),
 		TotalTokens:      int(anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens),
+		PromptTokensDetails: &openai.PromptTokensDetails{
+			CachedTokens: int(anthropicResp.Usage.CacheReadInputTokens),
+		},
 	}
 
 	finishReason, err := anthropicToOpenAIFinishReason(anthropicResp.StopReason)

--- a/internal/extproc/translator/openai_gcpanthropic_stream.go
+++ b/internal/extproc/translator/openai_gcpanthropic_stream.go
@@ -194,7 +194,8 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 			return nil, fmt.Errorf("unmarshal message_start: %w", err)
 		}
 		p.activeMessageID = event.Message.ID
-		p.tokenUsage.InputTokens = uint32(event.Message.Usage.InputTokens) //nolint:gosec
+		p.tokenUsage.InputTokens = uint32(event.Message.Usage.InputTokens)            //nolint:gosec
+		p.tokenUsage.CachedTokens += uint32(event.Message.Usage.CacheReadInputTokens) //nolint:gosec
 		return nil, nil
 
 	case string(constant.ValueOf[constant.ContentBlockStart]()):
@@ -254,7 +255,6 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 			return nil, fmt.Errorf("unmarshal message_delta: %w", err)
 		}
 		p.tokenUsage.OutputTokens += uint32(event.Usage.OutputTokens) //nolint:gosec
-		p.tokenUsage.CachedTokens += uint32(event.Usage.CacheReadInputTokens)
 		if event.Delta.StopReason != "" {
 			p.stopReason = event.Delta.StopReason
 		}

--- a/internal/extproc/translator/openai_gcpanthropic_stream.go
+++ b/internal/extproc/translator/openai_gcpanthropic_stream.go
@@ -112,10 +112,13 @@ func (p *anthropicStreamParser) Process(body io.Reader, endOfStream bool, span t
 		finalChunk := openai.ChatCompletionResponseChunk{
 			Object:  "chat.completion.chunk",
 			Choices: []openai.ChatCompletionResponseChunkChoice{},
-			Usage: &openai.ChatCompletionResponseUsage{
+			Usage: &openai.Usage{
 				PromptTokens:     int(p.tokenUsage.InputTokens),
 				CompletionTokens: int(p.tokenUsage.OutputTokens),
 				TotalTokens:      int(p.tokenUsage.TotalTokens),
+				PromptTokensDetails: &openai.PromptTokensDetails{
+					CachedTokens: int(p.tokenUsage.CachedTokens),
+				},
 			},
 		}
 
@@ -251,6 +254,7 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 			return nil, fmt.Errorf("unmarshal message_delta: %w", err)
 		}
 		p.tokenUsage.OutputTokens += uint32(event.Usage.OutputTokens) //nolint:gosec
+		p.tokenUsage.CachedTokens += uint32(event.Usage.CacheReadInputTokens)
 		if event.Delta.StopReason != "" {
 			p.stopReason = event.Delta.StopReason
 		}

--- a/internal/extproc/translator/openai_gcpanthropic_test.go
+++ b/internal/extproc/translator/openai_gcpanthropic_test.go
@@ -369,12 +369,19 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_ResponseBody(t *testing.
 				Role:       constant.Assistant(anthropic.MessageParamRoleAssistant),
 				Content:    []anthropic.ContentBlockUnion{{Type: "text", Text: "Hello there!"}},
 				StopReason: anthropic.StopReasonEndTurn,
-				Usage:      anthropic.Usage{InputTokens: 10, OutputTokens: 20},
+				Usage:      anthropic.Usage{InputTokens: 10, OutputTokens: 20, CacheReadInputTokens: 5},
 			},
 			respHeaders: map[string]string{statusHeaderName: "200"},
 			expectedOpenAIResponse: openai.ChatCompletionResponse{
 				Object: "chat.completion",
-				Usage:  openai.ChatCompletionResponseUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30},
+				Usage: openai.Usage{
+					PromptTokens:     10,
+					CompletionTokens: 20,
+					TotalTokens:      30,
+					PromptTokensDetails: &openai.PromptTokensDetails{
+						CachedTokens: 5,
+					},
+				},
 				Choices: []openai.ChatCompletionResponseChoice{
 					{
 						Index:        0,
@@ -393,12 +400,15 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_ResponseBody(t *testing.
 					{Type: "tool_use", ID: "toolu_01", Name: "get_weather", Input: json.RawMessage(`{"location": "Tokyo", "unit": "celsius"}`)},
 				},
 				StopReason: anthropic.StopReasonToolUse,
-				Usage:      anthropic.Usage{InputTokens: 25, OutputTokens: 15},
+				Usage:      anthropic.Usage{InputTokens: 25, OutputTokens: 15, CacheReadInputTokens: 10},
 			},
 			respHeaders: map[string]string{statusHeaderName: "200"},
 			expectedOpenAIResponse: openai.ChatCompletionResponse{
 				Object: "chat.completion",
-				Usage:  openai.ChatCompletionResponseUsage{PromptTokens: 25, CompletionTokens: 15, TotalTokens: 40},
+				Usage: openai.Usage{PromptTokens: 25, CompletionTokens: 15, TotalTokens: 40,
+					PromptTokensDetails: &openai.PromptTokensDetails{
+						CachedTokens: 10},
+				},
 				Choices: []openai.ChatCompletionResponseChoice{
 					{
 						Index:        0,
@@ -446,9 +456,10 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_ResponseBody(t *testing.
 			require.NoError(t, err)
 
 			expectedTokenUsage := LLMTokenUsage{
-				InputTokens:  uint32(tt.expectedOpenAIResponse.Usage.PromptTokens),     //nolint:gosec
-				OutputTokens: uint32(tt.expectedOpenAIResponse.Usage.CompletionTokens), //nolint:gosec
-				TotalTokens:  uint32(tt.expectedOpenAIResponse.Usage.TotalTokens),      //nolint:gosec
+				InputTokens:  uint32(tt.expectedOpenAIResponse.Usage.PromptTokens),                     //nolint:gosec
+				OutputTokens: uint32(tt.expectedOpenAIResponse.Usage.CompletionTokens),                 //nolint:gosec
+				TotalTokens:  uint32(tt.expectedOpenAIResponse.Usage.TotalTokens),                      //nolint:gosec
+				CachedTokens: uint32(tt.expectedOpenAIResponse.Usage.PromptTokensDetails.CachedTokens), //nolint:gosec
 			}
 			require.Equal(t, expectedTokenUsage, usedToken)
 

--- a/internal/extproc/translator/openai_gcpanthropic_test.go
+++ b/internal/extproc/translator/openai_gcpanthropic_test.go
@@ -405,9 +405,11 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_ResponseBody(t *testing.
 			respHeaders: map[string]string{statusHeaderName: "200"},
 			expectedOpenAIResponse: openai.ChatCompletionResponse{
 				Object: "chat.completion",
-				Usage: openai.Usage{PromptTokens: 25, CompletionTokens: 15, TotalTokens: 40,
+				Usage: openai.Usage{
+					PromptTokens: 25, CompletionTokens: 15, TotalTokens: 40,
 					PromptTokensDetails: &openai.PromptTokensDetails{
-						CachedTokens: 10},
+						CachedTokens: 10,
+					},
 				},
 				Choices: []openai.ChatCompletionResponseChoice{
 					{

--- a/internal/extproc/translator/openai_gcpvertexai.go
+++ b/internal/extproc/translator/openai_gcpvertexai.go
@@ -171,9 +171,10 @@ func (o *openAIToGCPVertexAITranslatorV1ChatCompletion) handleStreamingResponse(
 		// Extract token usage if present in this chunk (typically in the last chunk).
 		if chunk.UsageMetadata != nil {
 			tokenUsage = LLMTokenUsage{
-				InputTokens:  uint32(chunk.UsageMetadata.PromptTokenCount),     //nolint:gosec
-				OutputTokens: uint32(chunk.UsageMetadata.CandidatesTokenCount), //nolint:gosec
-				TotalTokens:  uint32(chunk.UsageMetadata.TotalTokenCount),      //nolint:gosec
+				InputTokens:  uint32(chunk.UsageMetadata.PromptTokenCount),        //nolint:gosec
+				OutputTokens: uint32(chunk.UsageMetadata.CandidatesTokenCount),    //nolint:gosec
+				TotalTokens:  uint32(chunk.UsageMetadata.TotalTokenCount),         //nolint:gosec
+				CachedTokens: uint32(chunk.UsageMetadata.CachedContentTokenCount), //nolint:gosec
 			}
 		}
 
@@ -244,7 +245,7 @@ func (o *openAIToGCPVertexAITranslatorV1ChatCompletion) convertGCPChunkToOpenAI(
 	}
 
 	// Convert usage to pointer if available.
-	var usage *openai.ChatCompletionResponseUsage
+	var usage *openai.Usage
 	if chunk.UsageMetadata != nil {
 		usage = ptr.To(geminiUsageToOpenAIUsage(chunk.UsageMetadata))
 	}

--- a/internal/extproc/translator/openai_gcpvertexai_test.go
+++ b/internal/extproc/translator/openai_gcpvertexai_test.go
@@ -683,14 +683,16 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
 				"usageMetadata": {
 					"promptTokenCount": 10,
 					"candidatesTokenCount": 15,
-					"totalTokenCount": 25
+					"totalTokenCount": 25,
+                    "cachedContentTokenCount": 10,
+                    "thoughtsTokenCount": 10
 				}
 			}`,
 			endOfStream: true,
 			wantError:   false,
 			wantHeaderMut: &extprocv3.HeaderMutation{
 				SetHeaders: []*corev3.HeaderValueOption{{
-					Header: &corev3.HeaderValue{Key: "Content-Length", RawValue: []byte("256")},
+					Header: &corev3.HeaderValue{Key: "Content-Length", RawValue: []byte("353")},
 				}},
 			},
 			wantBodyMut: &extprocv3.BodyMutation{
@@ -709,7 +711,13 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
     "object": "chat.completion",
     "usage": {
         "completion_tokens": 15,
+        "completion_tokens_details": {
+            reasoning_tokens: 10
+        },
         "prompt_tokens": 10,
+        "prompt_tokens_details": {
+            cached_tokens: 10
+        },
         "total_tokens": 25
     }
 }`),
@@ -757,7 +765,7 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
 			wantHeaderMut: nil,
 			wantBodyMut: &extprocv3.BodyMutation{
 				Mutation: &extprocv3.BodyMutation_Body{
-					Body: []byte(`data: {"choices":[{"index":0,"delta":{"content":"Hello","role":"assistant"}}],"object":"chat.completion.chunk","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}
+					Body: []byte(`data: {"choices":[{"index":0,"delta":{"content":"Hello","role":"assistant"}}],"object":"chat.completion.chunk","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8,"completion_tokens_details":{},"prompt_tokens_details":{}}}
 
 data: [DONE]
 `),

--- a/internal/extproc/translator/openai_gcpvertexai_test.go
+++ b/internal/extproc/translator/openai_gcpvertexai_test.go
@@ -712,11 +712,11 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
     "usage": {
         "completion_tokens": 15,
         "completion_tokens_details": {
-            reasoning_tokens: 10
+            "reasoning_tokens": 10
         },
         "prompt_tokens": 10,
         "prompt_tokens_details": {
-            cached_tokens: 10
+            "cached_tokens": 10
         },
         "total_tokens": 25
     }

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -157,6 +157,9 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseBody(_ map[string]str
 		OutputTokens: uint32(resp.Usage.CompletionTokens), //nolint:gosec
 		TotalTokens:  uint32(resp.Usage.TotalTokens),      //nolint:gosec
 	}
+	if resp.Usage.PromptTokensDetails != nil {
+		tokenUsage.CachedTokens = uint32(resp.Usage.PromptTokensDetails.CachedTokens)
+	}
 	// Fallback to request model for test or non-compliant OpenAI backends
 	responseModel = cmp.Or(resp.Model, o.requestModel)
 	if span != nil {

--- a/internal/extproc/translator/openai_openai.go
+++ b/internal/extproc/translator/openai_openai.go
@@ -158,7 +158,7 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) ResponseBody(_ map[string]str
 		TotalTokens:  uint32(resp.Usage.TotalTokens),      //nolint:gosec
 	}
 	if resp.Usage.PromptTokensDetails != nil {
-		tokenUsage.CachedTokens = uint32(resp.Usage.PromptTokensDetails.CachedTokens)
+		tokenUsage.CachedTokens = uint32(resp.Usage.PromptTokensDetails.CachedTokens) //nolint:gosec
 	}
 	// Fallback to request model for test or non-compliant OpenAI backends
 	responseModel = cmp.Or(resp.Model, o.requestModel)

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -213,6 +213,8 @@ type LLMTokenUsage struct {
 	OutputTokens uint32
 	// TotalTokens is the total number of tokens consumed.
 	TotalTokens uint32
+	// CachedTokens is the total number of tokens read from cache.
+	CachedTokens uint32
 }
 
 // SJSONOptions are the options used for sjson operations in the translator.

--- a/internal/tracing/openinference/openai/response_attrs_test.go
+++ b/internal/tracing/openinference/openai/response_attrs_test.go
@@ -29,7 +29,7 @@ var (
 			},
 			FinishReason: openai.ChatCompletionChoicesFinishReasonStop,
 		}},
-		Usage: openai.ChatCompletionResponseUsage{
+		Usage: openai.Usage{
 			PromptTokens:     20,
 			CompletionTokens: 10,
 			TotalTokens:      30,
@@ -56,7 +56,7 @@ var (
 			},
 			FinishReason: openai.ChatCompletionChoicesFinishReasonToolCalls,
 		}},
-		Usage: openai.ChatCompletionResponseUsage{
+		Usage: openai.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 20,
 			TotalTokens:      30,
@@ -78,7 +78,7 @@ var (
 			},
 			FinishReason: openai.ChatCompletionChoicesFinishReasonStop,
 		}},
-		Usage: openai.ChatCompletionResponseUsage{
+		Usage: openai.Usage{
 			PromptTokens:     9,
 			CompletionTokens: 9,
 			TotalTokens:      18,

--- a/internal/tracing/openinference/openai/sse_converter.go
+++ b/internal/tracing/openinference/openai/sse_converter.go
@@ -28,7 +28,7 @@ func convertSSEToJSON(chunks []*openai.ChatCompletionResponseChunk) *openai.Chat
 	var (
 		firstChunk   *openai.ChatCompletionResponseChunk
 		content      strings.Builder
-		usage        *openai.ChatCompletionResponseUsage
+		usage        *openai.Usage
 		annotations  []openai.Annotation
 		role         string
 		obfuscation  string


### PR DESCRIPTION
**Description**
Update cached token usage stats from cloud provider responses and remove the deprecated usage of `ChatCompletionResponseUsage`.


Related to #220 
