### PR TITLE
fix: failed to transform request: unexpected type: map[string]interface {}

### DIFF
--- a/internal/extproc/translator/openai_awsbedrock.go
+++ b/internal/extproc/translator/openai_awsbedrock.go
@@ -142,7 +142,7 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) openAIToolsToBedrockToolC
 	bedrockReq.ToolConfig.Tools = tools
 
 	if openAIReq.ToolChoice != nil {
-		if toolChoice, ok := openAIReq.ToolChoice.(string); ok {
+		if toolChoice, ok := openAIReq.ToolChoice.Value.(string); ok {
 			switch toolChoice {
 			case "auto":
 				bedrockReq.ToolConfig.ToolChoice = &awsbedrock.ToolChoice{
@@ -166,7 +166,7 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) openAIToolsToBedrockToolC
 					}
 				}
 			}
-		} else if toolChoice, ok := openAIReq.ToolChoice.(openai.ToolChoice); ok {
+		} else if toolChoice, ok := openAIReq.ToolChoice.Value.(openai.ToolChoice); ok {
 			tool := string(toolChoice.Type)
 			bedrockReq.ToolConfig.ToolChoice = &awsbedrock.ToolChoice{
 				Tool: &awsbedrock.SpecificToolChoice{


### PR DESCRIPTION
There seems to be parsing issues when selecting tool choice `function` for aws conversion.

Initially wanted to use the openai v2 but there are currently issues with unmarshaling.
https://github.com/openai/openai-go/issues/520

Example:

This commit adds a new feature to the translator that allows it to translate
text from English to Spanish. This feature is useful for users who want to
translate text from English to Spanish.
-->

**Related Issues/PRs (if applicable)**

<!--
Please add the related issues or PRs here.

Example:

Fixes #12345
Close #12346
Related PR: #12347
-->

**Special notes for reviewers (if applicable)**

<!--
Please add any special notes for reviewers here.

Example:
The changes in this PR are not yet complete. I am still working on the
controller part of this feature, but I wanted to get feedback on the
filter part first.
-->
