### PR TITLE
feat: add gemini safety ratings to ChatCompletion responses

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1207,6 +1207,14 @@ type ChatCompletionResponseChoiceMessage struct {
 	// ReasoningContent is used to hold any non-standard fields from the backend which supports reasoning,
 	// like "reasoningContent" from AWS Bedrock.
 	ReasoningContent *ReasoningContentUnion `json:"reasoning_content,omitempty"`
+
+	// GCPVertexAI specific fields.
+
+	// SafetyRatings contains safety ratings copied from the GCP Vertex AI response as-is.
+	// List of ratings for the safety of a response candidate. There is at most one rating per category.
+	// https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#SafetyRating
+
+	SafetyRatings []*genai.SafetyRating `json:"safety_ratings,omitempty"`
 }
 
 // URLCitation contains citation information for web search results.

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genai"
 	"k8s.io/utils/ptr"
 )
 
@@ -1016,6 +1017,69 @@ func TestChatCompletionResponse(t *testing.T) {
 					"prompt_tokens": 14,
 					"completion_tokens": 192,
 					"total_tokens": 206
+				}
+			}`,
+		},
+		{
+			name: "response with safety settings",
+			response: ChatCompletionResponse{
+				ID:      "chatcmpl-safety-test",
+				Created: JSONUNIXTime(time.Unix(1755135425, 0)),
+				Model:   "gpt-4.1-nano",
+				Object:  "chat.completion",
+				Choices: []ChatCompletionResponseChoice{
+					{
+						Index:        0,
+						FinishReason: ChatCompletionChoicesFinishReasonStop,
+						Message: ChatCompletionResponseChoiceMessage{
+							Role:    "assistant",
+							Content: ptr.To("This is a safe response"),
+							SafetyRatings: []*genai.SafetyRating{
+								{
+									Category:    genai.HarmCategoryHarassment,
+									Probability: genai.HarmProbabilityLow,
+								},
+								{
+									Category:    genai.HarmCategorySexuallyExplicit,
+									Probability: genai.HarmProbabilityNegligible,
+								},
+							},
+						},
+					},
+				},
+				Usage: ChatCompletionResponseUsage{
+					CompletionTokens: 5,
+					PromptTokens:     3,
+					TotalTokens:      8,
+				},
+			},
+			expected: `{
+				"id": "chatcmpl-safety-test",
+				"object": "chat.completion",
+				"created": 1755135425,
+				"model": "gpt-4.1-nano",
+				"choices": [{
+					"index": 0,
+					"message": {
+						"role": "assistant",
+						"content": "This is a safe response",
+						"safety_ratings": [
+							{
+								"category": "HARM_CATEGORY_HARASSMENT",
+								"probability": "LOW"
+							},
+							{
+								"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+								"probability": "NEGLIGIBLE"
+							}
+						]
+					},
+					"finish_reason": "stop"
+				}],
+				"usage": {
+					"prompt_tokens": 3,
+					"completion_tokens": 5,
+					"total_tokens": 8
 				}
 			}`,
 		},

--- a/internal/extproc/translator/gemini_helper.go
+++ b/internal/extproc/translator/gemini_helper.go
@@ -492,6 +492,14 @@ func geminiCandidatesToOpenAIChoices(candidates []*genai.Candidate) ([]openai.Ch
 			choice.Message = message
 		}
 
+		if candidate.SafetyRatings != nil {
+			if choice.Message.Role == "" {
+				choice.Message.Role = openai.ChatMessageRoleAssistant
+			}
+
+			choice.Message.SafetyRatings = candidate.SafetyRatings
+		}
+
 		// Handle logprobs if available.
 		if candidate.LogprobsResult != nil {
 			choice.Logprobs = geminiLogprobsToOpenAILogprobs(*candidate.LogprobsResult)


### PR DESCRIPTION
**Description**

This PR adds support for safety ratings in ChatCompletion responses when using GCP Vertex AI. The safety ratings are copied from the Vertex AI response as-is and included in the OpenAI-compatible response format.

The implementation adds a new `SafetyRatings` field to the `ChatCompletionResponseChoiceMessage` struct.
GCP Safety Ratings doc: [1]

Key changes:
- Added `SafetyRatings` field to OpenAI API schema for chat completion responses
- Updated Gemini translator to map safety ratings from Vertex AI responses
- Safety ratings are only included when present in the backend response

**Special notes for reviewers (if applicable)**

The safety ratings follow the GCP Vertex AI format and are passed through unchanged to maintain compatibility with Google's safety rating system. The field is optional and only populated when safety ratings are present in the upstream response.

[1]: https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#SafetyRating