### PR TITLE
fix: make mcp span names informative

### DIFF
--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -234,6 +234,7 @@ func (m *MCPProxy) servePOST(w http.ResponseWriter, r *http.Request) {
 			}
 			err = m.handleSetLoggingLevel(ctx, s, w, msg, p, span)
 		case "ping":
+			// Ping is intentionally not traced as it's a lightweight health check.
 			err = m.handlePing(ctx, w, msg)
 		case "prompts/list":
 			p := &mcp.ListPromptsParams{}

--- a/internal/testing/testotel/collector.go
+++ b/internal/testing/testotel/collector.go
@@ -133,17 +133,6 @@ func (o *OTLPCollector) TakeSpan() *tracev1.Span {
 	}
 }
 
-// DrainSpans drains all pending spans from the channel.
-func (o *OTLPCollector) DrainSpans() {
-	for {
-		select {
-		case <-o.spanCh:
-			// Discard the span
-		case <-time.After(otlpTimeout):
-			return // No more spans available
-		}
-	}
-}
 
 // DrainMetrics returns metrics or nil if none were recorded.
 func (o *OTLPCollector) DrainMetrics() *metricsv1.ResourceMetrics {

--- a/internal/testing/testotel/collector.go
+++ b/internal/testing/testotel/collector.go
@@ -133,6 +133,18 @@ func (o *OTLPCollector) TakeSpan() *tracev1.Span {
 	}
 }
 
+// DrainSpans drains all pending spans from the channel.
+func (o *OTLPCollector) DrainSpans() {
+	for {
+		select {
+		case <-o.spanCh:
+			// Discard the span
+		case <-time.After(otlpTimeout):
+			return // No more spans available
+		}
+	}
+}
+
 // DrainMetrics returns metrics or nil if none were recorded.
 func (o *OTLPCollector) DrainMetrics() *metricsv1.ResourceMetrics {
 	select {

--- a/internal/testing/testotel/collector.go
+++ b/internal/testing/testotel/collector.go
@@ -133,7 +133,6 @@ func (o *OTLPCollector) TakeSpan() *tracev1.Span {
 	}
 }
 
-
 // DrainMetrics returns metrics or nil if none were recorded.
 func (o *OTLPCollector) DrainMetrics() *metricsv1.ResourceMetrics {
 	select {

--- a/internal/tracing/mcp.go
+++ b/internal/tracing/mcp.go
@@ -86,7 +86,9 @@ func (m mcpTracer) StartSpanAndInjectMeta(ctx context.Context, req *jsonrpc.Requ
 	parentCtx := m.propagator.Extract(ctx, mc)
 
 	// Start the span with options appropriate for the semantic convention.
-	newCtx, span := m.tracer.Start(parentCtx, "mcp.request", trace.WithSpanKind(trace.SpanKindClient))
+	// Convert method name to span name following mcp-go SDK patterns
+	spanName := getSpanName(req.Method)
+	newCtx, span := m.tracer.Start(parentCtx, spanName, trace.WithSpanKind(trace.SpanKindClient))
 
 	// Always inject trace context into the header mutation if provided.
 	// This ensures trace propagation works even for unsampled spans.
@@ -173,4 +175,38 @@ func (c metaMapCarrier) Keys() []string {
 	}
 
 	return keys
+}
+
+// getSpanName converts MCP method names to span names following mcp-go SDK patterns.
+func getSpanName(method string) string {
+	switch method {
+	case "initialize":
+		return "Initialize"
+	case "tools/list":
+		return "ListTools"
+	case "tools/call":
+		return "CallTool"
+	case "prompts/list":
+		return "ListPrompts"
+	case "prompts/get":
+		return "GetPrompt"
+	case "resources/list":
+		return "ListResources"
+	case "resources/read":
+		return "ReadResource"
+	case "resources/subscribe":
+		return "Subscribe"
+	case "resources/unsubscribe":
+		return "Unsubscribe"
+	case "resources/templates/list":
+		return "ListResourceTemplates"
+	case "logging/setLevel":
+		return "SetLoggingLevel"
+	case "completion/complete":
+		return "Complete"
+	case "ping":
+		return "Ping"
+	default:
+		return method
+	}
 }


### PR DESCRIPTION
**Description**

Before everything was vaguely "mcp.request" which is not untrue, but not helpful. There are plenty of low-cardinality choices for span or metric names and the `req.Method` is the most intuitive. This uses the same naming conventions as mcp-go

<img width="3340" height="1740" alt="image" src="https://github.com/user-attachments/assets/b7118aba-63f2-49b6-a05c-4e01060fd131" />