### PR TITLE
ci: format Go with golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,7 @@ GO_FILES=$(shell git ls-files --cached --others --exclude-standard | grep '\.go$
 .PHONY: format
 format: ## Format the codebase.
 	@echo "format => *.go"
-	@gofmt -s -w $(GO_FILES)
-	@$(GO_TOOL) gofumpt -l -w $(GO_FILES)
-	@echo "gci => *.go"
-	@$(GO_TOOL) gci write -s standard -s default -s "prefix(github.com/envoyproxy/ai-gateway)" $(GO_FILES)
+	@$(GO_TOOL) golangci-lint fmt $(GO_FILES)
 	@echo "licenses => **"
 	@$(GO_TOOL) license-eye header fix
 	@echo "prettier => **.{yaml,yml}"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,6 @@ go 1.25
 
 tool (
 	github.com/apache/skywalking-eyes/cmd/license-eye
-	github.com/daixiang0/gci
 	github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker
 	github.com/elastic/crd-ref-docs
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
@@ -12,7 +11,6 @@ tool (
 	github.com/vladopajic/go-test-coverage/v2
 	github.com/wasilibs/go-prettier/v3/cmd/prettier
 	helm.sh/helm/v3/cmd/helm
-	mvdan.cc/gofumpt
 	sigs.k8s.io/controller-runtime/tools/setup-envtest
 	sigs.k8s.io/controller-tools/cmd/controller-gen
 	sigs.k8s.io/kind


### PR DESCRIPTION
**Description**

Replaces manual invocation of gci and gofumpt with `golangci-lint fmt` which is effectively the same

**Related Issues/PRs (if applicable)**

**Special notes for reviewers (if applicable)**

I happened to notice that gci / gofumpt were being directly invoked, but since v2 golangci-lint has a formatting command for the configured formatters. It just applies the formatters without any compilation, etc and is fast and equivalent