### PR TITLE
fix: makes gRPC's MaxRecvMsgSize for the extension server

### DIFF
--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -29,6 +29,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 		require.Equal(t, "/certs", f.tlsCertDir)
 		require.Equal(t, "tls.crt", f.tlsCertName)
 		require.Equal(t, "tls.key", f.tlsKeyName)
+		require.Equal(t, 4*1024*1024, f.maxRecvMsgSize)
 		require.NoError(t, err)
 	})
 	t.Run("all flags", func(t *testing.T) {
@@ -49,6 +50,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 					tc.dash + "port=:8080",
 					tc.dash + "extProcExtraEnvVars=OTEL_SERVICE_NAME=test;OTEL_TRACES_EXPORTER=console",
 					tc.dash + "spanRequestHeaderAttributes=x-session-id:session.id",
+					tc.dash + "maxRecvMsgSize=33554432",
 				}
 				f, err := parseAndValidateFlags(args)
 				require.Equal(t, "debug", f.extProcLogLevel)
@@ -59,6 +61,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				require.Equal(t, ":8080", f.extensionServerPort)
 				require.Equal(t, "OTEL_SERVICE_NAME=test;OTEL_TRACES_EXPORTER=console", f.extProcExtraEnvVars)
 				require.Equal(t, "x-session-id:session.id", f.spanRequestHeaderAttributes)
+				require.Equal(t, 32*1024*1024, f.maxRecvMsgSize)
 				require.NoError(t, err)
 			})
 		}

--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
             - --enableLeaderElection=true
             {{- end }}
             - --rootPrefix={{ .Values.endpointConfig.rootPrefix }}
+            {{- if ne .Values.controller.maxRecvMsgSize nil }}
+            - --maxRecvMsgSize={{ .Values.controller.maxRecvMsgSize }}
+            {{- end }}
           livenessProbe:
             grpc:
               port: 1063

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -155,4 +155,8 @@ controller:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
+  # maxRecvMsgSize is the maximum message size in bytes that the gRPC extension server can receive
+  # from xDS (envoy-gateway).
+  # This value should be increased in setups where count/complexity of xDS
+  # resources (configuration) is big. Defaults to 4MB.
+  # maxRecvMsgSize: "4194304"


### PR DESCRIPTION
**Description**
Makes go's gRPC `MaxRecvMsgSize` configurable for the extension server, whose default value is 4MB https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize

When the gRPC message payload from the xDS server exceeds 4MB, it is rejected by the extension server and the below errors is observed on envoy-gateway:
```
2025-10-07T10:26:44.625Z        ERROR   xds     runner/runner.go:245    failed to translate xds ir      {"runner": "xds", "error": "rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6683527 vs. 4194304)"}
2025-10-07T10:26:44.625Z        ERROR   watchable       message/watchutil.go:86 observed an error       {"runner": "xds", "error": "rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6683527 vs. 4194304)"}
```
This PR makes it configurable via the command-line flag `maxRecvMsgSize` and keeps its default at 4MB.


**Related Issues/PRs (if applicable)**
Fixes https://github.com/envoyproxy/ai-gateway/issues/1293
Related PR to make gRPC's message sizes configurable, though that was for the external processor gRPC server: https://github.com/envoyproxy/ai-gateway/pull/1213


**Special notes for reviewers (if applicable)**

Note that this applies to the xDS resource messages sent from the xDS server to the extension server. The payload of these messages increases with the size/count of the config resources.