### PR TITLE
mcp: configure access logs for upstream mcp servers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ tests/internal/testopenai/cassettes
 tests/internal/testopeninference/spans
 cmd/aigw/testdata
 internal/autoconfig/testdata
+examples/aigw/ollama.yaml

--- a/examples/aigw/ollama.yaml
+++ b/examples/aigw/ollama.yaml
@@ -169,3 +169,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/examples/mcp/mcp_example.yaml
+++ b/examples/mcp/mcp_example.yaml
@@ -52,6 +52,26 @@ spec:
       group: gateway.envoyproxy.io
       path: "/"
 ---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: MCPRoute
+metadata:
+  name: mcp-route-custom-path
+  namespace: default
+spec:
+  parentRefs:
+    - name: aigw-run
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  path: "/mcp/custom/path"
+  backendRefs:
+    - name: aws-knowledge
+      kind: Backend
+      group: gateway.envoyproxy.io
+      path: "/"
+      toolSelector:
+        include:
+          - aws___read_documentation
+---
 kind: Secret
 apiVersion: v1
 metadata:
@@ -237,23 +257,45 @@ spec:
           socket_address:
             address: 127.0.0.1
             port_value: 9901
+  telemetry:
+    accessLog:
+      settings:
+        - sinks:
+            - type: File
+              file:
+                path: /dev/stdout
+          format:
+            type: JSON
+            json:
+              # MCP specific fields
+              mcp_request_id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
+              mcp_session_id: "%REQ(MCP-SESSION-ID)%"
+              mcp_method: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
+              mcp_backend: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
+              # Default fields
+              start_time: "%START_TIME%"
+              method: "%REQ(:METHOD)%"
+              x-envoy-origin-path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+              protocol: "%PROTOCOL%"
+              response_code: "%RESPONSE_CODE%"
+              response_flags: "%RESPONSE_FLAGS%"
+              response_code_details: "%RESPONSE_CODE_DETAILS%"
+              connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+              upstream_transport_failure_reason: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"
+              bytes_received: "%BYTES_RECEIVED%"
+              bytes_sent: "%BYTES_SENT%"
+              duration: "%DURATION%"
+              x-envoy-upstream-service-time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+              x-forwarded-for: "%REQ(X-FORWARDED-FOR)%"
+              user-agent: "%REQ(USER-AGENT)%"
+              x-request-id: "%REQ(X-REQUEST-ID)%"
+              ":authority": "%REQ(:AUTHORITY)%"
+              upstream_host: "%UPSTREAM_HOST%"
+              upstream_cluster: "%UPSTREAM_CLUSTER%"
+              upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+              downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+              downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+              requested_server_name: "%REQUESTED_SERVER_NAME%"
+              route_name: "%ROUTE_NAME%"
 ---
-apiVersion: aigateway.envoyproxy.io/v1alpha1
-kind: MCPRoute
-metadata:
-  name: mcp-route-custom-path
-  namespace: default
-spec:
-  parentRefs:
-    - name: aigw-run
-      kind: Gateway
-      group: gateway.networking.k8s.io
-  path: "/mcp/custom/path"
-  backendRefs:
-    - name: aws-knowledge
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/"
-      toolSelector:
-        include:
-          - aws___read_documentation
+

--- a/internal/autoconfig/config.yaml.tmpl
+++ b/internal/autoconfig/config.yaml.tmpl
@@ -66,6 +66,13 @@ spec:
               genai_tokens_input: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               genai_tokens_output: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
 {{- end }}
+{{- if .MCPBackendRefs }}
+              # MCP specific fields
+              mcp_request_id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
+              mcp_session_id: "%REQ(MCP-SESSION-ID)%"
+              mcp_method: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
+              mcp_backend: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
+{{- end }}
               # A few default fields
               start_time: "%START_TIME%"
               method: "%REQ(:METHOD)%"
@@ -265,6 +272,7 @@ spec:
     secretRef:
       name: openai-apikey
 {{- end }}
+---
 {{- end }}
 {{- range .MCPBackendRefs }}
 {{- if .APIKey }}

--- a/internal/autoconfig/config_test.go
+++ b/internal/autoconfig/config_test.go
@@ -63,6 +63,9 @@ var (
 
 	//go:embed testdata/kiwi.yaml
 	kiwiYAML string
+
+	//go:embed testdata/openai-github.yaml
+	openaiGithubYAML string
 )
 
 func TestWriteConfig(t *testing.T) {
@@ -320,6 +323,41 @@ func TestWriteConfig(t *testing.T) {
 				},
 			},
 			expected: kiwiYAML,
+		},
+		{
+			name: "OpenAI with GitHub MCP server",
+			input: ConfigData{
+				Backends: []Backend{
+					{
+						Name:             "openai",
+						Hostname:         "api.openai.com",
+						OriginalHostname: "api.openai.com",
+						Port:             443,
+						NeedsTLS:         true,
+					},
+					{
+						Name:             "github",
+						Hostname:         "api.githubcopilot.com",
+						OriginalHostname: "api.githubcopilot.com",
+						Port:             443,
+						NeedsTLS:         true,
+					},
+				},
+				OpenAI: &OpenAIConfig{
+					BackendName: "openai",
+					SchemaName:  "OpenAI",
+					Version:     "",
+				},
+				MCPBackendRefs: []MCPBackendRef{
+					{
+						BackendName:  "github",
+						Path:         "/mcp/x/issues/readonly",
+						APIKey:       "${GITHUB_MCP_TOKEN}",
+						IncludeTools: []string{"get_issue", "list_issues"},
+					},
+				},
+			},
+			expected: openaiGithubYAML,
 		},
 	}
 

--- a/internal/autoconfig/testdata/azure-openai-with-org-and-project.yaml
+++ b/internal/autoconfig/testdata/azure-openai-with-org-and-project.yaml
@@ -190,3 +190,4 @@ spec:
   azureAPIKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/azure-openai.yaml
+++ b/internal/autoconfig/testdata/azure-openai.yaml
@@ -184,3 +184,4 @@ spec:
   azureAPIKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/debug.yaml
+++ b/internal/autoconfig/testdata/debug.yaml
@@ -183,3 +183,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/kiwi.yaml
+++ b/internal/autoconfig/testdata/kiwi.yaml
@@ -47,6 +47,11 @@ spec:
           format:
             type: JSON
             json:
+              # MCP specific fields
+              mcp_request_id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
+              mcp_session_id: "%REQ(MCP-SESSION-ID)%"
+              mcp_method: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
+              mcp_backend: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
               # A few default fields
               start_time: "%START_TIME%"
               method: "%REQ(:METHOD)%"

--- a/internal/autoconfig/testdata/llamastack.yaml
+++ b/internal/autoconfig/testdata/llamastack.yaml
@@ -170,3 +170,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/openai-github.yaml
+++ b/internal/autoconfig/testdata/openai-github.yaml
@@ -3,7 +3,7 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-# Configuration for Envoy AI Gateway with OpenAI compatible endpoint
+# Configuration for Envoy AI Gateway with MCP servers
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
@@ -55,6 +55,11 @@ spec:
               genai_backend_name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               genai_tokens_input: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               genai_tokens_output: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              # MCP specific fields
+              mcp_request_id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
+              mcp_session_id: "%REQ(MCP-SESSION-ID)%"
+              mcp_method: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
+              mcp_backend: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
               # A few default fields
               start_time: "%START_TIME%"
               method: "%REQ(:METHOD)%"
@@ -102,6 +107,31 @@ spec:
     - metadataKey: llm_output_token
       type: OutputToken
 ---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: MCPRoute
+metadata:
+  name: mcp-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: aigw-run
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  path: "/mcp"
+  backendRefs:
+    - name: github
+      kind: Backend
+      group: gateway.envoyproxy.io
+      path: "/mcp/x/issues/readonly"
+      toolSelector:
+        include:
+          - get_issue
+          - list_issues
+      securityPolicy:
+        apiKey:
+          secretRef:
+            name: github-token
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend
 metadata:
@@ -111,6 +141,17 @@ spec:
   endpoints:
     - fqdn:
         hostname: api.openai.com
+        port: 443
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: github
+  namespace: default
+spec:
+  endpoints:
+    - fqdn:
+        hostname: api.githubcopilot.com
         port: 443
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
@@ -142,6 +183,20 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: api.openai.com
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: github-tls
+  namespace: default
+spec:
+  targetRefs:
+    - group: 'gateway.envoyproxy.io'
+      kind: Backend
+      name: github
+  validation:
+    wellKnownCACertificates: "System"
+    hostname: api.githubcopilot.com
 ---
 # By default, Envoy Gateway sets the buffer limit to 32kiB which is not
 # sufficient for AI workloads. This ClientTrafficPolicy sets the buffer limit
@@ -183,56 +238,6 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
----
-apiVersion: aigateway.envoyproxy.io/v1alpha1
-kind: MCPRoute
-metadata:
-  name: mcp-route
-  namespace: default
-spec:
-  parentRefs:
-    - name: aigw-run
-      kind: Gateway
-      group: gateway.networking.k8s.io
-  path: "/mcp"
-  backendRefs:
-    - name: github
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/mcp/x/issues/readonly"
-      toolSelector:
-        include:
-          - get_issue
-          - list_issues
-      securityPolicy:
-        apiKey:
-          secretRef:
-            name: github-token
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: github
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: api.githubcopilot.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: github-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: 'gateway.envoyproxy.io'
-      kind: Backend
-      name: github
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: api.githubcopilot.com
 ---
 kind: Secret
 apiVersion: v1

--- a/internal/autoconfig/testdata/openai-with-org-and-project.yaml
+++ b/internal/autoconfig/testdata/openai-with-org-and-project.yaml
@@ -189,3 +189,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/openai-with-org.yaml
+++ b/internal/autoconfig/testdata/openai-with-org.yaml
@@ -187,3 +187,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/openai-with-project.yaml
+++ b/internal/autoconfig/testdata/openai-with-project.yaml
@@ -187,3 +187,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/openai.yaml
+++ b/internal/autoconfig/testdata/openai.yaml
@@ -183,3 +183,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/openrouter.yaml
+++ b/internal/autoconfig/testdata/openrouter.yaml
@@ -184,3 +184,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/autoconfig/testdata/tars.yaml
+++ b/internal/autoconfig/testdata/tars.yaml
@@ -183,3 +183,4 @@ spec:
   apiKey:
     secretRef:
       name: openai-apikey
+---

--- a/internal/extensionserver/mcproute.go
+++ b/internal/extensionserver/mcproute.go
@@ -51,8 +51,8 @@ func (s *Server) maybeGenerateResourcesForMCPGateway(req *egextension.PostTransl
 	// Only create the backend listener if there are routes for it
 	if mcpBackendRoutes != nil {
 		// Extract MCP backend filters from existing listeners and create the backend listener with those filters.
-		mcpBackendHTTPFilters := s.extractMCPBackendFiltersFromMCPProxyListener(req.Listeners)
-		req.Listeners = append(req.Listeners, s.createBackendListener(mcpBackendHTTPFilters))
+		mcpBackendHTTPFilters, accessLogConfig := s.extractMCPBackendFiltersFromMCPProxyListener(req.Listeners)
+		req.Listeners = append(req.Listeners, s.createBackendListener(mcpBackendHTTPFilters, accessLogConfig))
 		req.Routes = append(req.Routes, mcpBackendRoutes)
 	}
 
@@ -70,7 +70,7 @@ func (s *Server) maybeGenerateResourcesForMCPGateway(req *egextension.PostTransl
 }
 
 // createBackendListener creates the backend listener for MCP Gateway.
-func (s *Server) createBackendListener(mcpHTTPFilters []*httpconnectionmanagerv3.HttpFilter) *listenerv3.Listener {
+func (s *Server) createBackendListener(mcpHTTPFilters []*httpconnectionmanagerv3.HttpFilter, accessLogConfig []*accesslogv3.AccessLog) *listenerv3.Listener {
 	httpConManager := &httpconnectionmanagerv3.HttpConnectionManager{
 		StatPrefix: fmt.Sprintf("%s-http", mcpBackendListenerName),
 		RouteSpecifier: &httpconnectionmanagerv3.HttpConnectionManager_Rds{
@@ -86,15 +86,18 @@ func (s *Server) createBackendListener(mcpHTTPFilters []*httpconnectionmanagerv3
 		},
 	}
 
-	// Add HTTP access log to the backend listener HCM (log to stdout via file logger to /dev/stdout).
-	// This helps debugging MCP traffic flowing through the backend listener.
-	// TODO(nacx): Make the AccessLogFormat configurable so that we emit access logs for upstream MCP server calls.
-	fal := &filelogv3.FileAccessLog{Path: "/dev/stdout"}
-	httpConManager.AccessLog = []*accesslogv3.AccessLog{
-		{
-			Name:       "envoy.access_loggers.file",
-			ConfigType: &accesslogv3.AccessLog_TypedConfig{TypedConfig: mustToAny(fal)},
-		},
+	httpConManager.AccessLog = accessLogConfig
+	if len(httpConManager.AccessLog) == 0 {
+		// Fallback access log configuration if none is found.
+		// This should not happen in practice, because Envoy Gateway configures a default access log format if users
+		// do not explicitly configure one.
+		fal := &filelogv3.FileAccessLog{Path: "/dev/stdout"}
+		httpConManager.AccessLog = []*accesslogv3.AccessLog{
+			{
+				Name:       "envoy.access_loggers.file",
+				ConfigType: &accesslogv3.AccessLog_TypedConfig{TypedConfig: mustToAny(fal)},
+			},
+		}
 	}
 
 	// Add MCP HTTP filters (like credential injection filters) to the backend listener.
@@ -281,8 +284,27 @@ func (s *Server) modifyMCPGatewayGeneratedCluster(clusters []*clusterv3.Cluster)
 // extractMCPBackendFiltersFromMCPProxyListener scans through MCP proxy listeners to find HTTP filters
 // that correspond to MCP backend processing (those with MCPBackendFilterPrefix in their names)
 // and extracts them from the proxy listeners so they can be moved to the backend listener.
-func (s *Server) extractMCPBackendFiltersFromMCPProxyListener(listeners []*listenerv3.Listener) []*httpconnectionmanagerv3.HttpFilter {
-	var mcpHTTPFilters []*httpconnectionmanagerv3.HttpFilter
+//
+// This method also returns the access log configuration to use in the MCP backend listener. We want to use the same
+// access log configuration that has been configured in the Gateway.
+// The challenge is that the MCP backend listener will have a single HCM, and here we have N listeners, each with its own
+// HCM, so we need to decide how to properly configure the access logs in the backend listener based on multiple input
+// access log configurations.
+//
+// The Envoy Gateway extension server works, it will call the main `PostTranslateModify` individually for each gateway. This means
+// that this method will receive ONLY listeners for the same gateway.
+// Since the access logs are configured in the EnvoyProxy resource, and the Gateway object targets the EnvoyProxy resource via the
+// "infrastructure" setting, it is guaranteed that all listeners here will have the same access log configuration, so it is safe to
+// just pick the first one.
+//
+// When using the envoy Gateway `mergeGateways` feature, this method will receive all the listeners attached to the GatewayClass instead.
+// This is still safe because in the end all Gateway objects will be attached to the same "infrastructure", so it is still safe to assume
+// that all received listeners will have the same access log configuration
+func (s *Server) extractMCPBackendFiltersFromMCPProxyListener(listeners []*listenerv3.Listener) ([]*httpconnectionmanagerv3.HttpFilter, []*accesslogv3.AccessLog) {
+	var (
+		mcpHTTPFilters  []*httpconnectionmanagerv3.HttpFilter
+		accessLogConfig []*accesslogv3.AccessLog
+	)
 
 	for _, listener := range listeners {
 		// Skip the backend MCP listener if it already exists.
@@ -302,6 +324,13 @@ func (s *Server) extractMCPBackendFiltersFromMCPProxyListener(listeners []*liste
 			httpConManager, hcmIndex, err := findHCM(chain)
 			if err != nil {
 				continue // Skip chains without HCM.
+			}
+
+			// All listeners will have the same access log configuration, as they all belong to the same gateway
+			// and share the infrastructure. we can just return the first not-empty access log config and use that
+			// to configure the MCP backend listener with the same settings.
+			if len(accessLogConfig) == 0 {
+				accessLogConfig = httpConManager.AccessLog
 			}
 
 			// Look for MCP HTTP filters in this HCM and extract them.
@@ -330,7 +359,7 @@ func (s *Server) extractMCPBackendFiltersFromMCPProxyListener(listeners []*liste
 	if len(mcpHTTPFilters) > 0 {
 		s.log.Info("Extracted MCP HTTP filters", "count", len(mcpHTTPFilters))
 	}
-	return mcpHTTPFilters
+	return mcpHTTPFilters, accessLogConfig
 }
 
 // isMCPBackendHTTPFilter checks if an HTTP filter is used for MCP backend processing.

--- a/internal/extensionserver/mcproute_test.go
+++ b/internal/extensionserver/mcproute_test.go
@@ -10,6 +10,7 @@ import (
 
 	xdscorev3 "github.com/cncf/xds/go/xds/core/v3"
 	matcherv3 "github.com/cncf/xds/go/xds/type/matcher/v3"
+	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -33,10 +34,29 @@ func TestServer_createBackendListener(t *testing.T) {
 	tests := []struct {
 		name             string
 		mcpHTTPFilters   []*httpconnectionmanagerv3.HttpFilter
+		accessLogConfig  []*accesslogv3.AccessLog
 		expectedListener *listenerv3.Listener
 	}{
 		{
 			name:           "no filters",
+			mcpHTTPFilters: nil,
+			expectedListener: &listenerv3.Listener{
+				Name: mcpBackendListenerName,
+				Address: &corev3.Address{
+					Address: &corev3.Address_SocketAddress{
+						SocketAddress: &corev3.SocketAddress{
+							Protocol: corev3.SocketAddress_TCP,
+							Address:  "127.0.0.1",
+							PortSpecifier: &corev3.SocketAddress_PortValue{
+								PortValue: internalapi.MCPBackendListenerPort,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "no filters with access logs",
 			mcpHTTPFilters: nil,
 			expectedListener: &listenerv3.Listener{
 				Name: mcpBackendListenerName,
@@ -58,12 +78,25 @@ func TestServer_createBackendListener(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Server{log: testr.New(t)}
-			listener := s.createBackendListener(tt.mcpHTTPFilters)
+			listener := s.createBackendListener(tt.mcpHTTPFilters, tt.accessLogConfig)
 
 			require.Equal(t, tt.expectedListener.Name, listener.Name)
 			require.Equal(t, tt.expectedListener.Address.GetSocketAddress().Address, listener.Address.GetSocketAddress().Address)
 			require.Equal(t, tt.expectedListener.Address.GetSocketAddress().GetPortValue(), listener.Address.GetSocketAddress().GetPortValue())
 			require.Equal(t, tt.expectedListener.Address.GetSocketAddress().Protocol, listener.Address.GetSocketAddress().Protocol)
+
+			hcm, _, err := findHCM(listener.FilterChains[0])
+			require.NoError(t, err)
+			require.NotEmpty(t, hcm.AccessLog)
+			if tt.accessLogConfig != nil {
+				require.Len(t, hcm.AccessLog, len(tt.accessLogConfig))
+				for i := range tt.accessLogConfig {
+					require.Equal(t, tt.accessLogConfig[i].Name, hcm.AccessLog[i].Name)
+				}
+			} else {
+				require.Len(t, hcm.AccessLog, 1)
+				require.Equal(t, "envoy.access_loggers.file", hcm.AccessLog[0].Name)
+			}
 		})
 	}
 }
@@ -289,17 +322,19 @@ func TestServer_maybeUpdateMCPRoutes(t *testing.T) {
 
 func TestServer_extractMCPBackendFiltersFromMCPProxyListener(t *testing.T) {
 	tests := []struct {
-		name            string
-		listeners       []*listenerv3.Listener
-		expectedFilters []*httpconnectionmanagerv3.HttpFilter
+		name               string
+		listeners          []*listenerv3.Listener
+		expectedFilters    []*httpconnectionmanagerv3.HttpFilter
+		expectedAccessLogs []*accesslogv3.AccessLog
 	}{
 		{
-			name:            "no listeners",
-			listeners:       []*listenerv3.Listener{},
-			expectedFilters: nil,
+			name:               "no listeners",
+			listeners:          []*listenerv3.Listener{},
+			expectedFilters:    nil,
+			expectedAccessLogs: nil,
 		},
 		{
-			name: "listener with MCP backend filter",
+			name: "listener with MCP backend filter without access logs",
 			listeners: []*listenerv3.Listener{
 				{
 					Name: "test-listener",
@@ -327,13 +362,99 @@ func TestServer_extractMCPBackendFiltersFromMCPProxyListener(t *testing.T) {
 				{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter"},
 			},
 		},
+		{
+			name: "listener with MCP backend filter with access logs",
+			listeners: []*listenerv3.Listener{
+				{
+					Name: "test-listener1",
+					FilterChains: []*listenerv3.FilterChain{
+						{
+							Filters: []*listenerv3.Filter{
+								{
+									Name: wellknown.HTTPConnectionManager,
+									ConfigType: &listenerv3.Filter_TypedConfig{
+										TypedConfig: mustToAny(&httpconnectionmanagerv3.HttpConnectionManager{
+											StatPrefix: "http",
+											HttpFilters: []*httpconnectionmanagerv3.HttpFilter{
+												{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter"},
+												{Name: "envoy.filters.http.router"},
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "test-listener2",
+					FilterChains: []*listenerv3.FilterChain{
+						{
+							Filters: []*listenerv3.Filter{
+								{
+									Name: wellknown.HTTPConnectionManager,
+									ConfigType: &listenerv3.Filter_TypedConfig{
+										TypedConfig: mustToAny(&httpconnectionmanagerv3.HttpConnectionManager{
+											StatPrefix: "http",
+											HttpFilters: []*httpconnectionmanagerv3.HttpFilter{
+												{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter2"},
+												{Name: "envoy.filters.http.router"},
+											},
+											AccessLog: []*accesslogv3.AccessLog{
+												{Name: "listener2-accesslog1"},
+												{Name: "listener2-accesslog2"},
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "test-listener3",
+					FilterChains: []*listenerv3.FilterChain{
+						{
+							Filters: []*listenerv3.Filter{
+								{
+									Name: wellknown.HTTPConnectionManager,
+									ConfigType: &listenerv3.Filter_TypedConfig{
+										TypedConfig: mustToAny(&httpconnectionmanagerv3.HttpConnectionManager{
+											StatPrefix: "http",
+											HttpFilters: []*httpconnectionmanagerv3.HttpFilter{
+												{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter3"},
+												{Name: "envoy.filters.http.router"},
+											},
+											AccessLog: []*accesslogv3.AccessLog{
+												{Name: "listener3-accesslog1"},
+												{Name: "listener3-accesslog2"},
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFilters: []*httpconnectionmanagerv3.HttpFilter{
+				{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter"},
+				{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter2"},
+				{Name: internalapi.MCPPerBackendHTTPRouteFilterPrefix + "test-filter3"},
+			},
+			expectedAccessLogs: []*accesslogv3.AccessLog{
+				{Name: "listener2-accesslog1"},
+				{Name: "listener2-accesslog2"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Server{log: testr.New(t)}
-			filters := s.extractMCPBackendFiltersFromMCPProxyListener(tt.listeners)
+			filters, accessLogConfigs := s.extractMCPBackendFiltersFromMCPProxyListener(tt.listeners)
 			require.Empty(t, cmp.Diff(tt.expectedFilters, filters, protocmp.Transform()))
+			require.Empty(t, cmp.Diff(tt.expectedAccessLogs, accessLogConfigs, protocmp.Transform()))
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Previously, we only had access logs for the main gateway listeners, but not for the internal listener created to route requests to the upstream MCP servers.

This PR configures the access logs for the upstream MCP server listener with the same settings as the gateway access logs, to have logs for the MCP server upstream accesses. With this change, MCP upstream access logs will appear as well, and, if configured, the MCP metadata will also be present:

<details>
<summary>
<strong>Example initialize:</strong> We can see now the main POST request as well as the 2 initialize requests to the upstream MCP servers and the corresponding notifications.
</summary>

```json
{
  "bytes_received": 259,
  "bytes_sent": 329,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58117",
  "duration": 870,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "context7",
  "mcp_method": "initialize",
  "mcp_request_id": "9f518a27-08ab-4d01-92fd-5fd2b560957c",
  "mcp_session_id": null,
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:40:13.834Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-context7/rule/0",
  "upstream_host": "13.217.64.66:443",
  "upstream_local_address": "192.168.40.127:58119",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "98ad661e-080a-4ae2-bb62-efebdb2a248e"
}
{
  "bytes_received": 66,
  "bytes_sent": 0,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58117",
  "duration": 118,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "context7",
  "mcp_method": "notifications/initialized",
  "mcp_request_id": "<nil>",
  "mcp_session_id": null,
  "method": "POST",
  "response_code": 202,
  "start_time": "2025-10-08T10:40:14.706Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-context7/rule/0",
  "upstream_host": "13.217.64.66:443",
  "upstream_local_address": "192.168.40.127:58119",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "6b49ac24-6ec2-4291-a39f-0c6a31f06e61"
}
{
  "bytes_received": 259,
  "bytes_sent": 362,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58116",
  "duration": 1068,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "github",
  "mcp_method": "initialize",
  "mcp_request_id": "8c86794e-0f5e-472a-852b-92632d6aafc8",
  "mcp_session_id": null,
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:40:13.832Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-github/rule/0",
  "upstream_host": "140.82.114.21:443",
  "upstream_local_address": "192.168.40.127:58118",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp/readonly",
  "x-request-id": "b84bfe17-b783-47d7-b565-8ac0036101b6"
}
{
  "bytes_received": 66,
  "bytes_sent": 0,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58116",
  "duration": 211,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "github",
  "mcp_method": "notifications/initialized",
  "mcp_request_id": "<nil>",
  "mcp_session_id": "09f09ce2-e99a-4ef2-91e1-b1d4a161dd00",
  "method": "POST",
  "response_code": 202,
  "start_time": "2025-10-08T10:40:14.901Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-github/rule/0",
  "upstream_host": "140.82.114.21:443",
  "upstream_local_address": "192.168.40.127:58118",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp/readonly",
  "x-request-id": "2891fff9-2130-4a61-8f1e-5ee774e19856"
}
{
  "bytes_received": 222,
  "bytes_sent": 317,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:1975",
  "downstream_remote_address": "127.0.0.1:58114",
  "duration": 1325,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": null,
  "mcp_method": null,
  "mcp_request_id": null,
  "mcp_session_id": null,
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:40:13.829Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-main-mcp-route/rule/0",
  "upstream_host": "127.0.0.1:9856",
  "upstream_local_address": "127.0.0.1:58115",
  "upstream_transport_failure_reason": null,
  "user-agent": "node-fetch",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "b12dac6e-b1f0-4af2-b500-3a89cc053c3d"
}
```
</details>

<details>
<summary>
<strong>Example tool list:</strong> We can see now the main POST request as well as the 2 tool list requests to the upstream MCP servers.
</summary>

```json
{
  "bytes_received": 85,
  "bytes_sent": 2709,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58116",
  "duration": 701,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "context7",
  "mcp_method": "tools/list",
  "mcp_request_id": "2",
  "mcp_session_id": "",
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:41:19.100Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-context7/rule/0",
  "upstream_host": "13.217.64.66:443",
  "upstream_local_address": "192.168.40.127:58149",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "4e857bd1-7c11-483d-91d3-d06cd905fea6"
}
{
  "bytes_received": 85,
  "bytes_sent": 46095,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58124",
  "duration": 1112,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "github",
  "mcp_method": "tools/list",
  "mcp_request_id": "2",
  "mcp_session_id": "09f09ce2-e99a-4ef2-91e1-b1d4a161dd00",
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:41:19.100Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-github/rule/0",
  "upstream_host": "140.82.113.21:443",
  "upstream_local_address": "192.168.40.127:58148",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp/readonly",
  "x-request-id": "2ed28447-cdee-4570-a1b4-91a2470b4408"
}
{
  "bytes_received": 85,
  "bytes_sent": 4550,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:1975",
  "downstream_remote_address": "127.0.0.1:58122",
  "duration": 1193,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": null,
  "mcp_method": null,
  "mcp_request_id": null,
  "mcp_session_id": "LEUnsU/tza7AVbVNwuyF7Kt6e6I+r0IpgzJughZNn+RAHOwtcIN16vyUZgERIFA+iktVrP8mshIsd1MBBxgtM7ibTiOWJNZsRK/hFtB+yP8INego+Txfy9RoLzFsHm/vV6aACb6P+AHVZgz86EKne73VzcPLDTIcy2N2f7SgUkU=",
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:41:19.065Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-main-mcp-route/rule/0",
  "upstream_host": "127.0.0.1:9856",
  "upstream_local_address": "127.0.0.1:58123",
  "upstream_transport_failure_reason": null,
  "user-agent": "node-fetch",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "e62b8491-b32d-434f-9ff9-caf0f4bab4d1"
}
```
</details>

<details>
<summary>
<strong>Example tool call:</strong> We can see now the main POST request as well as the tool call to the upstream MCP server.
</summary>

```json
{
  "bytes_received": 165,
  "bytes_sent": 10255,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:10088",
  "downstream_remote_address": "127.0.0.1:58124",
  "duration": 653,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": "context7",
  "mcp_method": "tools/call",
  "mcp_request_id": "3",
  "mcp_session_id": null,
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:42:11.430Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-br-mcp-route-context7/rule/0",
  "upstream_host": "13.217.64.66:443",
  "upstream_local_address": "192.168.40.127:58172",
  "upstream_transport_failure_reason": null,
  "user-agent": "Go-http-client/1.1",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "cf2c0454-6290-498e-af6c-e32a611b5da1"
}
{
  "bytes_received": 175,
  "bytes_sent": 10350,
  "connection_termination_details": null,
  "downstream_local_address": "127.0.0.1:1975",
  "downstream_remote_address": "127.0.0.1:58122",
  "duration": 725,
  "genai_backend_name": null,
  "genai_model_name": null,
  "genai_model_name_override": null,
  "genai_tokens_input": null,
  "genai_tokens_output": null,
  "mcp_backend": null,
  "mcp_method": null,
  "mcp_request_id": null,
  "mcp_session_id": "LEUnsU/tza7AVbVNwuyF7Kt6e6I+r0IpgzJughZNn+RAHOwtcIN16vyUZgERIFA+iktVrP8mshIsd1MBBxgtM7ibTiOWJNZsRK/hFtB+yP8INego+Txfy9RoLzFsHm/vV6aACb6P+AHVZgz86EKne73VzcPLDTIcy2N2f7SgUkU=",
  "method": "POST",
  "response_code": 200,
  "start_time": "2025-10-08T10:42:11.399Z",
  "upstream_cluster": "httproute/default/ai-eg-mcp-main-mcp-route/rule/0",
  "upstream_host": "127.0.0.1:9856",
  "upstream_local_address": "127.0.0.1:58123",
  "upstream_transport_failure_reason": null,
  "user-agent": "node-fetch",
  "x-envoy-origin-path": "/mcp",
  "x-request-id": "fc253d7b-2c80-4fa6-972e-3d8aae25be29"
}
```
</details>

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
