### PR TITLE
test(mcp): drops learn-microsoft as it's flaky 

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -39,8 +39,6 @@ Then, you can use the MCP Inspector to interact with the MCP Proxy:
 $ npx @modelcontextprotocol/inspector --cli http://localhost:1975/mcp --transport http --method 'tools/list' | jq '.tools[] | .name'
 "context7__resolve-library-id"
 "context7__get-library-docs"
-"learn-microsoft__microsoft_docs_search"
-"learn-microsoft__microsoft_docs_fetch"
 "aws-knowledge__aws___search_documentation"
 "github__get_pull_request"
 "kiwi__search-flight"

--- a/examples/mcp/mcp_example.yaml
+++ b/examples/mcp/mcp_example.yaml
@@ -28,13 +28,6 @@ spec:
         apiKey:
           secretRef:
             name: github-access-token
-    - name: learn-microsoft
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/api/mcp"
-      toolSelector:
-        includeRegex:
-          - .*microsoft_docs?.*
     - name: context7
       kind: Backend
       group: gateway.envoyproxy.io
@@ -162,31 +155,6 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: mcp.context7.com
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: learn-microsoft
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: learn.microsoft.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: learn-microsoft-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: learn-microsoft
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: learn.microsoft.com
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/examples/mcp/mcp_oauth_example.yaml
+++ b/examples/mcp/mcp_oauth_example.yaml
@@ -17,13 +17,6 @@ spec:
       kind: Gateway
       group: gateway.networking.k8s.io
   backendRefs:
-    - name: learn-microsoft
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/api/mcp"
-      toolSelector:
-        includeRegex:
-          - .*microsoft_docs?.*
     - name: context7
       kind: Backend
       group: gateway.envoyproxy.io
@@ -136,31 +129,6 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: mcp.context7.com
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: learn-microsoft
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: learn.microsoft.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: learn-microsoft-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: learn-microsoft
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: learn.microsoft.com
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/examples/mcp/mcp_oauth_keycloak.yaml
+++ b/examples/mcp/mcp_oauth_keycloak.yaml
@@ -39,10 +39,6 @@ spec:
             "email",
           ]
   backendRefs:
-    - name: learn-microsoft
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/api/mcp"
     - name: kiwi
       kind: Backend
       group: gateway.envoyproxy.io
@@ -101,31 +97,6 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: mcp.context7.com
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: learn-microsoft
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: learn.microsoft.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: learn-microsoft-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: learn-microsoft
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: learn.microsoft.com
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/tests/e2e-aigw/examples_test.go
+++ b/tests/e2e-aigw/examples_test.go
@@ -38,8 +38,6 @@ var (
 		"context7__resolve-library-id",
 		"kiwi__feedback-to-devs",
 		"kiwi__search-flight",
-		"learn-microsoft__microsoft_docs_fetch",
-		"learn-microsoft__microsoft_docs_search",
 	}
 	allGithubTools = []string{
 		"github__get_issue",
@@ -70,8 +68,6 @@ var (
 		"context7__resolve-library-id",
 		"kiwi__feedback-to-devs",
 		"kiwi__search-flight",
-		"learn-microsoft__microsoft_docs_fetch",
-		"learn-microsoft__microsoft_docs_search",
 	}
 	filteredAllTools = []string{
 		"aws-knowledge__aws___read_documentation",
@@ -94,8 +90,6 @@ var (
 		"github__search_pull_requests",
 		"kiwi__feedback-to-devs",
 		"kiwi__search-flight",
-		"learn-microsoft__microsoft_docs_fetch",
-		"learn-microsoft__microsoft_docs_search",
 	}
 )
 

--- a/tests/extproc/mcp/envoy.yaml
+++ b/tests/extproc/mcp/envoy.yaml
@@ -125,17 +125,6 @@ static_resources:
                             headers:
                               - name: x-ai-eg-mcp-backend
                                 string_match:
-                                  exact: learn-microsoft
-                          route:
-                            autoHostRewrite: true
-                            cluster: learn-microsoft
-                            idleTimeout: 3600s
-                            timeout: 120s
-                        - match:
-                            prefix: "/"
-                            headers:
-                              - name: x-ai-eg-mcp-backend
-                                string_match:
                                   exact: context7
                           route:
                             autoHostRewrite: true
@@ -248,26 +237,6 @@ static_resources:
                     socket_address:
                       address: 127.0.0.1
                       port_value: 8080
-
-    - name: learn-microsoft
-      connect_timeout: 30s
-      dns_lookup_family: V4_ONLY
-      type: STRICT_DNS
-      load_assignment:
-        cluster_name: learn-microsoft
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  hostname: learn.microsoft.com
-                  address:
-                    socket_address:
-                      address: learn.microsoft.com
-                      port_value: 443
-      transport_socket:
-        name: envoy.transport_sockets.tls
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          auto_host_sni: true
 
     - name: context7
       connect_timeout: 30s

--- a/tests/extproc/mcp/publicmcp_test.go
+++ b/tests/extproc/mcp/publicmcp_test.go
@@ -28,13 +28,6 @@ func TestPublicMCPServers(t *testing.T) {
 			{
 				Name: "test-route",
 				Backends: []filterapi.MCPBackend{
-					{
-						Name: "learn-microsoft",
-						Path: "/api/mcp",
-						ToolSelector: &filterapi.MCPToolSelector{
-							IncludeRegex: []string{".*microsoft_docs?.*"},
-						},
-					},
 					{Name: "context7", Path: "/mcp"},
 					{
 						Name: "aws-knowledge",
@@ -95,8 +88,6 @@ func TestPublicMCPServers(t *testing.T) {
 		}
 
 		exps := []string{
-			"learn-microsoft__microsoft_docs_search",
-			"learn-microsoft__microsoft_docs_fetch",
 			"context7__resolve-library-id",
 			"context7__get-library-docs",
 			"kiwi__search-flight",
@@ -134,19 +125,6 @@ func TestPublicMCPServers(t *testing.T) {
 			params   map[string]any
 		}
 		tests := []callToolTest{
-			{
-				toolName: "learn-microsoft__microsoft_docs_search",
-				params: map[string]any{
-					"query":    "microsoft 365",
-					"question": "What does microsoft 365 include?",
-				},
-			},
-			{
-				toolName: "learn-microsoft__microsoft_docs_fetch",
-				params: map[string]any{
-					"url": "https://learn.microsoft.com/en-us/copilot/manage",
-				},
-			},
 			{
 				toolName: "context7__resolve-library-id",
 				params: map[string]any{


### PR DESCRIPTION
**Description**

Learn Microsoft MCP server is flaky in the sense that it's unreliable implementation: it _sometimes_ return 405 for exactly the same requests which previously returns 200. This removes our test dependence on it.