### PR TITLE
fix: remove aws knowledge MCP server

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -39,28 +39,8 @@ Then, you can use the MCP Inspector to interact with the MCP Proxy:
 $ npx @modelcontextprotocol/inspector --cli http://localhost:1975/mcp --transport http --method 'tools/list' | jq '.tools[] | .name'
 "context7__resolve-library-id"
 "context7__get-library-docs"
-"aws-knowledge__aws___search_documentation"
 "github__get_pull_request"
 "kiwi__search-flight"
-
-# Different MCP path is configured by a different MCPRoute in the same Gateway.
-$ npx @modelcontextprotocol/inspector --cli http://localhost:1975/mcp/custom/path --transport http --method 'tools/list' | jq '.tools[] | .name'
-"aws-knowledge__aws___read_documentation
-```
-
-### Search AWS Documentation
-
-```
-$ npx @modelcontextprotocol/inspector --cli http://localhost:1975/mcp --transport http --method tools/call --tool-name aws-knowledge__aws___search_documentation --tool-arg search_phrase="DynamoDB global index" --tool-arg limit=5
-{
-  "content": [
-    {
-      "type": "text",
-      "text": "{\"content\":{\"result\":[{\"rank_order\":1,\"url\":\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GCICli.html\",\"title\":\"Working with Global Secondary Indexes in DynamoDB using AWS CLI - Amazon DynamoDB\",\"context\":\"Create a table with one or more global secondary indexes in DynamoDB using the AWS CLI.\"},{\"rank_order\":2,\"url\":\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html\",\"title\":\"Using Global Secondary Indexes in DynamoDB - Amazon DynamoDB\",\"context\":\"Use global secondary indexes to perform alternate queries from the base DynamoDB table to model your application's various access patterns.\"},{\"rank_order\":3,\"url\":\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html\",\"title\":\"Core components of Amazon DynamoDB - Amazon DynamoDB\",\"context\":\"Learn about the building blocks of DynamoDB your app will need. You'll discover the basics of tables, items, attributes, and how they work together to make a database for any scale you may need.\"},{\"rank_order\":4,\"url\":\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html\",\"title\":\"What is Amazon DynamoDB? - Amazon DynamoDB\",\"context\":\"Use DynamoDB, a fully managed NoSQL database service to store and retrieve any amount of data, and serve any level of request traffic.\"},{\"rank_order\":5,\"url\":\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GlobalTables.html\",\"title\":\"Global tables - multi-active, multi-Region replication - Amazon DynamoDB\",\"context\":\"DynamoDB global tables provide multi-Region, multi-active database replication for fast, localized performance and high availability in global applications.\"}]}}"
-    }
-  ],
-  "isError": false
-}
 ```
 
 ### Accessing GitHub Pull Request Info

--- a/examples/mcp/mcp_example.yaml
+++ b/examples/mcp/mcp_example.yaml
@@ -32,38 +32,10 @@ spec:
       kind: Backend
       group: gateway.envoyproxy.io
       path: "/mcp"
-    - name: aws-knowledge
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/"
-      toolSelector:
-        include:
-          - aws___read_documentation
-          - aws___search_documentation
     - name: kiwi
       kind: Backend
       group: gateway.envoyproxy.io
       path: "/"
----
-apiVersion: aigateway.envoyproxy.io/v1alpha1
-kind: MCPRoute
-metadata:
-  name: mcp-route-custom-path
-  namespace: default
-spec:
-  parentRefs:
-    - name: aigw-run
-      kind: Gateway
-      group: gateway.networking.k8s.io
-  path: "/mcp/custom/path"
-  backendRefs:
-    - name: aws-knowledge
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/"
-      toolSelector:
-        include:
-          - aws___read_documentation
 ---
 kind: Secret
 apiVersion: v1
@@ -155,31 +127,6 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: mcp.context7.com
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: aws-knowledge
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: knowledge-mcp.global.api.aws
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: aws-knowledge-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: aws-knowledge
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: knowledge-mcp.global.api.aws
 ---
 ###################################################################################
 ############################### Gateway Definitions ###############################

--- a/examples/mcp/mcp_oauth_example.yaml
+++ b/examples/mcp/mcp_oauth_example.yaml
@@ -21,10 +21,6 @@ spec:
       kind: Backend
       group: gateway.envoyproxy.io
       path: "/mcp"
-    - name: aws-knowledge
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/"
     - name: kiwi
       kind: Backend
       group: gateway.envoyproxy.io
@@ -129,31 +125,6 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: mcp.context7.com
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: aws-knowledge
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: knowledge-mcp.global.api.aws
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: aws-knowledge-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: aws-knowledge
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: knowledge-mcp.global.api.aws
 ---
 ###################################################################################
 ############################### Gateway Definitions ###############################

--- a/examples/mcp/mcp_oauth_keycloak.yaml
+++ b/examples/mcp/mcp_oauth_keycloak.yaml
@@ -98,31 +98,6 @@ spec:
     wellKnownCACertificates: "System"
     hostname: mcp.context7.com
 ---
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: aws-knowledge
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: knowledge-mcp.global.api.aws
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: aws-knowledge-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: aws-knowledge
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: knowledge-mcp.global.api.aws
----
 ###################################################################################
 ############################### Gateway Definitions ###############################
 ###################################################################################

--- a/site/docs/capabilities/mcp/index.md
+++ b/site/docs/capabilities/mcp/index.md
@@ -201,14 +201,6 @@ spec:
       kind: Backend
       group: gateway.envoyproxy.io
       path: "/mcp"
-    - name: aws-knowledge
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/"
-      toolSelector:
-        include:
-          - aws___read_documentation
-          - aws___search_documentation
 ```
 
 Clients will see all tools with prefixed names:
@@ -217,8 +209,6 @@ Clients will see all tools with prefixed names:
 - `github__list_issues`
 - `context7__resolve-library-id`
 - `context7__get-library-docs`
-- `aws-knowledge__aws___read_documentation`
-- `aws-knowledge__aws___search_documentation`
 
 ### OAuth Authentication
 

--- a/tests/e2e-aigw/examples_test.go
+++ b/tests/e2e-aigw/examples_test.go
@@ -29,11 +29,6 @@ var (
 	// Adjust these as services update, as they can be added, removed or renamed
 
 	allNonGithubTools = []string{
-		"aws-knowledge__aws___get_regional_availability",
-		"aws-knowledge__aws___list_regions",
-		"aws-knowledge__aws___read_documentation",
-		"aws-knowledge__aws___recommend",
-		"aws-knowledge__aws___search_documentation",
 		"context7__get-library-docs",
 		"context7__resolve-library-id",
 		"kiwi__feedback-to-devs",
@@ -62,16 +57,12 @@ var (
 
 	// Filtered tools based on mcp_example.yaml selectors
 	filteredNonGithubTools = []string{
-		"aws-knowledge__aws___read_documentation",
-		"aws-knowledge__aws___search_documentation",
 		"context7__get-library-docs",
 		"context7__resolve-library-id",
 		"kiwi__feedback-to-devs",
 		"kiwi__search-flight",
 	}
 	filteredAllTools = []string{
-		"aws-knowledge__aws___read_documentation",
-		"aws-knowledge__aws___search_documentation",
 		"context7__get-library-docs",
 		"context7__resolve-library-id",
 		"github__get_issue",
@@ -144,13 +135,6 @@ func TestMCP_standalone(t *testing.T) {
 				toolName: "context7__get-library-docs",
 				params: map[string]any{
 					"context7CompatibleLibraryID": "/mongodb/docs",
-				},
-			},
-			{
-				toolName: "aws-knowledge__aws___search_documentation",
-				params: map[string]any{
-					"limit":         1,
-					"search_phrase": "DynamoDB",
 				},
 			},
 			{

--- a/tests/e2e-aigw/mcp_include.go
+++ b/tests/e2e-aigw/mcp_include.go
@@ -58,8 +58,7 @@ func includeSelectedTools(yamlPath string, allTools []string) []string {
 
 	// Build map of backend name -> list of selectors.
 	// We collect ALL selectors because multiple MCPRoute documents can reference
-	// the same backend with different filters (e.g., one route might include
-	// only "aws___read_documentation" while another includes "aws___search_documentation").
+	// the same backend with different filters.
 	backends := make(map[string][]*toolSelector)
 
 	for {
@@ -87,7 +86,7 @@ func includeSelectedTools(yamlPath string, allTools []string) []string {
 	for _, fullTool := range allTools {
 		// Extract backend and tool name from "backend__toolname" format.
 		// We iterate through known backends to handle backends with dashes or underscores
-		// in their names (e.g., "aws-knowledge").
+		// in their names.
 		var backend, tool string
 		for backendName := range backends {
 			prefix := backendName + "__"

--- a/tests/extproc/mcp/envoy.yaml
+++ b/tests/extproc/mcp/envoy.yaml
@@ -151,17 +151,6 @@ static_resources:
                             headers:
                               - name: x-ai-eg-mcp-backend
                                 string_match:
-                                  exact: aws-knowledge
-                          route:
-                            autoHostRewrite: true
-                            cluster: aws-knowledge
-                            idleTimeout: 3600s
-                            timeout: 120s
-                        - match:
-                            prefix: "/"
-                            headers:
-                              - name: x-ai-eg-mcp-backend
-                                string_match:
                                   exact: kiwi
                           route:
                             autoHostRewrite: true
@@ -271,26 +260,6 @@ static_resources:
                   address:
                     socket_address:
                       address: api.githubcopilot.com
-                      port_value: 443
-      transport_socket:
-        name: envoy.transport_sockets.tls
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          auto_host_sni: true
-
-    - name: aws-knowledge
-      connect_timeout: 30s
-      type: STRICT_DNS
-      dns_lookup_family: V4_ONLY
-      load_assignment:
-        cluster_name: aws-knowledge
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  hostname: knowledge-mcp.global.api.aws
-                  address:
-                    socket_address:
-                      address: knowledge-mcp.global.api.aws
                       port_value: 443
       transport_socket:
         name: envoy.transport_sockets.tls

--- a/tests/extproc/mcp/publicmcp_test.go
+++ b/tests/extproc/mcp/publicmcp_test.go
@@ -29,13 +29,6 @@ func TestPublicMCPServers(t *testing.T) {
 				Name: "test-route",
 				Backends: []filterapi.MCPBackend{
 					{Name: "context7", Path: "/mcp"},
-					{
-						Name: "aws-knowledge",
-						Path: "/",
-						ToolSelector: &filterapi.MCPToolSelector{
-							Include: []string{"aws___read_documentation", "aws___search_documentation"},
-						},
-					},
 					{Name: "kiwi", Path: "/"},
 				},
 			},
@@ -92,8 +85,6 @@ func TestPublicMCPServers(t *testing.T) {
 			"context7__get-library-docs",
 			"kiwi__search-flight",
 			"kiwi__feedback-to-devs",
-			"aws-knowledge__aws___read_documentation",
-			"aws-knowledge__aws___search_documentation",
 		}
 
 		if githubConfigured {
@@ -135,13 +126,6 @@ func TestPublicMCPServers(t *testing.T) {
 				toolName: "context7__get-library-docs",
 				params: map[string]any{
 					"context7CompatibleLibraryID": "/mongodb/docs",
-				},
-			},
-			{
-				toolName: "aws-knowledge__aws___search_documentation",
-				params: map[string]any{
-					"limit":         1,
-					"search_phrase": "DynamoDB",
 				},
 			},
 			{


### PR DESCRIPTION
**Description**

AWS knowledge MCP server is subject to rate limits which causes flakey tests.

If we need another public MCP, there are 39 others not including shopify sites.


**Related Issues/PRs (if applicable)**
Fixes #1320 