### PR TITLE
docs(api): ensure optional attributes on optional fields for MCP CRDs

### DIFF
--- a/api/v1alpha1/mcp_route.go
+++ b/api/v1alpha1/mcp_route.go
@@ -107,6 +107,7 @@ type MCPRouteBackendRef struct {
 	// Supports exact matches and RE2-compatible regular expressions for both include and exclude patterns.
 	// If not specified, all tools from the MCP server are exposed.
 	// +kubebuilder:validation:Optional
+	// +optional
 	ToolSelector *MCPToolFilter `json:"toolSelector,omitempty"`
 
 	// TODO: we can add resource and prompt selectors in the future.

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -1468,7 +1468,7 @@ MCPRouteBackendRef wraps a EG's BackendObjectReference to reference an MCP serve
 /><ApiField
   name="toolSelector"
   type="[MCPToolFilter](#mcptoolfilter)"
-  required="true"
+  required="false"
   description="ToolSelector filters the tools exposed by this MCP server.<br />Supports exact matches and RE2-compatible regular expressions for both include and exclude patterns.<br />If not specified, all tools from the MCP server are exposed."
 /><ApiField
   name="securityPolicy"


### PR DESCRIPTION
**Description**

This backfills "+optional" attribute on the fields on MCP CRDs to ensure that they are marked optional on the generated documentation.
