### PR TITLE
fix: fix very bad poll interval which causes test flakes

### DIFF
--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -224,7 +224,7 @@ func run(ctx context.Context, c cmdRun, o runOpts, stdout, stderr io.Writer) err
 			return
 		}
 		debugLogger.Info("Found Envoy admin server", "adminPort", envoyAdmin.Port())
-		if err = pollEnvoyReady(ctx, debugLogger, envoyAdmin, 2*time.Second); err != nil {
+		if err = pollEnvoyReady(ctx, debugLogger, envoyAdmin, 100*time.Millisecond); err != nil {
 			return
 		}
 		c.AdminPort = envoyAdminPort // write back for testing


### PR DESCRIPTION
**Description**

Probably was me who accidentally committed a *2 Second* poll interval for envoy readiness which causes our integration tests to fail, as the status message didn't appear promptly.