### PR TITLE
ci: add missing EG_VERSION env var in inference e2e

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -294,20 +294,12 @@ jobs:
   test_e2e_inference_extension:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
-    name: E2E Test for Inference Extensions (Envoy Gateway ${{ matrix.name }})
+    name: E2E Test for Inference Extensions
     # TODO: make it possible to run this job on macOS as well, which is a bit tricky due to the nested
     # virtualization is not supported on macOS runners.
     # E.g. Use https://github.com/douglascamata/setup-docker-macos-action  per the comment in
     # https://github.com/actions/runner-images/issues/17#issuecomment-1971073406
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: latest
-            envoy_gateway_version: v0.0.0-latest
-          - name: v1.5.0
-            envoy_gateway_version: v1.5.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -325,7 +317,9 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - run: make test-e2e-inference-extension
         env:
-          EG_VERSION: ${{ matrix.envoy_gateway_version }}
+          # We only need to test with the latest stable version of EG, since these e2e tests
+          # do not depend on the EG version.
+          EG_VERSION: v1.5.0
 
   test_e2e_aigw:
     needs: changes


### PR DESCRIPTION
**Description**

Add the missing environment variable to force the EG version to use in the inference e2e tests.

@mathetake @Xunzhuo am I reading it wrong or this env var was missing and the tests were running twice against the same EG version?

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
