### PR TITLE
test: use aigw also for llm in goose e2e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/envoyproxy/ai-gateway
 
 // Explicitly specify the Go patch version to be able to purge the CI cache correctly.
-go 1.25.1
+go 1.25.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/tests/e2e-aigw/examples_test.go
+++ b/tests/e2e-aigw/examples_test.go
@@ -82,7 +82,7 @@ func TestMCP_standalone(t *testing.T) {
 	}
 
 	exampleYaml := path.Join(examplesDir, "mcp_example.yaml")
-	startAIGWCLI(t, aigwBin, "run", "--debug", exampleYaml)
+	startAIGWCLI(t, aigwBin, nil, "run", "--debug", exampleYaml)
 
 	url := fmt.Sprintf("http://localhost:%d/mcp", 1975)
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "public-mcp-client", Version: "0.1.0"}, &mcp.ClientOptions{})
@@ -187,7 +187,7 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestMCP_standalone_oauth(t *testing.T) {
-	startAIGWCLI(t, aigwBin, "run", "--debug", path.Join(examplesDir, "mcp_oauth_example.yaml"))
+	startAIGWCLI(t, aigwBin, nil, "run", "--debug", path.Join(examplesDir, "mcp_oauth_example.yaml"))
 
 	url := fmt.Sprintf("http://localhost:%d/mcp", 1975)
 

--- a/tests/e2e-aigw/testdata/kiwi_recipe.yaml
+++ b/tests/e2e-aigw/testdata/kiwi_recipe.yaml
@@ -31,6 +31,18 @@ prompt: |
 
   ***********ANY FLIGHT IS FINE. DO NOT CONSIDER ANY USER PREFERENCES.************
 
+# Start aigw like this to use Ollama and Kiwi MCP backends:
+# OPENAI_BASE_URL=http://localhost:11434/v1 OPENAI_API_KEY=unused aigw run --mcp-json '{
+#   "mcpServers": {
+#     "kiwi": {
+#       "type": "http",
+#       "url": "https://mcp.kiwi.com"
+#     }
+#   }
+# }'
+#
+# Then, run goose like this to use Envoy AI Gateway for both LLM and MCP:
+# OPENAI_HOST=http://127.0.0.1:1975 OPENAI_API_KEY=test-key goose run --provider openai --model qwen3:1.7b --recipe kiwi_recipe.yaml --params flight_date=31/12/2025
 extensions:
   - name: mcp_gateway
     type: streamable_http
@@ -41,11 +53,10 @@ parameters:
     input_type: string
     requirement: required
     description: flight date in DD/MM/YYYY format
-    default: "01/10/2025"
+    default: "31/12/2025"
 
 settings:
-  goose_provider: ollama
-  goose_model: qwen3:0.6b
+  # Remove this if using GPT-5 series (e.g., gpt-5, gpt-5-mini, gpt-5-nano)
   temperature: 0.0
 
 response:


### PR DESCRIPTION
**Description**

Before, our goose test only went through aigw for MCP instead of proving single agent origin works, by also using it for LLM. Now.. we're good.