### PR TITLE
docs: metrics enrichment with custom headers

### DIFF
--- a/site/docs/capabilities/observability/metrics.md
+++ b/site/docs/capabilities/observability/metrics.md
@@ -40,9 +40,13 @@ Each metric comes with some default attributes such as:
 - `gen_ai.request.model` - The model name requested (may be overridden)
 - `gen_ai.response.model` - The model name returned in the response
 - `gen_ai.provider.name` - The provider name (e.g., `openai`, `anthropic`)
+
 :::tip
+
 You can enrich the metrics with custom labels extracted from HTTP request headers. It can be configured via the `controller.metricsRequestHeaderAttributes` helm installation value. Please refer to [values.yaml](https://github.com/envoyproxy/ai-gateway/blob/main/manifests/charts/ai-gateway-helm/values.yaml) for more details including other configurations.
+
 :::
+
 ## Trying it out
 
 Before you begin, you'll need to complete the basic setup from the [Basic Usage](/docs/getting-started/basic-usage) guide.


### PR DESCRIPTION
**Description**

https://github.com/envoyproxy/ai-gateway/pull/981/files

After inspecting this PR I found out how to add custom headers as metric labels. This is a small update to the documentation on how to pass the configuration during install.

**Related Issues/PRs (if applicable)**

Related PR: #981


