### PR TITLE
test: deflake pprof/TestRun_enabled

### DIFF
--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -7,38 +7,53 @@ package pprof
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
 )
 
 func TestRun_disabled(t *testing.T) {
 	t.Setenv(DisableEnvVarKey, "anything")
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	Run(ctx)
 	// Try accessing the pprof server here if needed.
 	response, err := http.Get("http://localhost:6060/debug/pprof/") //nolint:bodyclose
 	require.Error(t, err)
 	require.Nil(t, response)
-	cancel()
 }
 
 func TestRun_enabled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	Run(ctx)
-	// Try accessing the pprof server here if needed.
-	resp, err := http.Get("http://localhost:6060/debug/pprof/cmdline")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, resp.Body.Close())
-	}()
-	require.NotNil(t, resp)
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(body),
+	// Use eventually to avoid flake when the server is not yet started by the time we access it.
+	internaltesting.RequireEventuallyNoError(t, func() error {
+		resp, err := http.Get("http://localhost:6060/debug/pprof/cmdline")
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
 		// Test binary name should be present in the cmdline output.
-		"pprof.test")
-	cancel()
+		if !strings.Contains(string(body), "pprof.test") {
+			return fmt.Errorf("unexpected body: %s", string(body))
+		}
+		return nil
+	}, 3*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
**Description**

This fixes the flaky pprof/TestRun_enabled test.

```
mathetake@mathetake-Venus-series:~/envoy-ai-gateway$ uname -mo
x86_64 GNU/Linux
mathetake@mathetake-Venus-series:~/envoy-ai-gateway$ go test ./internal/pprof/ -race -count=100
ok      github.com/envoyproxy/ai-gateway/internal/pprof 1.937s
```

```
~/envoy-ai-gateway deflakerun
>> uname -mo       
Darwin arm64

~/envoy-ai-gateway deflakerun
>> go test ./internal/pprof/ -race -count=100    
ok      github.com/envoyproxy/ai-gateway/internal/pprof 1.544s
```