### PR TITLE
docs: show all posts in the blog sidebar

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -120,6 +120,8 @@ const config: Config = {
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',
           onUntruncatedBlogPosts: 'warn',
+          blogSidebarTitle: 'Blog posts',
+          blogSidebarCount: 'ALL',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
**Description**

Configure docusaurus to show all posts in the sidebar.

**Related Issues/PRs (if applicable)**

Fixes https://github.com/envoyproxy/ai-gateway/issues/1426

**Special notes for reviewers (if applicable)**

N/A
