### PR TITLE
fix: on retry preserve removed headers locally for metrics while still stripping them upstream

### DIFF
--- a/internal/extproc/headermutator/header_mutator_test.go
+++ b/internal/extproc/headermutator/header_mutator_test.go
@@ -69,14 +69,16 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 
 		require.NotNil(t, mutation)
 		require.ElementsMatch(t, []string{"authorization", "only-set-previously"}, mutation.RemoveHeaders)
-		require.Len(t, mutation.SetHeaders, 5)
+		require.Len(t, mutation.SetHeaders, 4)
 		setHeadersMap := make(map[string]string)
 		for _, h := range mutation.SetHeaders {
 			setHeadersMap[h.Header.Key] = string(h.Header.RawValue)
 		}
 		require.Equal(t, "key123", setHeadersMap["x-api-key"])
 		require.Equal(t, "value", setHeadersMap["other"])
-		require.Equal(t, "secret", setHeadersMap["authorization"])
+		// Removed header should not be added back via SetHeaders on retry
+		_, ok := setHeadersMap["authorization"]
+		require.False(t, ok)
 		require.Equal(t, "original", setHeadersMap["only-in-original"])
 		require.Equal(t, "pikachu", setHeadersMap["in-original-too-but-previous-attempt-set"])
 		// Check the final headers map too.


### PR DESCRIPTION
**Description**
On retry, the header mutator suppressed restoring values needed for metrics if the header was in removeHeaders and also listed in metricsRequestHeaderAttributes. Also, the retry cleanup logic didn’t account for headers flagged for removal, potentially re-setting them incorrectly.
Changes:
- Always restore the original header value into the local headers map on retry if it’s not already present and not currently being set, even if it is configured in removeHeaders. This guarantees metrics can read it.
- Do not add those removed headers back to SetHeaders on retry, so they are still stripped before forwarding upstream.
- In the retry cleanup pass, skip keys that are either being set now or configured for removal, preventing accidental re-setting or redundant remove operations.

