### PR TITLE
test: force deletion on cleanup

### DIFF
--- a/tests/internal/e2elib/e2elib.go
+++ b/tests/internal/e2elib/e2elib.go
@@ -501,7 +501,7 @@ func KubectlApplyManifestStdin(ctx context.Context, manifest string) (err error)
 
 // KubectlDeleteManifest deletes the given manifest using kubectl.
 func KubectlDeleteManifest(ctx context.Context, manifest string) (err error) {
-	cmd := Kubectl(ctx, "delete", "-f", manifest)
+	cmd := Kubectl(ctx, "delete", "-f", manifest, "--force=true")
 	return cmd.Run()
 }
 


### PR DESCRIPTION
**Description**

In e2e, we cleanup resources for faster iterations when the resource is constrained such as on GHA. To make it faster and less flaky, this commit adds "force=true" flag to the deletion, which is safe anyways since it's only used in tests.