### PR TITLE
chore: adds 'watch' verb into inference pool reader cluster role

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/envoy_gateway_cluster_role_for_inference_pool.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/envoy_gateway_cluster_role_for_inference_pool.yaml
@@ -19,6 +19,7 @@ rules:
     verbs:
       - "get"
       - "list"
+      - "watch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description**

In #1377, we dropped a few verbs from the RBAC for EG to read inference pools. Although the tests have been passing, EG was emitting errors saying the 'watch' verb was missing in its role.

> Failed to watch {"runner": "provider", "reflector": "pkg/mod/k8s.io/client-go@v0.34.1/tools/cache/reflector.go:290", "type": "inference.networking.k8s.io/v1, Kind=InferencePool", "error": "inferencepools.inference.networking.k8s.io is forbidden: User "system:serviceaccount:envoy-gateway-system:envoy-gateway" cannot watch resource "inferencepools" in API group "inference.networking.k8s.io" at the cluster scope"}

So this commit brings it back to the generated ClusterRole.

**Related Issues/PRs (if applicable)**

Closes #1472 