### PR TITLE
fix: ai gateway mutating webhook should default failurePolicy to Fail

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/admission_webhook.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/admission_webhook.yaml
@@ -30,7 +30,7 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 10
-    failurePolicy: Ignore
+    failurePolicy: Fail
 ---
 {{- if .Values.controller.mutatingWebhook.certManager.enable }}
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
**Description**


-  ai gateway mutating webhook should default failurePolicy to Fail

**Related Issues/PRs (if applicable)**

fixes: https://github.com/envoyproxy/ai-gateway/issues/1493

**Special notes for reviewers (if applicable)**


