### PR TITLE
cli: align on apigroup for backendtlspolicy

### DIFF
--- a/cmd/aigw/translate.go
+++ b/cmd/aigw/translate.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gwapiv1a3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 	kyaml "sigs.k8s.io/yaml"
 
 	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
@@ -110,7 +109,7 @@ func collectObjects(yamlInput string, out io.Writer, logger *slog.Logger) (
 	mcpRoutes []*aigv1a1.MCPRoute,
 	aigwBackends []*aigv1a1.AIServiceBackend,
 	backendSecurityPolicies []*aigv1a1.BackendSecurityPolicy,
-	backendTLSConfigs []*gwapiv1a3.BackendTLSPolicy,
+	backendTLSConfigs []*gwapiv1.BackendTLSPolicy,
 	gws []*gwapiv1.Gateway,
 	secrets []*corev1.Secret,
 	envoyProxies []*egv1a1.EnvoyProxy,
@@ -184,7 +183,7 @@ func translateCustomResourceObjects(
 	mcpRoutes []*aigv1a1.MCPRoute,
 	aigwBackends []*aigv1a1.AIServiceBackend,
 	backendSecurityPolicies []*aigv1a1.BackendSecurityPolicy,
-	backendTLSPolicies []*gwapiv1a3.BackendTLSPolicy,
+	backendTLSPolicies []*gwapiv1.BackendTLSPolicy,
 	gws []*gwapiv1.Gateway,
 	usedDefinedSecrets []*corev1.Secret,
 	logger *slog.Logger,


### PR DESCRIPTION
**Description**

Fixes a small issue that happened in standalone mode and the discovery of BackendTLS policies for the MCPRoute security configuration.
In the controller code we're using `gwapiv1` in all reconcilers and the controller-runtime Client. That client is typed and works with the specific version. The fakeClient used in standalone mode, populated the BackendTLSPolicy as `gwapiv1alpha3`, causing the controller code to not find it.

We could change the controller code and make sure all operations that use the `client.Client` from teh controller runtime account for all versions, but that would be a lot of repeated code, and the controller consistently uses `gwapiv1` everywhere, so I think it is OK to jsut fix the standalone mode to initialize its fakeClient with the right version (note that we can still "read any version from the YAML file", as we generically unmarshal to `Unstructured`; it's just a matter of how we populate the data in the fakeClient)..


**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
