### PR TITLE
chore: remove nip.io now that EG supports localhost backends in cli

### DIFF
--- a/cmd/aigw/README.md
+++ b/cmd/aigw/README.md
@@ -2,7 +2,7 @@
 
 ## Quick Start
 
-[docker-compose.yml](docker-compose.yaml) builds and runs `aigw`, targeting
+[docker-compose.yaml](docker-compose.yaml) builds and runs `aigw`, targeting
 [Ollama][ollama] for OpenAI chat completion requests on port 1975.
 
 - **aigw** (port 1975): Envoy AI Gateway CLI (standalone mode)

--- a/cmd/aigw/config_test.go
+++ b/cmd/aigw/config_test.go
@@ -58,16 +58,7 @@ func TestReadConfig(t *testing.T) {
 				"OPENAI_BASE_URL": "http://localhost:11434/v1",
 			},
 			mcpServers:      testMcpServers,
-			expectHostnames: []string{"127.0.0.1.nip.io", "dreamtap.xyz"},
-			expectPort:      "11434",
-		},
-		{
-			name: "generates config from OpenAI env vars for localhost",
-			envVars: map[string]string{
-				"OPENAI_API_KEY":  "test-key",
-				"OPENAI_BASE_URL": "http://localhost:11434/v1",
-			},
-			expectHostnames: []string{"127.0.0.1.nip.io"},
+			expectHostnames: []string{"localhost", "dreamtap.xyz"},
 			expectPort:      "11434",
 		},
 		{

--- a/cmd/aigw/testdata/gateway_no_listeners.yaml
+++ b/cmd/aigw/testdata/gateway_no_listeners.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   endpoints:
     - fqdn:
-        hostname: 127.0.0.1.nip.io
+        hostname: localhost
         port: 11434
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1

--- a/examples/aigw/ollama.yaml
+++ b/examples/aigw/ollama.yaml
@@ -110,7 +110,7 @@ metadata:
 spec:
   endpoints:
     - fqdn:
-        hostname: 127.0.0.1.nip.io
+        hostname: localhost
         port: 11434
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/cohere-ai/cohere-go/v2 v2.15.3
 	github.com/coreos/go-oidc/v3 v3.16.0
 	github.com/docker/docker v28.5.1+incompatible
-	github.com/envoyproxy/gateway v1.6.0-rc.1
+	github.com/envoyproxy/gateway v1.6.0
 	github.com/envoyproxy/go-control-plane v0.13.5-0.20251029084203-42a4a9261f66
 	github.com/envoyproxy/go-control-plane/envoy v1.35.1-0.20251029084203-42a4a9261f66
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A
 github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/envoyproxy/gateway v1.6.0-rc.1 h1:zXTOQNqPOr8HFf0AcOLjZvCp3v9PRO2WiIu2+aBNqTk=
-github.com/envoyproxy/gateway v1.6.0-rc.1/go.mod h1:lU7mZThgBr0lIQuh9igpToqBGlgX6JSHt2UsJnzRufw=
+github.com/envoyproxy/gateway v1.6.0 h1:AWKXQpvnNs6vqSeDgSwOyqMKlPircGXvw97mkfcDh/w=
+github.com/envoyproxy/gateway v1.6.0/go.mod h1:F3Spa//JPyvpg8XXa5ZAvbrG8KdjObBpPYWVVHT9Hv8=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20251029084203-42a4a9261f66 h1:L453OETmTe0Oc+D3ufM+5+lsmT2fOfH+5rYKUqX2gZo=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20251029084203-42a4a9261f66/go.mod h1:Alz8LEClvR7xKsrq3qzoc4N0guvVNSS8KmSChGYr9hs=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20251029084203-42a4a9261f66 h1:49APukzYTc6nj6PLe7Flrmpe0lib4z5ZZcrMMNK5CIk=

--- a/internal/autoconfig/anthropic.go
+++ b/internal/autoconfig/anthropic.go
@@ -40,11 +40,10 @@ func PopulateAnthropicEnvConfig(data *ConfigData) error {
 
 	// Create Backend for Anthropic
 	backend := Backend{
-		Name:             "anthropic",
-		Hostname:         parsed.hostname,
-		OriginalHostname: parsed.originalHostname,
-		Port:             parsed.port,
-		NeedsTLS:         parsed.needsTLS,
+		Name:     "anthropic",
+		Hostname: parsed.hostname,
+		Port:     parsed.port,
+		NeedsTLS: parsed.needsTLS,
 	}
 
 	// Create AnthropicConfig referencing the backend

--- a/internal/autoconfig/anthropic_test.go
+++ b/internal/autoconfig/anthropic_test.go
@@ -28,11 +28,10 @@ func TestPopulateAnthropicEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "anthropic",
-						Hostname:         "api.anthropic.com",
-						OriginalHostname: "api.anthropic.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "anthropic",
+						Hostname: "api.anthropic.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				Anthropic: &AnthropicConfig{
@@ -51,11 +50,10 @@ func TestPopulateAnthropicEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "anthropic",
-						Hostname:         "custom.anthropic.com",
-						OriginalHostname: "custom.anthropic.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "anthropic",
+						Hostname: "custom.anthropic.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				Anthropic: &AnthropicConfig{
@@ -74,11 +72,10 @@ func TestPopulateAnthropicEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "anthropic",
-						Hostname:         "127.0.0.1.nip.io",
-						OriginalHostname: "localhost",
-						Port:             8080,
-						NeedsTLS:         false,
+						Name:     "anthropic",
+						Hostname: "localhost",
+						Port:     8080,
+						NeedsTLS: false,
 					},
 				},
 				Anthropic: &AnthropicConfig{

--- a/internal/autoconfig/config.go
+++ b/internal/autoconfig/config.go
@@ -21,11 +21,10 @@ var configTemplate string
 // Backend represents a network backend endpoint (OpenAI or MCP server).
 // Backends are rendered as Kubernetes Backend resources with optional TLS policy.
 type Backend struct {
-	Name             string // Backend resource name (e.g., "openai", "github")
-	Hostname         string // Hostname for Backend endpoint (modified from "localhost"/"127.0.0.1" to "127.0.0.1.nip.io" for Docker/K8s compatibility)
-	OriginalHostname string // Original unmodified hostname for TLS certificate validation (e.g., "localhost" when Hostname is "127.0.0.1.nip.io")
-	Port             int    // Port number
-	NeedsTLS         bool   // Whether to generate BackendTLSPolicy resource
+	Name     string // Backend resource name (e.g., "openai", "github")
+	Hostname string // Hostname for Backend endpoint
+	Port     int    // Port number
+	NeedsTLS bool   // Whether to generate BackendTLSPolicy resource
 }
 
 // OpenAIConfig holds OpenAI-specific configuration for generating AIServiceBackend resources.
@@ -85,11 +84,10 @@ func WriteConfig(data *ConfigData) (string, error) {
 
 // parsedURL holds parsed URL components for creating Backend, OpenAIConfig, and AnthropicConfig.
 type parsedURL struct {
-	hostname         string
-	originalHostname string
-	port             int
-	version          string
-	needsTLS         bool
+	hostname string
+	port     int
+	version  string
+	needsTLS bool
 }
 
 // parseURL extracts hostname, port, and version from the base URL.
@@ -103,12 +101,6 @@ func parseURL(baseURL string) (*parsedURL, error) {
 	hostname := u.Hostname()
 	if hostname == "" {
 		return nil, fmt.Errorf("invalid base URL: missing hostname")
-	}
-	originalHostname := hostname
-
-	// Convert localhost/127.0.0.1 to nip.io for Docker/K8s compatibility
-	if hostname == "localhost" || hostname == "127.0.0.1" {
-		hostname = "127.0.0.1.nip.io"
 	}
 
 	// Determine port
@@ -140,10 +132,9 @@ func parseURL(baseURL string) (*parsedURL, error) {
 	}
 
 	return &parsedURL{
-		hostname:         hostname,
-		originalHostname: originalHostname,
-		port:             port,
-		version:          version,
-		needsTLS:         u.Scheme == "https",
+		hostname: hostname,
+		port:     port,
+		version:  version,
+		needsTLS: u.Scheme == "https",
 	}, nil
 }

--- a/internal/autoconfig/config.yaml.tmpl
+++ b/internal/autoconfig/config.yaml.tmpl
@@ -277,7 +277,7 @@ spec:
       name: {{ .Name }}
   validation:
     wellKnownCACertificates: "System"
-    hostname: {{ .OriginalHostname }}
+    hostname: {{ .Hostname }}
 ---
 {{- end }}
 {{- end }}

--- a/internal/autoconfig/config_test.go
+++ b/internal/autoconfig/config_test.go
@@ -82,11 +82,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -102,11 +101,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "my-resource.openai.azure.com",
-						OriginalHostname: "my-resource.openai.azure.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "my-resource.openai.azure.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -122,11 +120,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "127.0.0.1.nip.io",
-						OriginalHostname: "localhost",
-						Port:             11434,
-						NeedsTLS:         false,
+						Name:     "openai",
+						Hostname: "localhost",
+						Port:     11434,
+						NeedsTLS: false,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -142,11 +139,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.router.tetrate.ai",
-						OriginalHostname: "api.router.tetrate.ai",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.router.tetrate.ai",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -162,11 +158,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "openrouter.ai",
-						OriginalHostname: "openrouter.ai",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "openrouter.ai",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -182,11 +177,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "127.0.0.1.nip.io",
-						OriginalHostname: "localhost",
-						Port:             8321,
-						NeedsTLS:         false,
+						Name:     "openai",
+						Hostname: "localhost",
+						Port:     8321,
+						NeedsTLS: false,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -202,11 +196,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -223,11 +216,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -244,11 +236,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -266,11 +257,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "my-resource.openai.azure.com",
-						OriginalHostname: "my-resource.openai.azure.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "my-resource.openai.azure.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -288,11 +278,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -312,11 +301,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "kiwi",
-						Hostname:         "mcp.kiwi.com",
-						OriginalHostname: "mcp.kiwi.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "kiwi",
+						Hostname: "mcp.kiwi.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				MCPBackendRefs: []MCPBackendRef{
@@ -333,18 +321,16 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 					{
-						Name:             "github",
-						Hostname:         "api.githubcopilot.com",
-						OriginalHostname: "api.githubcopilot.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "github",
+						Hostname: "api.githubcopilot.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -368,11 +354,10 @@ func TestWriteConfig(t *testing.T) {
 			input: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "anthropic",
-						Hostname:         "api.anthropic.com",
-						OriginalHostname: "api.anthropic.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "anthropic",
+						Hostname: "api.anthropic.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				Anthropic: &AnthropicConfig{
@@ -405,77 +390,50 @@ func TestParseURL(t *testing.T) {
 			name:    "HTTPS with default port",
 			baseURL: "https://api.openai.com/v1",
 			expected: parsedURL{
-				hostname:         "api.openai.com",
-				originalHostname: "api.openai.com",
-				port:             443,
-				version:          "", // v1 is omitted for cleaner output
-				needsTLS:         true,
-			},
-		},
-		{
-			name:    "localhost converted to nip.io",
-			baseURL: "http://localhost:11434/v1",
-			expected: parsedURL{
-				hostname:         "127.0.0.1.nip.io",
-				originalHostname: "localhost",
-				port:             11434,
-				version:          "", // v1 is omitted
-				needsTLS:         false,
-			},
-		},
-		{
-			name:    "127.0.0.1 converted to nip.io",
-			baseURL: "http://127.0.0.1:8080/v1",
-			expected: parsedURL{
-				hostname:         "127.0.0.1.nip.io",
-				originalHostname: "127.0.0.1",
-				port:             8080,
-				version:          "", // v1 is omitted
-				needsTLS:         false,
+				hostname: "api.openai.com",
+				port:     443,
+				version:  "", // v1 is omitted for cleaner output
+				needsTLS: true,
 			},
 		},
 		{
 			name:    "custom path preserved",
 			baseURL: "https://custom.ai/v1beta/openai",
 			expected: parsedURL{
-				hostname:         "custom.ai",
-				originalHostname: "custom.ai",
-				port:             443,
-				version:          "v1beta/openai",
-				needsTLS:         true,
+				hostname: "custom.ai",
+				port:     443,
+				version:  "v1beta/openai",
+				needsTLS: true,
 			},
 		},
 		{
 			name:    "HTTP with default port 80",
 			baseURL: "http://example.com/v1",
 			expected: parsedURL{
-				hostname:         "example.com",
-				originalHostname: "example.com",
-				port:             80,
-				version:          "", // v1 is omitted
-				needsTLS:         false,
+				hostname: "example.com",
+				port:     80,
+				version:  "", // v1 is omitted
+				needsTLS: false,
 			},
 		},
 		{
 			name:    "empty path treated as no version",
 			baseURL: "https://api.example.com",
 			expected: parsedURL{
-				hostname:         "api.example.com",
-				originalHostname: "api.example.com",
-				port:             443,
-				version:          "",
-				needsTLS:         true,
+				hostname: "api.example.com",
+				port:     443,
+				version:  "",
+				needsTLS: true,
 			},
 		},
 		{
 			name:    "trailing slash ignored",
 			baseURL: "https://api.example.com/",
 			expected: parsedURL{
-				hostname:         "api.example.com",
-				originalHostname: "api.example.com",
-				port:             443,
-				version:          "",
-				needsTLS:         true,
+				hostname: "api.example.com",
+				port:     443,
+				version:  "",
+				needsTLS: true,
 			},
 		},
 		{

--- a/internal/autoconfig/mcp.go
+++ b/internal/autoconfig/mcp.go
@@ -126,11 +126,10 @@ func AddMCPServers(data *ConfigData, input *MCPServers) error {
 
 		// Create Backend for this MCP server
 		backend := Backend{
-			Name:             name,
-			Hostname:         serverURL.Hostname(),
-			OriginalHostname: serverURL.Hostname(),
-			Port:             port,
-			NeedsTLS:         serverURL.Scheme == "https",
+			Name:     name,
+			Hostname: serverURL.Hostname(),
+			Port:     port,
+			NeedsTLS: serverURL.Scheme == "https",
 		}
 
 		// Create MCPBackendRef referencing the backend

--- a/internal/autoconfig/mcp_test.go
+++ b/internal/autoconfig/mcp_test.go
@@ -34,11 +34,10 @@ func TestAddMCPServersConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "github",
-						Hostname:         "api.githubcopilot.com",
-						OriginalHostname: "api.githubcopilot.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "github",
+						Hostname: "api.githubcopilot.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				MCPBackendRefs: []MCPBackendRef{
@@ -70,11 +69,10 @@ func TestAddMCPServersConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "custom",
-						Hostname:         "mcp.example.com",
-						OriginalHostname: "mcp.example.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "custom",
+						Hostname: "mcp.example.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				MCPBackendRefs: []MCPBackendRef{
@@ -111,18 +109,16 @@ func TestAddMCPServersConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "github",
-						Hostname:         "api.githubcopilot.com",
-						OriginalHostname: "api.githubcopilot.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "github",
+						Hostname: "api.githubcopilot.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 					{
-						Name:             "kiwi",
-						Hostname:         "mcp.kiwi.com",
-						OriginalHostname: "mcp.kiwi.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "kiwi",
+						Hostname: "mcp.kiwi.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				MCPBackendRefs: []MCPBackendRef{
@@ -168,11 +164,10 @@ func TestAddMCPServersConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "github",
-						Hostname:         "api.githubcopilot.com",
-						OriginalHostname: "api.githubcopilot.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "github",
+						Hostname: "api.githubcopilot.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				MCPBackendRefs: []MCPBackendRef{

--- a/internal/autoconfig/openai.go
+++ b/internal/autoconfig/openai.go
@@ -70,11 +70,10 @@ func PopulateOpenAIEnvConfig(data *ConfigData) error {
 
 	// Create Backend for OpenAI
 	backend := Backend{
-		Name:             "openai",
-		Hostname:         parsed.hostname,
-		OriginalHostname: parsed.originalHostname,
-		Port:             parsed.port,
-		NeedsTLS:         parsed.needsTLS,
+		Name:     "openai",
+		Hostname: parsed.hostname,
+		Port:     parsed.port,
+		NeedsTLS: parsed.needsTLS,
 	}
 
 	// Create OpenAIConfig referencing the backend

--- a/internal/autoconfig/openai_test.go
+++ b/internal/autoconfig/openai_test.go
@@ -28,11 +28,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -52,11 +51,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "my-resource.openai.azure.com",
-						OriginalHostname: "my-resource.openai.azure.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "my-resource.openai.azure.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -78,11 +76,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "my-resource.openai.azure.com",
-						OriginalHostname: "my-resource.openai.azure.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "my-resource.openai.azure.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -101,11 +98,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "127.0.0.1.nip.io",
-						OriginalHostname: "localhost",
-						Port:             11434,
-						NeedsTLS:         false,
+						Name:     "openai",
+						Hostname: "localhost",
+						Port:     11434,
+						NeedsTLS: false,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -124,11 +120,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -148,11 +143,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{
@@ -173,11 +167,10 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			expected: ConfigData{
 				Backends: []Backend{
 					{
-						Name:             "openai",
-						Hostname:         "api.openai.com",
-						OriginalHostname: "api.openai.com",
-						Port:             443,
-						NeedsTLS:         true,
+						Name:     "openai",
+						Hostname: "api.openai.com",
+						Port:     443,
+						NeedsTLS: true,
 					},
 				},
 				OpenAI: &OpenAIConfig{

--- a/internal/autoconfig/testdata/llamastack.yaml
+++ b/internal/autoconfig/testdata/llamastack.yaml
@@ -110,7 +110,7 @@ metadata:
 spec:
   endpoints:
     - fqdn:
-        hostname: 127.0.0.1.nip.io
+        hostname: localhost
         port: 8321
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1


### PR DESCRIPTION
**Description**

Now that EG has merged the patch that allows using `localhost` in Backends when running in standalone mode, we can remove the uses of `.nip.io` we were using to overcome the limitation when proxying local Ollama LLMs or local MCP servers.

I've verified all Docker guides we had as well as all ollama configs and everything works as expected (cc @codefromthecrypt)

**Related Issues/PRs (if applicable)**

https://github.com/envoyproxy/gateway/pull/7427

**Special notes for reviewers (if applicable)**


This requires upgrading to the latest EG from main (the change hasn't yet been cherry-picked to the 1.6 release branch). Opening as a draft to avoid bumping the EG dependency beyond 1.6 until we release.
