### PR TITLE
fix: use the right namespace for DNS names in the default webhook certificates

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/admission_webhook.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/admission_webhook.yaml
@@ -54,84 +54,39 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
-{{- else }}
 ---
+{{- else }}
+{{- $caCrt := "" }}
+{{- $tlsCrt := "" }}
+{{- $tlsKey := "" }}
+{{/* Check fi the secret exists to avoid regenerating the certificate on upgrades */}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.controller.mutatingWebhook.tlsCertSecretName }}
+{{- if $existing }}
+  {{- $caCrt = index $existing.data .Values.controller.mutatingWebhook.caBundleName }}
+  {{- $tlsCrt = index $existing.data .Values.controller.mutatingWebhook.tlsCertName }}
+  {{- $tlsKey = index $existing.data .Values.controller.mutatingWebhook.tlsKeyName }}
+{{- else }}
+  {{- $serviceName := include "ai-gateway-helm.controller.fullname" . }}
+  {{- $ca := genCA (printf "%s-ca" $serviceName) 3650 }}
+  {{- $dnsNames := list
+        $serviceName
+        (printf "%s.%s" $serviceName .Release.Namespace)
+        (printf "%s.%s.svc" $serviceName .Release.Namespace)
+        (printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace)
+  -}}
+  {{- $cert := genSignedCert (printf "%s.%s.svc" $serviceName .Release.Namespace) nil $dnsNames 365 $ca }}
+  {{- $caCrt = $ca.Cert | b64enc }}
+  {{- $tlsCrt = $cert.Cert | b64enc }}
+  {{- $tlsKey = $cert.Key | b64enc }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.controller.mutatingWebhook.tlsCertSecretName }}
   namespace: {{ .Release.Namespace }}
-stringData:
-  ca.crt: |
-    -----BEGIN CERTIFICATE-----
-    MIIDOzCCAiOgAwIBAgIUU+g1Upp1Qtfpk87zY5H2/EY55QUwDQYJKoZIhvcNAQEL
-    BQAwLTELMAkGA1UEBhMCQVUxHjAcBgNVBAMMFWFpLWdhdGV3YXktY29udHJvbGxl
-    cjAeFw0yNTA1MjAxNjQzNTJaFw0zNTA1MTgxNjQzNTJaMC0xCzAJBgNVBAYTAkFV
-    MR4wHAYDVQQDDBVhaS1nYXRld2F5LWNvbnRyb2xsZXIwggEiMA0GCSqGSIb3DQEB
-    AQUAA4IBDwAwggEKAoIBAQDKN5YmMh7TgGqNpedC0DWBWdn2pMiHtCeRlTkluDjK
-    l+ZeleiR7rooNUXc6gE02RAaRCEaNMSZL3m6BkZ1Xoo92Mvabu+ORkwApO+OTIvj
-    NsYb3/blsST1qHXApm7n886Ed80CG3Jczi7AioXsAhTv+SoJeQJsoKLeVYV5m5l/
-    j4xoJl9fY+lzpmgdcALBm7FDrAbsEgjKwmFEQAxTNxWowZDiARW21io45saC411S
-    m/ZhthSxDQpqSzPwYcXwR04syZxGUewYrpIE54hRsM8KwpqNEZVnjlaKBssiEgG8
-    97sx9wDb3HLzep7FShKz4LslePAc8DmvdYjnooZaxzsfAgMBAAGjUzBRMB0GA1Ud
-    DgQWBBS9puJ0i+zKW4Y3FY2NvRKAb0ONYzAfBgNVHSMEGDAWgBS9puJ0i+zKW4Y3
-    FY2NvRKAb0ONYzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCZ
-    ZgPCQnaXt/xSJ7oUFBMba5TLeqvzIKPeDvS0ii64tZeQ75R7nQvSVt2QnGDjpyJ+
-    00ERja7jWpjL3IWijmE199vv40ZY4pajhBAL3y8wPf6vRh8d7TO4XmN7hser2tci
-    denNGPxu1bX2tLE8FAGM8SUarVy6veHdiUyoMlJWpvjWYNgaVE5Yx/839WmxRhnS
-    2IOljAsTwaIkI0wms51lZXGPhRgES9AoLPuywsgq7GcjIhYHpfso/3DgS8/MTR5B
-    iWqiXpgjD6ZOzTQyp8zpnGzYGdxSKaxd1I0LhLTuawdLQ+DS3zvR5S5V5vLQUZ1r
-    0Un8E68n7s8EplV8N6xl
-    -----END CERTIFICATE-----
-  tls.crt: |
-    -----BEGIN CERTIFICATE-----
-    MIIDaTCCAlGgAwIBAgIUHUaEt6oW5HaBSAc/DZZ39PclDaUwDQYJKoZIhvcNAQEL
-    BQAwLTELMAkGA1UEBhMCQVUxHjAcBgNVBAMMFWFpLWdhdGV3YXktY29udHJvbGxl
-    cjAeFw0yNTA1MjAxNjQ1MzNaFw0zNTA1MTgxNjQ1MzNaMC0xCzAJBgNVBAYTAkFV
-    MR4wHAYDVQQDDBVhaS1nYXRld2F5LWNvbnRyb2xsZXIwggEiMA0GCSqGSIb3DQEB
-    AQUAA4IBDwAwggEKAoIBAQDHhlhQBR2pplNbgA5Q0lvqimzUylfGAeTVPrSQs73L
-    Fj2Lqi/ROtyFHdfruRzVMnmWfMWbh57kIv6KEXHkhJngD4rjcWjLQvKZjUKUe9s7
-    P1tQ0S9rIzMeBk8dQ3vrm+XcFy9zhuROccpmaXOTjanW9I7Uxl0/fINfc2++nIUx
-    8LSJPf845iHJlHF7uuzhRIMD3M0ShXSS8SnPQPicq18mqufczN+8SC5jwDeCAUEM
-    67ter1OnXdjuJSSHpRY9Rj32jyIGYEjFTgqV1tU+ut86xzzRMGilcXio1NubJxfH
-    IwOWCG82qyddZpGLVHAUapgaW4H5Lce+uELhShc0HiRpAgMBAAGjgYAwfjA8BgNV
-    HREENTAzgjFhaS1nYXRld2F5LWNvbnRyb2xsZXIuZW52b3ktYWktZ2F0ZXdheS1z
-    eXN0ZW0uc3ZjMB0GA1UdDgQWBBTHtH9TzxZK9i29+djfBe6foVNN4jAfBgNVHSME
-    GDAWgBS9puJ0i+zKW4Y3FY2NvRKAb0ONYzANBgkqhkiG9w0BAQsFAAOCAQEAmOKx
-    ws4huAPawx1hcZQNNz6TTv6BwxGAVG4WX69Pb3ZWXB/vxPIIPkbhP23oumtn0N7l
-    ehy6K89FPDCCeuz9kibsDHQWjl349jPSyGULMVYT2DoI9KKxwFdjgVwF8pOOvBe3
-    8tTiPcCoYbssMpmYQKGXiqENrIKTq9dzzqMxkN9a4XNyk2xB9P8RSiv/6sQqE5Ni
-    bY6TeD4T8AgaGdHteCeRNBJxaiKPttv9D62zd02lJ9w7BKsphNRDH1dNCNgM8KJE
-    Rxf1TRtGZTXfz6y7gFYK1w7RwI9v5JUiRH28RyexeNKmAYlP6pbKN6wM4S0OktyY
-    znuy770iwgvtVaugwQ==
-    -----END CERTIFICATE-----
-  tls.key: |
-    -----BEGIN PRIVATE KEY-----
-    MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDHhlhQBR2pplNb
-    gA5Q0lvqimzUylfGAeTVPrSQs73LFj2Lqi/ROtyFHdfruRzVMnmWfMWbh57kIv6K
-    EXHkhJngD4rjcWjLQvKZjUKUe9s7P1tQ0S9rIzMeBk8dQ3vrm+XcFy9zhuROccpm
-    aXOTjanW9I7Uxl0/fINfc2++nIUx8LSJPf845iHJlHF7uuzhRIMD3M0ShXSS8SnP
-    QPicq18mqufczN+8SC5jwDeCAUEM67ter1OnXdjuJSSHpRY9Rj32jyIGYEjFTgqV
-    1tU+ut86xzzRMGilcXio1NubJxfHIwOWCG82qyddZpGLVHAUapgaW4H5Lce+uELh
-    Shc0HiRpAgMBAAECggEAAe3u5zExeP1Cg5lAqi/qkyFNDZ66TBAjIBvH37lZPcBE
-    jpfx9+4/iSsBdkZXPMmM6vNgbtFYLEEZYIjsJsdQfJ3x3CKx3ntSgMEgsnJjK5bA
-    gY7QTFMuEJ2DgNcw+NWMWr0/qHiWtxp7GFPvOe9OA+XgBrc3WiCQXakuXLPDRvkW
-    SbSurGfzhlPNVSlqRAK/uYYeRFUvjjvuFB77+ozVPCqMxqMDW9ez7y/oMK5Rphl7
-    GbBSHjv/aCfN4OKno/xtPup3xaYHXkNLP1ktGCplJoyx6JSqBqYoKXP9sGsbhlif
-    xNI2zhB7VRfjQzclS+26zUIK2GhNd4/LI4ZvzB4bjQKBgQDse6MPqrkW2YFJSQOd
-    bpghzHfv3P7VCJi5pgneOeH+qgYvWHtXASC6XmHgd7RjIAkmIkI01VGhIQW1Lwzh
-    /K/qmmNgyP1MVIpAedYaMBFFV6q9qWaT+AojFp+PnHjuQHtFP9Lx0dtMwvafb821
-    mN1i3ZDWmD7wFt1D6nBetDm2tQKBgQDX/d0HjexwhLILboAzgTWgOPjks60+uh4k
-    zf/SxdRE6wHaeUuT5disUJD70G52jGQRR5EMazJvSCPDffIsHdId5qM/H1+LuRs9
-    RvPttxyZACgghV+M2cOCkQkbwpMe8O7+SHtSQt2hNnkXu9QUOrU01qgXJrSF6WQn
-    vCWiDwczZQKBgH5A/+yEXC7bzs9+gMSTX/tje4D+/rpjzY4IHGqdgo+A3K54UdlA
-    i+WUMDM0FYV6fAf08F3eqacZxz9VME6SpqTc6kOo6rrOw8TqhykSEpZv2INLpq1H
-    FrpnAKcehd3FZUqyaX+bZ7aSvDKg8TWLuF5pJkO7opZxzo3M41NcaxelAoGADnfc
-    5HKnUeoxmv5t7AVNuEvYsEkw47DH8CM0bcP+shcj6qSRYXjWCMTk0Vlm7N3+ngGz
-    P6e2mymz65Z2MGpW9tXKPaI2Xj+qCXLFSDkp2z3dckA85Ex6AjcA6zEfdcUh3Tqx
-    uBLukav6dJKKZEiCduWiINrg4M9/fAHoa3CiRNkCgYEAnEn9gCO4e0raIREBFMRW
-    9uiRLb1cc4GvZxYDj4xf0AR99bL599GMe/yMbtaeqhC5z2pVgyRGwxPCmoY5KQrB
-    i4X6Yrl37GEpCf94kpkdM6AtzA2DZ9Tfzoai61RKvP1W93vWohjXtv1OZWDuDB+H
-    SJhKidoVRcKlB8eLvnwIh+g=
-    -----END PRIVATE KEY-----
+data:
+  {{ .Values.controller.mutatingWebhook.caBundleName }}: {{ $caCrt }}
+  {{ .Values.controller.mutatingWebhook.tlsCertName }}: {{ $tlsCrt }}
+  {{ .Values.controller.mutatingWebhook.tlsKeyName }}: {{ $tlsKey }}
+---
 {{- end }}

--- a/tests/e2e-namespaced/namespaced_test.go
+++ b/tests/e2e-namespaced/namespaced_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestMain(m *testing.M) {
 	e2elib.TestMain(m, e2elib.AIGatewayHelmOption{
+		Namespace: "envoy-ai-gateway-e2e", // Also install AI Gateway on a different namespace
 		AdditionalArgs: []string{
 			// Configure the controller to only watch certain namespaces
 			// By skipping the "route1-ns" the models defined in that namespace routes


### PR DESCRIPTION
**Description**

Removes the hardcoded webhook certificate when cert-manager is not configured and uses the Helm cert functions [1] to generate it, so that the right namespace is used in the certificate DNS names.

**Related Issues/PRs (if applicable)**

Fixes https://github.com/envoyproxy/ai-gateway/issues/1502
Fixes: https://github.com/envoyproxy/ai-gateway/issues/1363

**Special notes for reviewers (if applicable)**

N/A

1: https://helm.sh/docs/chart_template_guide/function_list#cryptographic-and-security-functions