### PR TITLE
feat: support JSON schema dereferencing in tool-param for GCP Anthropic req

### DIFF
--- a/internal/extproc/translator/openai_gcpanthropic.go
+++ b/internal/extproc/translator/openai_gcpanthropic.go
@@ -163,6 +163,16 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 
 				inputSchema := anthropic.ToolInputSchemaParam{}
 
+				// Dereference json schema
+				// If the paramsMap contains $refs we need to dereference them
+				var dereferencedParamsMap any
+				if dereferencedParamsMap, err = jsonSchemaDereference(paramsMap); err != nil {
+					return nil, anthropic.ToolChoiceUnionParam{}, fmt.Errorf("failed to dereference tool parameters: %w", err)
+				}
+				if paramsMap, ok = dereferencedParamsMap.(map[string]any); !ok {
+					return nil, anthropic.ToolChoiceUnionParam{}, fmt.Errorf("failed to cast dereferenced tool parameters to map[string]interface{}")
+				}
+
 				var typeVal string
 				if typeVal, ok = paramsMap["type"].(string); ok {
 					inputSchema.Type = constant.Object(typeVal)


### PR DESCRIPTION
**Description**

This commit adds support for dereferencing JSON schema `$ref` references in tool parameters for the OpenAI to GCP Anthropic translator. When OpenAI tool definitions contain JSON schemas with `$ref` pointers, these references are now automatically resolved before the schema is converted to Anthropic's format.

