### PR TITLE
docs: update envoy AI Gateway helm chart version to v1.3.0

### DIFF
--- a/site/versioned_docs/version-0.3/getting-started/prerequisites.md
+++ b/site/versioned_docs/version-0.3/getting-started/prerequisites.md
@@ -145,7 +145,7 @@ Ensure you're using a clean Envoy Gateway deployment. If you have an existing En
 
 :::info Version Requirements
 
-Envoy AI Gateway requires Envoy Gateway version 1.3.0 or higher. For the best experience while trying out AI Gateway, we recommend using the latest version as shown in the commands below.
+Envoy AI Gateway requires Envoy Gateway version 1.5.0 or higher. For the best experience while trying out AI Gateway, we recommend using the latest version as shown in the commands below.
 
 :::
 


### PR DESCRIPTION
**Description**

https://aigateway.envoyproxy.io/docs/0.3/getting-started/prerequisites has error in the doc mentioning v0.3.0 version for envoy gateway helm chart, it needs to be 1.3.0 instead

**Related Issues/PRs (if applicable)**
N/A

**Special notes for reviewers (if applicable)**
N/A