### PR TITLE
refactor: fixes inconsistent span usage in imagegen/rerank translators

### DIFF
--- a/internal/extproc/imagegeneration_processor.go
+++ b/internal/extproc/imagegeneration_processor.go
@@ -179,7 +179,7 @@ type imageGenerationProcessorUpstreamFilter struct {
 func (i *imageGenerationProcessorUpstreamFilter) selectTranslator(out filterapi.VersionedAPISchema) error {
 	switch out.Name {
 	case filterapi.APISchemaOpenAI:
-		i.translator = translator.NewImageGenerationOpenAIToOpenAITranslator(out.Version, i.modelNameOverride, i.span)
+		i.translator = translator.NewImageGenerationOpenAIToOpenAITranslator(out.Version, i.modelNameOverride)
 	default:
 		return fmt.Errorf("unsupported API schema: backend=%s", out)
 	}
@@ -363,7 +363,7 @@ func (i *imageGenerationProcessorUpstreamFilter) ProcessResponseBody(ctx context
 	var newBody []byte
 	var tokenUsage translator.LLMTokenUsage
 	var responseModel internalapi.ResponseModel
-	newHeaders, newBody, tokenUsage, responseModel, err = i.translator.ResponseBody(i.responseHeaders, decodingResult.reader, body.EndOfStream, nil)
+	newHeaders, newBody, tokenUsage, responseModel, err = i.translator.ResponseBody(i.responseHeaders, decodingResult.reader, body.EndOfStream, i.span)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform response: %w", err)
 	}

--- a/internal/extproc/imagegeneration_processor_test.go
+++ b/internal/extproc/imagegeneration_processor_test.go
@@ -500,7 +500,7 @@ func (m *mockImageGenerationTranslator) ResponseHeaders(headers map[string]strin
 	return m.retHeaderMutation, m.retErr
 }
 
-func (m *mockImageGenerationTranslator) ResponseBody(headers map[string]string, body io.Reader, endOfStream bool, _ any) ([]internalapi.Header, []byte, translator.LLMTokenUsage, internalapi.ResponseModel, error) {
+func (m *mockImageGenerationTranslator) ResponseBody(headers map[string]string, body io.Reader, endOfStream bool, _ tracing.ImageGenerationSpan) ([]internalapi.Header, []byte, translator.LLMTokenUsage, internalapi.ResponseModel, error) {
 	_ = headers
 	if m.expResponseBody != nil {
 		bodyBytes, _ := io.ReadAll(body)

--- a/internal/extproc/rerank_processor.go
+++ b/internal/extproc/rerank_processor.go
@@ -172,7 +172,7 @@ type rerankProcessorUpstreamFilter struct {
 func (r *rerankProcessorUpstreamFilter) selectTranslator(out filterapi.VersionedAPISchema) error {
 	switch out.Name {
 	case filterapi.APISchemaCohere:
-		r.translator = translator.NewRerankCohereToCohereTranslator(out.Version, r.modelNameOverride, r.span)
+		r.translator = translator.NewRerankCohereToCohereTranslator(out.Version, r.modelNameOverride)
 	default:
 		return fmt.Errorf("unsupported API schema: backend=%s", out)
 	}
@@ -332,7 +332,7 @@ func (r *rerankProcessorUpstreamFilter) ProcessResponseBody(ctx context.Context,
 		}, nil
 	}
 
-	newHeaders, newBody, tokenUsage, responseModel, err := r.translator.ResponseBody(r.responseHeaders, decodingResult.reader, body.EndOfStream, nil)
+	newHeaders, newBody, tokenUsage, responseModel, err := r.translator.ResponseBody(r.responseHeaders, decodingResult.reader, body.EndOfStream, r.span)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform response: %w", err)
 	}

--- a/internal/extproc/rerank_processor_test.go
+++ b/internal/extproc/rerank_processor_test.go
@@ -543,7 +543,7 @@ func (m *mockRerankTranslator) ResponseHeaders(headers map[string]string) ([]int
 	return m.retHeaderMutation, m.retErr
 }
 
-func (m *mockRerankTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool, _ any) ([]internalapi.Header, []byte, translator.LLMTokenUsage, internalapi.ResponseModel, error) {
+func (m *mockRerankTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool, _ tracing.RerankSpan) ([]internalapi.Header, []byte, translator.LLMTokenUsage, internalapi.ResponseModel, error) {
 	if m.expResponseBody != nil {
 		got, _ := io.ReadAll(body)
 		require.True(m.t, bytes.Equal(m.expResponseBody.Body, got))

--- a/internal/translator/cohere_rerank_v2_test.go
+++ b/internal/translator/cohere_rerank_v2_test.go
@@ -54,7 +54,7 @@ func TestCohereToCohereTranslatorV2Rerank_RequestBody(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			translator := NewRerankCohereToCohereTranslator("v2", tc.modelNameOverride, nil)
+			translator := NewRerankCohereToCohereTranslator("v2", tc.modelNameOverride)
 			originalBody := `{"model":"rerank-english-v3","query":"reset password","documents":["doc1","doc2"]}`
 			var req cohereschema.RerankV2Request
 			require.NoError(t, json.Unmarshal([]byte(originalBody), &req))
@@ -86,7 +86,7 @@ func TestCohereToCohereTranslatorV2Rerank_RequestBody(t *testing.T) {
 }
 
 func TestCohereToCohereTranslatorV2Rerank_RequestBody_InvalidJSONCreatesBodyWithOverride(t *testing.T) {
-	translator := NewRerankCohereToCohereTranslator("v2", "override-model", nil)
+	translator := NewRerankCohereToCohereTranslator("v2", "override-model")
 	// Provide invalid JSON; sjson with Optimistic mode can still produce a body with the override.
 	originalBody := []byte("not-json")
 	var req cohereschema.RerankV2Request
@@ -108,7 +108,7 @@ func TestCohereToCohereTranslatorV2Rerank_RequestBody_SetModelNameError(t *testi
 	sjsonOptions = &sjson.Options{Optimistic: false, ReplaceInPlace: false}
 	t.Cleanup(func() { sjsonOptions = orig })
 
-	translator := NewRerankCohereToCohereTranslator("v2", "override-model", nil)
+	translator := NewRerankCohereToCohereTranslator("v2", "override-model")
 	// Use an array root to make setting an object key fail with Optimistic=false.
 	originalBody := []byte("[]")
 	var req cohereschema.RerankV2Request
@@ -121,7 +121,7 @@ func TestCohereToCohereTranslatorV2Rerank_RequestBody_SetModelNameError(t *testi
 }
 
 func TestCohereToCohereTranslatorV2Rerank_ResponseHeaders(t *testing.T) {
-	translator := NewRerankCohereToCohereTranslator("v2", "", nil)
+	translator := NewRerankCohereToCohereTranslator("v2", "")
 	headerMutation, err := translator.ResponseHeaders(map[string]string{})
 	require.NoError(t, err)
 	require.Nil(t, headerMutation)
@@ -159,7 +159,7 @@ func TestCohereToCohereTranslatorV2Rerank_ResponseBody(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			translator := NewRerankCohereToCohereTranslator("v2", "", nil)
+			translator := NewRerankCohereToCohereTranslator("v2", "")
 			translator.(*cohereToCohereTranslatorV2Rerank).requestModel = "rerank-english-v3"
 			headerMutation, bodyMutation, tokenUsage, responseModel, err := translator.ResponseBody(
 				map[string]string{contentTypeHeaderName: jsonContentType},
@@ -183,7 +183,7 @@ func TestCohereToCohereTranslatorV2Rerank_ResponseBody(t *testing.T) {
 }
 
 func TestCohereToCohereTranslatorV2Rerank_ResponseError(t *testing.T) {
-	translator := NewRerankCohereToCohereTranslator("v2", "", nil)
+	translator := NewRerankCohereToCohereTranslator("v2", "")
 
 	t.Run("non_json_error", func(t *testing.T) {
 		respHeaders := map[string]string{
@@ -239,7 +239,7 @@ func (m *mockRerankSpanTranslator) RecordResponse(_ *cohereschema.RerankV2Respon
 
 func TestCohereToCohereTranslatorV2Rerank_ResponseBody_RecordsResponseInSpan(t *testing.T) {
 	mspan := &mockRerankSpanTranslator{}
-	tr := NewRerankCohereToCohereTranslator("v2", "", mspan)
+	tr := NewRerankCohereToCohereTranslator("v2", "")
 	tr.(*cohereToCohereTranslatorV2Rerank).requestModel = "rerank-english-v3"
 
 	body := `{"results":[{"index":0,"relevance_score":0.9}],"id":"rr-1"}`
@@ -247,7 +247,7 @@ func TestCohereToCohereTranslatorV2Rerank_ResponseBody_RecordsResponseInSpan(t *
 		map[string]string{contentTypeHeaderName: jsonContentType},
 		strings.NewReader(body),
 		true,
-		nil,
+		mspan,
 	)
 	require.NoError(t, err)
 	require.True(t, mspan.recordCalled)

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -82,11 +82,11 @@ type (
 	// OpenAICompletionTranslator translates the OpenAI's /completions endpoint.
 	OpenAICompletionTranslator = Translator[openai.CompletionRequest, tracing.CompletionSpan]
 	// CohereRerankTranslator translates the Cohere's /v2/rerank endpoint.
-	CohereRerankTranslator = Translator[cohereschema.RerankV2Request, any]
+	CohereRerankTranslator = Translator[cohereschema.RerankV2Request, tracing.RerankSpan]
 	// AnthropicMessagesTranslator translates the Anthropic's /messages endpoint.
-	AnthropicMessagesTranslator = Translator[anthropicschema.MessagesRequest, any]
+	AnthropicMessagesTranslator = Translator[anthropicschema.MessagesRequest, any] // We don't have tracing implementation for /messages yet.
 	// OpenAIImageGenerationTranslator translates the OpenAI's /images/generations endpoint.
-	OpenAIImageGenerationTranslator = Translator[openaisdk.ImageGenerateParams, any]
+	OpenAIImageGenerationTranslator = Translator[openaisdk.ImageGenerateParams, tracing.ImageGenerationSpan]
 )
 
 // LLMTokenUsage represents the token usage reported usually by the backend API in the response body.


### PR DESCRIPTION
**Description**

This fixes the inconsistency of span usage by image gen and rerank translators 

**Related Issues/PRs (if applicable)**
Preparation for #90 
Follow up on #1565 #1567 