### PR TITLE
refactor: simplifies endpoint prefix config init

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -235,8 +235,6 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to parse endpoint prefixes: %w", err)
 	}
-	// Set defaults for any missing endpoint prefixes.
-	endpointPrefixes.SetDefaults()
 
 	// Create Prometheus registry and reader which automatically converts
 	// attribute to Prometheus-compatible format (e.g. dots to underscores).
@@ -268,13 +266,13 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create external processor server: %w", err)
 	}
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.OpenAI, "/v1/chat/completions"), extproc.ChatCompletionProcessorFactory(chatCompletionMetrics))
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.OpenAI, "/v1/completions"), extproc.CompletionsProcessorFactory(completionMetrics))
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.OpenAI, "/v1/embeddings"), extproc.EmbeddingsProcessorFactory(embeddingsMetrics))
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.OpenAI, "/v1/images/generations"), extproc.ImageGenerationProcessorFactory(imageGenerationMetrics))
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.Cohere, "/v2/rerank"), extproc.RerankProcessorFactory(rerankMetrics))
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.OpenAI, "/v1/models"), extproc.NewModelsProcessor)
-	server.Register(path.Join(flags.rootPrefix, *endpointPrefixes.Anthropic, "/v1/messages"), extproc.MessagesProcessorFactory(messagesMetrics))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/chat/completions"), extproc.ChatCompletionProcessorFactory(chatCompletionMetrics))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/completions"), extproc.CompletionsProcessorFactory(completionMetrics))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/embeddings"), extproc.EmbeddingsProcessorFactory(embeddingsMetrics))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/images/generations"), extproc.ImageGenerationProcessorFactory(imageGenerationMetrics))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Cohere, "/v2/rerank"), extproc.RerankProcessorFactory(rerankMetrics))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/models"), extproc.NewModelsProcessor)
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Anthropic, "/v1/messages"), extproc.MessagesProcessorFactory(messagesMetrics))
 
 	if watchErr := filterapi.StartConfigWatcher(ctx, flags.configPath, server, l, time.Second*5); watchErr != nil {
 		return fmt.Errorf("failed to start config watcher: %w", watchErr)

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -126,32 +126,13 @@ func ParseRequestHeaderAttributeMapping(s string) (map[string]string, error) {
 }
 
 // EndpointPrefixes represents well-known endpoint prefixes that AI Gateway supports.
-// Only these keys are recognized when parsing the endpointPrefixes flag/value.
 type EndpointPrefixes struct {
-	OpenAI    *string
-	Cohere    *string
-	Anthropic *string
-}
-
-// SetDefaults populates empty fields with default provider prefixes (without version components).
-// Defaults:
-//
-//	openai -> /
-//	cohere -> /cohere
-//	anthropic -> /anthropic
-func (e *EndpointPrefixes) SetDefaults() {
-	if e.OpenAI == nil {
-		prefix := "/"
-		e.OpenAI = &prefix
-	}
-	if e.Cohere == nil {
-		prefix := "/cohere"
-		e.Cohere = &prefix
-	}
-	if e.Anthropic == nil {
-		prefix := "/anthropic"
-		e.Anthropic = &prefix
-	}
+	// OpenAI defaults to "/"
+	OpenAI string
+	// Cohere defaults to "/cohere"
+	Cohere string
+	// Anthropic defaults to "/anthropic"
+	Anthropic string
 }
 
 // ParseEndpointPrefixes parses a comma-separated list of key:value pairs to populate EndpointPrefixes.
@@ -167,7 +148,11 @@ func (e *EndpointPrefixes) SetDefaults() {
 //
 // Unknown keys cause an error; values must be non-empty.
 func ParseEndpointPrefixes(s string) (EndpointPrefixes, error) {
-	var out EndpointPrefixes
+	out := EndpointPrefixes{
+		OpenAI:    "/",
+		Cohere:    "/cohere",
+		Anthropic: "/anthropic",
+	}
 	if s == "" {
 		return out, nil
 	}
@@ -189,11 +174,11 @@ func ParseEndpointPrefixes(s string) (EndpointPrefixes, error) {
 
 		switch key {
 		case "openai":
-			out.OpenAI = &value
+			out.OpenAI = value
 		case "cohere":
-			out.Cohere = &value
+			out.Cohere = value
 		case "anthropic":
-			out.Anthropic = &value
+			out.Anthropic = value
 		default:
 			return EndpointPrefixes{}, fmt.Errorf("unknown endpointPrefixes key %q at position %d (allowed: openai, cohere, anthropic)", key, i+1)
 		}

--- a/internal/internalapi/internalapi_test.go
+++ b/internal/internalapi/internalapi_test.go
@@ -13,23 +13,20 @@ import (
 )
 
 func TestParseEndpointPrefixes_Success(t *testing.T) {
-	in := "openai:/,cohere:/cohere,anthropic:/anthropic"
+	in := "openai:/foo,cohere:/1/2/3,anthropic:/cat"
 	ep, err := ParseEndpointPrefixes(in)
 	require.NoError(t, err)
-	require.NotNil(t, ep.OpenAI)
-	require.NotNil(t, ep.Cohere)
-	require.NotNil(t, ep.Anthropic)
-	require.Equal(t, "/", *ep.OpenAI)
-	require.Equal(t, "/cohere", *ep.Cohere)
-	require.Equal(t, "/anthropic", *ep.Anthropic)
+	require.Equal(t, "/foo", ep.OpenAI)
+	require.Equal(t, "/1/2/3", ep.Cohere)
+	require.Equal(t, "/cat", ep.Anthropic)
 }
 
 func TestParseEndpointPrefixes_EmptyInput(t *testing.T) {
 	ep, err := ParseEndpointPrefixes("")
 	require.NoError(t, err)
-	require.Nil(t, ep.OpenAI)
-	require.Nil(t, ep.Cohere)
-	require.Nil(t, ep.Anthropic)
+	require.Equal(t, "/", ep.OpenAI)
+	require.Equal(t, "/cohere", ep.Cohere)
+	require.Equal(t, "/anthropic", ep.Anthropic)
 }
 
 func TestParseEndpointPrefixes_UnknownKey(t *testing.T) {
@@ -41,8 +38,7 @@ func TestParseEndpointPrefixes_UnknownKey(t *testing.T) {
 func TestParseEndpointPrefixes_EmptyValue(t *testing.T) {
 	ep, err := ParseEndpointPrefixes("openai:")
 	require.NoError(t, err)
-	require.NotNil(t, ep.OpenAI)
-	require.Empty(t, *ep.OpenAI)
+	require.Empty(t, ep.OpenAI)
 }
 
 func TestParseEndpointPrefixes_MissingColon(t *testing.T) {
@@ -55,20 +51,6 @@ func TestParseEndpointPrefixes_EmptyPair(t *testing.T) {
 	_, err := ParseEndpointPrefixes("openai:/,,cohere:/cohere")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty endpointPrefixes pair at position 2")
-}
-
-func TestEndpointPrefixes_SetDefaults(t *testing.T) {
-	openai := "/custom/openai"
-	ep := EndpointPrefixes{OpenAI: &openai}
-	ep.SetDefaults()
-	// Provided field is preserved
-	require.NotNil(t, ep.OpenAI)
-	require.Equal(t, "/custom/openai", *ep.OpenAI)
-	// Missing fields defaulted
-	require.NotNil(t, ep.Cohere)
-	require.NotNil(t, ep.Anthropic)
-	require.Equal(t, "/cohere", *ep.Cohere)
-	require.Equal(t, "/anthropic", *ep.Anthropic)
 }
 
 func TestPerRouteRuleRefBackendName(t *testing.T) {


### PR DESCRIPTION
**Description**

This simplifies the code added in #1514.

**Related Issues/PRs (if applicable)**

#1514 