### PR TITLE
mcp: add support for OpenID Connect discovery

### DIFF
--- a/internal/controller/mcp_route_security_policy.go
+++ b/internal/controller/mcp_route_security_policy.go
@@ -33,6 +33,7 @@ import (
 const (
 	oauthWellKnownProtectedResourceMetadataPath   = "/.well-known/oauth-protected-resource"
 	oauthWellKnownAuthorizationServerMetadataPath = "/.well-known/oauth-authorization-server"
+	oidcWellKnownMetadataPath                     = "/.well-known/openid-configuration"
 
 	oauthProtectedResourceMetadataSuffix = "-oauth-protected-resource-metadata"
 	oauthAuthServerMetadataSuffix        = "-oauth-authorization-server-metadata"
@@ -675,6 +676,7 @@ func fetchOAuthAuthServerMetadata(authServer string, maxRetryElapsedTime time.Du
 	// Build the well-known URL according to the spec: https://datatracker.ietf.org/doc/html/rfc8414#section-3
 	// Some providers like Descope do not honor the spec and put the well-known endpoint
 	// after the issuer path, so we try a set of variants to maximize compatibility.
+	// See: https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-metadata-discovery
 	wellKnownURLVariants := []string{
 		fmt.Sprintf("%s://%s%s%s",
 			authServerURL.Scheme,
@@ -685,8 +687,20 @@ func fetchOAuthAuthServerMetadata(authServer string, maxRetryElapsedTime time.Du
 		fmt.Sprintf("%s://%s%s%s",
 			authServerURL.Scheme,
 			authServerURL.Host,
+			oidcWellKnownMetadataPath,
+			strings.TrimSuffix(authServerURL.Path, "/"),
+		),
+		fmt.Sprintf("%s://%s%s%s",
+			authServerURL.Scheme,
+			authServerURL.Host,
 			strings.TrimSuffix(authServerURL.Path, "/"),
 			oauthWellKnownAuthorizationServerMetadataPath,
+		),
+		fmt.Sprintf("%s://%s%s%s",
+			authServerURL.Scheme,
+			authServerURL.Host,
+			strings.TrimSuffix(authServerURL.Path, "/"),
+			oidcWellKnownMetadataPath,
 		),
 	}
 

--- a/internal/controller/mcp_route_security_policy_test.go
+++ b/internal/controller/mcp_route_security_policy_test.go
@@ -585,6 +585,20 @@ func Test_fetchOAuthServerMetadata(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 		},
 		{
+			name:           "oidc well-known at the end",
+			issuerPath:     "/some/path",
+			authSeverURL:   "/some/path/.well-known/openid-configuration",
+			forcedFailures: 0,
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "oidc well-known after issuer",
+			issuerPath:     "/some/path",
+			authSeverURL:   "/.well-known/openid-configuration/some/path",
+			forcedFailures: 0,
+			wantStatusCode: http.StatusOK,
+		},
+		{
 			name:           "unknown failure",
 			issuerPath:     "/",
 			authSeverURL:   "/.well-known/oauth-authorization-server",

--- a/internal/controller/mcp_route_test.go
+++ b/internal/controller/mcp_route_test.go
@@ -208,7 +208,7 @@ func Test_newHTTPRoute_MCPOauth(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mcp-route", Namespace: "ns"},
 		Spec: aigv1a1.MCPRouteSpec{
 			SecurityPolicy: &aigv1a1.MCPRouteSecurityPolicy{OAuth: &aigv1a1.MCPRouteOAuth{}},
-			Path:           ptr.To("/mcp/"),
+			Path:           ptr.To("/mcp"),
 			ParentRefs:     []gwapiv1.ParentReference{{Name: gwapiv1.ObjectName("gw")}},
 			BackendRefs:    []aigv1a1.MCPRouteBackendRef{{}},
 		},
@@ -217,12 +217,19 @@ func Test_newHTTPRoute_MCPOauth(t *testing.T) {
 	err := ctrlr.newMainHTTPRoute(httpRoute, mcpRoute)
 	require.NoError(t, err)
 
-	require.Len(t, httpRoute.Spec.Rules, 5) // 4 default routes for oauth which begins from index 1.
+	require.Len(t, httpRoute.Spec.Rules, 7) // 6 default routes for oauth which begins from index 1.
 	oauthRules := httpRoute.Spec.Rules[1:]
 	require.Equal(t, "oauth-protected-resource-metadata-root", string(ptr.Deref(oauthRules[0].Name, "")))
 	require.Equal(t, "oauth-protected-resource-metadata-suffix", string(ptr.Deref(oauthRules[1].Name, "")))
 	require.Equal(t, "oauth-authorization-server-metadata-root", string(ptr.Deref(oauthRules[2].Name, "")))
-	require.Equal(t, "oauth-authorization-server-metadata-suffix", string(ptr.Deref(oauthRules[3].Name, "")))
+	require.Equal(t, "oauth-authorization-server-metadata-root-oidc", string(ptr.Deref(oauthRules[3].Name, "")))
+	require.Equal(t, "oauth-authorization-server-metadata-suffix", string(ptr.Deref(oauthRules[4].Name, "")))
+	require.Equal(t, "oauth-authorization-server-metadata-suffix-oidc", string(ptr.Deref(oauthRules[5].Name, "")))
+
+	require.Equal(t, "/.well-known/oauth-authorization-server", ptr.Deref(oauthRules[2].Matches[0].Path.Value, ""))
+	require.Equal(t, "/.well-known/openid-configuration", ptr.Deref(oauthRules[3].Matches[0].Path.Value, ""))
+	require.Equal(t, "/.well-known/oauth-authorization-server/mcp", ptr.Deref(oauthRules[4].Matches[0].Path.Value, ""))
+	require.Equal(t, "/.well-known/openid-configuration/mcp", ptr.Deref(oauthRules[5].Matches[0].Path.Value, ""))
 }
 
 func TestMCPRouteController_updateMCPRouteStatus(t *testing.T) {

--- a/internal/extensionserver/mcproute.go
+++ b/internal/extensionserver/mcproute.go
@@ -578,8 +578,11 @@ func (s *Server) modifyMCPOAuthCustomResponseRoute(routes []*routev3.RouteConfig
 const (
 	oauthProtectedResourcePath   = "/.well-known/oauth-protected-resource"
 	oauthAuthorizationServerPath = "/.well-known/oauth-authorization-server"
+	oidcAuthorizationServerPath  = "/.well-known/openid-configuration"
 )
 
 func isWellKnownOAuthPath(path string) bool {
-	return strings.Contains(path, oauthProtectedResourcePath) || strings.Contains(path, oauthAuthorizationServerPath)
+	return strings.Contains(path, oauthProtectedResourcePath) ||
+		strings.Contains(path, oauthAuthorizationServerPath) ||
+		strings.Contains(path, oidcAuthorizationServerPath)
 }

--- a/internal/extensionserver/mcproute_test.go
+++ b/internal/extensionserver/mcproute_test.go
@@ -738,6 +738,21 @@ func TestIsWellKnownOAuthPath(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "oauth authorization server with path",
+			path:     "/.well-known/oauth-authorization-server/issuer",
+			expected: true,
+		},
+		{
+			name:     "oidc authorization server",
+			path:     "/.well-known/openid-configuration",
+			expected: true,
+		},
+		{
+			name:     "oidc authorization server with path",
+			path:     "/.well-known/openid-configuration/issuer",
+			expected: true,
+		},
+		{
 			name:     "oauth protected resource with suffix",
 			path:     "/.well-known/oauth-protected-resource/mcp",
 			expected: true,


### PR DESCRIPTION
**Description**

Adds support for the OIDC discovery well-known endpoints for the MCP OAuth authorization servers.

**Related Issues/PRs (if applicable)**

Fixes https://github.com/envoyproxy/ai-gateway/issues/1577

**Special notes for reviewers (if applicable)**

N/A