### PR TITLE
feat: add support for audio transcription endpoint /v1/audio/transcriptions

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -255,6 +255,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	embeddingsMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationEmbedding)
 	imageGenerationMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationImageGeneration)
 	rerankMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationRerank)
+	audioTranscriptionMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationAudioTranscription)
 	mcpMetrics := metrics.NewMCP(meter, metricsRequestHeaderAttributes)
 
 	tracing, err := tracing.NewTracingFromEnv(ctx, os.Stdout, spanRequestHeaderAttributes)
@@ -273,6 +274,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Cohere, "/v2/rerank"), extproc.RerankProcessorFactory(rerankMetricsFactory))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/models"), extproc.NewModelsProcessor)
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Anthropic, "/v1/messages"), extproc.MessagesProcessorFactory(messagesMetricsFactory))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/audio/transcriptions"), extproc.AudioTranscriptionProcessorFactory(audioTranscriptionMetricsFactory))
 
 	if watchErr := filterapi.StartConfigWatcher(ctx, flags.configPath, server, l, time.Second*5); watchErr != nil {
 		return fmt.Errorf("failed to start config watcher: %w", watchErr)

--- a/internal/apischema/openai/audio.go
+++ b/internal/apischema/openai/audio.go
@@ -1,0 +1,42 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package openai
+
+type AudioTranscriptionRequest struct {
+	Model                  string   `json:"model"`
+	Language               string   `json:"language,omitempty"`
+	Prompt                 string   `json:"prompt,omitempty"`
+	ResponseFormat         string   `json:"response_format,omitempty"`
+	Temperature            *float64 `json:"temperature,omitempty"`
+	TimestampGranularities []string `json:"timestamp_granularities,omitempty"`
+}
+
+type AudioTranscriptionResponse struct {
+	Text     string                 `json:"text"`
+	Language string                 `json:"language,omitempty"`
+	Duration float64                `json:"duration,omitempty"`
+	Segments []TranscriptionSegment `json:"segments,omitempty"`
+	Words    []TranscriptionWord    `json:"words,omitempty"`
+}
+
+type TranscriptionSegment struct {
+	ID               int     `json:"id"`
+	Seek             int     `json:"seek"`
+	Start            float64 `json:"start"`
+	End              float64 `json:"end"`
+	Text             string  `json:"text"`
+	Tokens           []int   `json:"tokens"`
+	Temperature      float64 `json:"temperature"`
+	AvgLogprob       float64 `json:"avg_logprob"`
+	CompressionRatio float64 `json:"compression_ratio"`
+	NoSpeechProb     float64 `json:"no_speech_prob"`
+}
+
+type TranscriptionWord struct {
+	Word  string  `json:"word"`
+	Start float64 `json:"start"`
+	End   float64 `json:"end"`
+}

--- a/internal/extproc/audiotranscription_processor.go
+++ b/internal/extproc/audiotranscription_processor.go
@@ -1,0 +1,422 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"strconv"
+	"strings"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/headermutator"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
+	"github.com/envoyproxy/ai-gateway/internal/translator"
+)
+
+// AudioTranscriptionProcessorFactory returns a factory method to instantiate the audio transcription processor.
+func AudioTranscriptionProcessorFactory(f metrics.Factory) ProcessorFactory {
+	return func(config *filterapi.RuntimeConfig, requestHeaders map[string]string, logger *slog.Logger, _ tracing.Tracing, isUpstreamFilter bool) (Processor, error) {
+		logger = logger.With("processor", "audio-transcription", "isUpstreamFilter", fmt.Sprintf("%v", isUpstreamFilter))
+		if !isUpstreamFilter {
+			return &audioTranscriptionProcessorRouterFilter{
+				config:         config,
+				requestHeaders: requestHeaders,
+				logger:         logger,
+			}, nil
+		}
+		return &audioTranscriptionProcessorUpstreamFilter{
+			config:         config,
+			requestHeaders: requestHeaders,
+			logger:         logger,
+			metrics:        f.NewMetrics(),
+		}, nil
+	}
+}
+
+type audioTranscriptionProcessorRouterFilter struct {
+	passThroughProcessor
+	upstreamFilter         Processor
+	logger                 *slog.Logger
+	config                 *filterapi.RuntimeConfig
+	requestHeaders         map[string]string
+	originalRequestBody    *openai.AudioTranscriptionRequest
+	originalRequestBodyRaw []byte
+	upstreamFilterCount    int
+}
+
+func (a *audioTranscriptionProcessorRouterFilter) ProcessResponseHeaders(ctx context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	if a.upstreamFilter != nil {
+		return a.upstreamFilter.ProcessResponseHeaders(ctx, headerMap)
+	}
+	return a.passThroughProcessor.ProcessResponseHeaders(ctx, headerMap)
+}
+
+func (a *audioTranscriptionProcessorRouterFilter) ProcessResponseBody(ctx context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	if a.upstreamFilter != nil {
+		return a.upstreamFilter.ProcessResponseBody(ctx, body)
+	}
+	return a.passThroughProcessor.ProcessResponseBody(ctx, body)
+}
+
+func (a *audioTranscriptionProcessorRouterFilter) ProcessRequestBody(_ context.Context, rawBody *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	contentType := a.requestHeaders["content-type"]
+	model, body, err := parseAudioTranscriptionBody(rawBody, contentType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	a.requestHeaders[internalapi.ModelNameHeaderKeyDefault] = model
+
+	var additionalHeaders []*corev3.HeaderValueOption
+	additionalHeaders = append(additionalHeaders, &corev3.HeaderValueOption{
+		Header: &corev3.HeaderValue{Key: internalapi.ModelNameHeaderKeyDefault, RawValue: []byte(model)},
+	}, &corev3.HeaderValueOption{
+		Header: &corev3.HeaderValue{Key: originalPathHeader, RawValue: []byte(a.requestHeaders[":path"])},
+	})
+
+	a.originalRequestBody = body
+	a.originalRequestBodyRaw = rawBody.Body
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: &extprocv3.HeaderMutation{
+						SetHeaders: additionalHeaders,
+					},
+					ClearRouteCache: true,
+				},
+			},
+		},
+	}, nil
+}
+
+type audioTranscriptionProcessorUpstreamFilter struct {
+	logger                 *slog.Logger
+	config                 *filterapi.RuntimeConfig
+	requestHeaders         map[string]string
+	responseHeaders        map[string]string
+	responseEncoding       string
+	modelNameOverride      internalapi.ModelNameOverride
+	backendName            string
+	handler                filterapi.BackendAuthHandler
+	headerMutator          *headermutator.HeaderMutator
+	originalRequestBodyRaw []byte
+	originalRequestBody    *openai.AudioTranscriptionRequest
+	translator             translator.AudioTranscriptionTranslator
+	onRetry                bool
+	costs                  metrics.TokenUsage
+	metrics                metrics.Metrics
+}
+
+func (a *audioTranscriptionProcessorUpstreamFilter) selectTranslator(out filterapi.VersionedAPISchema) error {
+	switch out.Name {
+	case filterapi.APISchemaOpenAI:
+		a.translator = translator.NewAudioTranscriptionOpenAIToOpenAITranslator(out.Version, a.modelNameOverride)
+	case filterapi.APISchemaGCPVertexAI:
+		a.translator = translator.NewAudioTranscriptionOpenAIToGCPVertexAITranslator(a.modelNameOverride)
+	default:
+		return fmt.Errorf("unsupported API schema: backend=%s", out)
+	}
+	return nil
+}
+
+func (a *audioTranscriptionProcessorUpstreamFilter) ProcessRequestHeaders(ctx context.Context, _ *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
+	defer func() {
+		if err != nil {
+			a.metrics.RecordRequestCompletion(ctx, false, a.requestHeaders)
+		}
+	}()
+
+	a.metrics.StartRequest(a.requestHeaders)
+	a.metrics.SetOriginalModel(a.originalRequestBody.Model)
+	reqModel := cmp.Or(a.requestHeaders[internalapi.ModelNameHeaderKeyDefault], a.originalRequestBody.Model)
+	a.metrics.SetRequestModel(reqModel)
+
+	// Set content-type header for GCP Vertex AI translator if needed
+	if gcpTranslator, ok := a.translator.(interface{ SetContentType(string) }); ok {
+		gcpTranslator.SetContentType(a.requestHeaders["content-type"])
+	}
+
+	headerMutation, bodyMutation, err := a.translator.RequestBody(a.originalRequestBodyRaw, a.originalRequestBody, a.onRetry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform request: %w", err)
+	}
+
+	if headerMutation == nil {
+		headerMutation = &extprocv3.HeaderMutation{}
+	}
+
+	if h := a.headerMutator; h != nil {
+		sets, removes := a.headerMutator.Mutate(a.requestHeaders, a.onRetry)
+		headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, removes...)
+		for _, hdr := range sets {
+			headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
+				AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+				Header: &corev3.HeaderValue{
+					Key:      hdr.Key(),
+					RawValue: []byte(hdr.Value()),
+				},
+			})
+		}
+	}
+
+	for _, h := range headerMutation.SetHeaders {
+		a.requestHeaders[h.Header.Key] = string(h.Header.RawValue)
+	}
+	if h := a.handler; h != nil {
+		var hdrs []internalapi.Header
+		hdrs, err = h.Do(ctx, a.requestHeaders, bodyMutation.GetBody())
+		if err != nil {
+			return nil, fmt.Errorf("failed to do auth request: %w", err)
+		}
+		for _, h := range hdrs {
+			headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
+				AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+				Header:       &corev3.HeaderValue{Key: h.Key(), RawValue: []byte(h.Value())},
+			})
+		}
+	}
+
+	var dm *structpb.Struct
+	if bm := bodyMutation.GetBody(); bm != nil {
+		dm = buildContentLengthDynamicMetadataOnRequest(len(bm))
+	}
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extprocv3.HeadersResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation, BodyMutation: bodyMutation,
+					Status: extprocv3.CommonResponse_CONTINUE_AND_REPLACE,
+				},
+			},
+		},
+		DynamicMetadata: dm,
+	}, nil
+}
+
+func (a *audioTranscriptionProcessorUpstreamFilter) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (res *extprocv3.ProcessingResponse, err error) {
+	panic("BUG: ProcessRequestBody should not be called in the upstream filter")
+}
+
+func (a *audioTranscriptionProcessorUpstreamFilter) ProcessResponseHeaders(ctx context.Context, headers *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
+	defer func() {
+		if err != nil {
+			a.metrics.RecordRequestCompletion(ctx, false, a.requestHeaders)
+		}
+	}()
+
+	a.responseHeaders = headersToMap(headers)
+	if enc := a.responseHeaders["content-encoding"]; enc != "" {
+		a.responseEncoding = enc
+	}
+	headerMutation, err := a.translator.ResponseHeaders(a.responseHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform response headers: %w", err)
+	}
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+		ResponseHeaders: &extprocv3.HeadersResponse{
+			Response: &extprocv3.CommonResponse{HeaderMutation: headerMutation},
+		},
+	}}, nil
+}
+
+func (a *audioTranscriptionProcessorUpstreamFilter) ProcessResponseBody(ctx context.Context, body *extprocv3.HttpBody) (res *extprocv3.ProcessingResponse, err error) {
+	recordRequestCompletionErr := false
+	defer func() {
+		if err != nil || recordRequestCompletionErr {
+			a.metrics.RecordRequestCompletion(ctx, false, a.requestHeaders)
+			return
+		}
+		if body.EndOfStream {
+			a.metrics.RecordRequestCompletion(ctx, true, a.requestHeaders)
+		}
+	}()
+
+	decodingResult, err := decodeContentIfNeeded(body.Body, a.responseEncoding)
+	if err != nil {
+		return nil, err
+	}
+
+	if code, _ := strconv.Atoi(a.responseHeaders[":status"]); !isGoodStatusCode(code) {
+		var headerMutation *extprocv3.HeaderMutation
+		var bodyMutation *extprocv3.BodyMutation
+		headerMutation, bodyMutation, err = a.translator.ResponseError(a.responseHeaders, decodingResult.reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform response error: %w", err)
+		}
+		recordRequestCompletionErr = true
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseBody{
+				ResponseBody: &extprocv3.BodyResponse{
+					Response: &extprocv3.CommonResponse{
+						HeaderMutation: headerMutation,
+						BodyMutation:   bodyMutation,
+					},
+				},
+			},
+		}, nil
+	}
+
+	headerMutation, bodyMutation, tokenUsage, responseModel, err := a.translator.ResponseBody(a.responseHeaders, decodingResult.reader, body.EndOfStream)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform response: %w", err)
+	}
+
+	headerMutation = removeContentEncodingIfNeeded(headerMutation, bodyMutation, decodingResult.isEncoded)
+
+	resp := &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseBody{
+			ResponseBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+	}
+
+	// Update costs with token usage from translator
+	a.costs.Override(tokenUsage)
+
+	a.metrics.SetResponseModel(responseModel)
+	a.metrics.RecordTokenUsage(ctx, a.costs, a.requestHeaders)
+
+	if body.EndOfStream && len(a.config.RequestCosts) > 0 {
+		resp.DynamicMetadata, err = buildDynamicMetadata(a.config, &a.costs, a.requestHeaders, a.backendName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build dynamic metadata: %w", err)
+		}
+	}
+
+	return resp, nil
+}
+
+func (a *audioTranscriptionProcessorUpstreamFilter) SetBackend(ctx context.Context, b *filterapi.Backend, backendHandler filterapi.BackendAuthHandler, routeProcessor Processor) (err error) {
+	defer func() {
+		if err != nil {
+			a.metrics.RecordRequestCompletion(ctx, false, a.requestHeaders)
+		}
+	}()
+	rp, ok := routeProcessor.(*audioTranscriptionProcessorRouterFilter)
+	if !ok {
+		panic("BUG: expected routeProcessor to be of type *audioTranscriptionProcessorRouterFilter")
+	}
+	rp.upstreamFilterCount++
+	a.metrics.SetBackend(b)
+	a.modelNameOverride = b.ModelNameOverride
+	a.backendName = b.Name
+	a.originalRequestBody = rp.originalRequestBody
+	a.originalRequestBodyRaw = rp.originalRequestBodyRaw
+	a.onRetry = rp.upstreamFilterCount > 1
+	if err = a.selectTranslator(b.Schema); err != nil {
+		return fmt.Errorf("failed to select translator: %w", err)
+	}
+
+	a.handler = backendHandler
+	a.headerMutator = headermutator.NewHeaderMutator(b.HeaderMutation, rp.requestHeaders)
+	if a.modelNameOverride != "" {
+		a.requestHeaders[internalapi.ModelNameHeaderKeyDefault] = a.modelNameOverride
+		a.metrics.SetRequestModel(a.modelNameOverride)
+	}
+	rp.upstreamFilter = a
+	return
+}
+
+func parseAudioTranscriptionBody(body *extprocv3.HttpBody, contentType string) (modelName string, rb *openai.AudioTranscriptionRequest, err error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse content-type: %w", err)
+	}
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		boundary, ok := params["boundary"]
+		if !ok {
+			return "", nil, fmt.Errorf("multipart content-type missing boundary")
+		}
+
+		req := &openai.AudioTranscriptionRequest{}
+		reader := multipart.NewReader(bytes.NewReader(body.Body), boundary)
+
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to read multipart part: %w", err)
+			}
+
+			formName := part.FormName()
+			switch formName {
+			case "model":
+				modelBytes, err := io.ReadAll(part)
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to read model field: %w", err)
+				}
+				req.Model = string(modelBytes)
+			case "language":
+				langBytes, err := io.ReadAll(part)
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to read language field: %w", err)
+				}
+				req.Language = string(langBytes)
+			case "prompt":
+				promptBytes, err := io.ReadAll(part)
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to read prompt field: %w", err)
+				}
+				req.Prompt = string(promptBytes)
+			case "response_format":
+				formatBytes, err := io.ReadAll(part)
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to read response_format field: %w", err)
+				}
+				req.ResponseFormat = string(formatBytes)
+			case "temperature":
+				tempBytes, err := io.ReadAll(part)
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to read temperature field: %w", err)
+				}
+				var temp float64
+				if err := json.Unmarshal(tempBytes, &temp); err == nil {
+					req.Temperature = &temp
+				}
+			case "file":
+				// Just skip the file part - the translator will extract it from rawBody
+			default:
+			}
+			part.Close()
+		}
+
+		if req.Model == "" {
+			req.Model = "whisper-1"
+		}
+
+		return req.Model, req, nil
+	}
+
+	var req openai.AudioTranscriptionRequest
+	if err := json.Unmarshal(body.Body, &req); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	return req.Model, &req, nil
+}

--- a/internal/extproc/audiotranscription_processor_test.go
+++ b/internal/extproc/audiotranscription_processor_test.go
@@ -1,0 +1,835 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
+	"github.com/envoyproxy/ai-gateway/internal/translator"
+)
+
+type mockAudioTranscriptionTranslator struct {
+	t                   *testing.T
+	expHeaders          map[string]string
+	expRequestBody      *openai.AudioTranscriptionRequest
+	expResponseBody     []byte
+	retHeaderMutation   *extprocv3.HeaderMutation
+	retBodyMutation     *extprocv3.BodyMutation
+	retUsedToken        metrics.TokenUsage
+	retResponseModel    internalapi.ResponseModel
+	retErr              error
+	responseErrorCalled bool
+	useGeminiDirectPath bool
+	contentType         string
+}
+
+func (m *mockAudioTranscriptionTranslator) RequestBody(_ []byte, body *openai.AudioTranscriptionRequest, _ bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	if m.expRequestBody != nil {
+		require.Equal(m.t, m.expRequestBody, body)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
+}
+
+func (m *mockAudioTranscriptionTranslator) ResponseHeaders(headers map[string]string) (*extprocv3.HeaderMutation, error) {
+	if m.expHeaders != nil {
+		require.Equal(m.t, m.expHeaders, headers)
+	}
+	return m.retHeaderMutation, m.retErr
+}
+
+func (m *mockAudioTranscriptionTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, metrics.TokenUsage, internalapi.ResponseModel, error) {
+	if m.expResponseBody != nil {
+		buf, err := io.ReadAll(body)
+		require.NoError(m.t, err)
+		require.Equal(m.t, m.expResponseBody, buf)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retUsedToken, m.retResponseModel, m.retErr
+}
+
+func (m *mockAudioTranscriptionTranslator) ResponseError(_ map[string]string, body io.Reader) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	m.responseErrorCalled = true
+	if m.expResponseBody != nil {
+		buf, err := io.ReadAll(body)
+		require.NoError(m.t, err)
+		require.Equal(m.t, m.expResponseBody, buf)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
+}
+
+func (m *mockAudioTranscriptionTranslator) SetUseGeminiDirectPath(use bool) {
+	m.useGeminiDirectPath = use
+}
+
+func (m *mockAudioTranscriptionTranslator) SetContentType(contentType string) {
+	m.contentType = contentType
+}
+
+var _ translator.AudioTranscriptionTranslator = &mockAudioTranscriptionTranslator{}
+
+func TestAudioTranscriptionProcessorFactory(t *testing.T) {
+	t.Run("router filter", func(t *testing.T) {
+		factory := AudioTranscriptionProcessorFactory(&mockMetricsFactory{})
+		processor, err := factory(&filterapi.RuntimeConfig{}, map[string]string{}, slog.Default(), tracing.NoopTracing{}, false)
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		require.IsType(t, &audioTranscriptionProcessorRouterFilter{}, processor)
+	})
+
+	t.Run("upstream filter", func(t *testing.T) {
+		factory := AudioTranscriptionProcessorFactory(&mockMetricsFactory{})
+		processor, err := factory(&filterapi.RuntimeConfig{}, map[string]string{}, slog.Default(), tracing.NoopTracing{}, true)
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		require.IsType(t, &audioTranscriptionProcessorUpstreamFilter{}, processor)
+	})
+}
+
+func TestAudioTranscriptionProcessorRouterFilter_ProcessRequestBody(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		p := &audioTranscriptionProcessorRouterFilter{
+			requestHeaders: map[string]string{
+				":path":        "/v1/audio/transcriptions",
+				"content-type": "application/json",
+			},
+		}
+		_, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: []byte("invalid")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse request body")
+	})
+
+	t.Run("success json", func(t *testing.T) {
+		req := openai.AudioTranscriptionRequest{
+			Model: "whisper-1",
+		}
+		reqBody, _ := json.Marshal(req)
+
+		p := &audioTranscriptionProcessorRouterFilter{
+			config: &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{
+				":path":        "/v1/audio/transcriptions",
+				"content-type": "application/json",
+			},
+			logger: slog.Default(),
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rb := resp.GetRequestBody()
+		require.NotNil(t, rb)
+		require.True(t, rb.Response.ClearRouteCache)
+
+		headers := rb.Response.HeaderMutation.SetHeaders
+		require.Len(t, headers, 2)
+		require.Equal(t, internalapi.ModelNameHeaderKeyDefault, headers[0].Header.Key)
+		require.Equal(t, "whisper-1", string(headers[0].Header.RawValue))
+	})
+
+	t.Run("success multipart", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		_ = writer.WriteField("model", "whisper-1")
+		_ = writer.WriteField("language", "en")
+
+		part, _ := writer.CreateFormFile("file", "test.mp3")
+		_, _ = part.Write([]byte("audio data"))
+
+		writer.Close()
+
+		p := &audioTranscriptionProcessorRouterFilter{
+			config: &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{
+				":path":        "/v1/audio/transcriptions",
+				"content-type": writer.FormDataContentType(),
+			},
+			logger: slog.Default(),
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: buf.Bytes()})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rb := resp.GetRequestBody()
+		require.NotNil(t, rb)
+		require.True(t, rb.Response.ClearRouteCache)
+
+		headers := rb.Response.HeaderMutation.SetHeaders
+		require.Len(t, headers, 2)
+		require.Equal(t, internalapi.ModelNameHeaderKeyDefault, headers[0].Header.Key)
+		require.Equal(t, "whisper-1", string(headers[0].Header.RawValue))
+	})
+}
+
+func TestAudioTranscriptionProcessorRouterFilter_ProcessResponseHeaders(t *testing.T) {
+	t.Run("with upstream filter", func(t *testing.T) {
+		headerMap := &corev3.HeaderMap{}
+		mockUpstream := &mockProcessor{
+			t:                     t,
+			expHeaderMap:          headerMap,
+			retProcessingResponse: &extprocv3.ProcessingResponse{},
+		}
+		p := &audioTranscriptionProcessorRouterFilter{
+			upstreamFilter: mockUpstream,
+		}
+
+		resp, err := p.ProcessResponseHeaders(context.Background(), headerMap)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("without upstream filter", func(t *testing.T) {
+		p := &audioTranscriptionProcessorRouterFilter{}
+		resp, err := p.ProcessResponseHeaders(context.Background(), &corev3.HeaderMap{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+}
+
+func TestAudioTranscriptionProcessorRouterFilter_ProcessResponseBody(t *testing.T) {
+	t.Run("with upstream filter", func(t *testing.T) {
+		httpBody := &extprocv3.HttpBody{}
+		mockUpstream := &mockProcessor{
+			t:                     t,
+			expBody:               httpBody,
+			retProcessingResponse: &extprocv3.ProcessingResponse{},
+		}
+		p := &audioTranscriptionProcessorRouterFilter{
+			upstreamFilter: mockUpstream,
+		}
+
+		resp, err := p.ProcessResponseBody(context.Background(), httpBody)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("without upstream filter", func(t *testing.T) {
+		p := &audioTranscriptionProcessorRouterFilter{}
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+}
+
+func TestAudioTranscriptionProcessorUpstreamFilter_SelectTranslator(t *testing.T) {
+	t.Run("openai", func(t *testing.T) {
+		p := &audioTranscriptionProcessorUpstreamFilter{}
+		err := p.selectTranslator(filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"})
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+	})
+
+	t.Run("gcp vertex ai", func(t *testing.T) {
+		p := &audioTranscriptionProcessorUpstreamFilter{}
+		err := p.selectTranslator(filterapi.VersionedAPISchema{Name: filterapi.APISchemaGCPVertexAI})
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		p := &audioTranscriptionProcessorUpstreamFilter{}
+		err := p.selectTranslator(filterapi.VersionedAPISchema{Name: "unsupported"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported API schema")
+	})
+}
+
+func TestAudioTranscriptionProcessorUpstreamFilter_ProcessRequestHeaders(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{Mutation: &extprocv3.BodyMutation_Body{Body: []byte("test")}},
+		}
+
+		req := openai.AudioTranscriptionRequest{
+			Model: "whisper-1",
+		}
+		reqBody, _ := json.Marshal(req)
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			logger:                 slog.Default(),
+			config:                 &filterapi.RuntimeConfig{},
+			requestHeaders:         map[string]string{},
+			originalRequestBody:    &req,
+			originalRequestBodyRaw: reqBody,
+			translator:             mockTranslator,
+			metrics:                &mockMetrics{},
+		}
+
+		resp, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("translator error", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:      t,
+			retErr: errors.New("translator error"),
+		}
+
+		req := openai.AudioTranscriptionRequest{Model: "whisper-1"}
+		reqBody, _ := json.Marshal(req)
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			logger:                 slog.Default(),
+			config:                 &filterapi.RuntimeConfig{},
+			requestHeaders:         map[string]string{},
+			originalRequestBody:    &req,
+			originalRequestBodyRaw: reqBody,
+			translator:             mockTranslator,
+			metrics:                &mockMetrics{},
+		}
+
+		_, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to transform request")
+	})
+
+	t.Run("with auth handler", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{Mutation: &extprocv3.BodyMutation_Body{Body: []byte("test")}},
+		}
+
+		req := openai.AudioTranscriptionRequest{Model: "whisper-1"}
+		reqBody, _ := json.Marshal(req)
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			logger:                 slog.Default(),
+			config:                 &filterapi.RuntimeConfig{},
+			requestHeaders:         map[string]string{},
+			originalRequestBody:    &req,
+			originalRequestBodyRaw: reqBody,
+			translator:             mockTranslator,
+			handler:                &mockBackendAuthHandler{},
+			metrics:                &mockMetrics{},
+		}
+
+		resp, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("auth handler error", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{Mutation: &extprocv3.BodyMutation_Body{Body: []byte("test")}},
+		}
+
+		req := openai.AudioTranscriptionRequest{Model: "whisper-1"}
+		reqBody, _ := json.Marshal(req)
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			logger:                 slog.Default(),
+			config:                 &filterapi.RuntimeConfig{},
+			requestHeaders:         map[string]string{},
+			originalRequestBody:    &req,
+			originalRequestBodyRaw: reqBody,
+			translator:             mockTranslator,
+			handler:                &mockBackendAuthHandlerError{},
+			metrics:                &mockMetrics{},
+		}
+
+		_, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to do auth request")
+	})
+
+	t.Run("with content type setter", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{Mutation: &extprocv3.BodyMutation_Body{Body: []byte("test")}},
+		}
+
+		req := openai.AudioTranscriptionRequest{Model: "whisper-1"}
+		reqBody, _ := json.Marshal(req)
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			logger:                 slog.Default(),
+			config:                 &filterapi.RuntimeConfig{},
+			requestHeaders:         map[string]string{"content-type": "multipart/form-data"},
+			originalRequestBody:    &req,
+			originalRequestBodyRaw: reqBody,
+			translator:             mockTranslator,
+			metrics:                &mockMetrics{},
+		}
+
+		resp, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, "multipart/form-data", mockTranslator.contentType)
+	})
+}
+
+func TestAudioTranscriptionProcessorUpstreamFilter_ProcessRequestBody(t *testing.T) {
+	p := &audioTranscriptionProcessorUpstreamFilter{}
+	require.Panics(t, func() {
+		_, _ = p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{})
+	})
+}
+
+func TestAudioTranscriptionProcessorUpstreamFilter_ProcessResponseHeaders(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator: mockTranslator,
+			metrics:    &mockMetrics{},
+		}
+
+		headers := &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "content-type", RawValue: []byte("application/json")},
+			},
+		}
+
+		resp, err := p.ProcessResponseHeaders(context.Background(), headers)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("with content-encoding", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator: mockTranslator,
+			metrics:    &mockMetrics{},
+		}
+
+		headers := &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: "content-encoding", RawValue: []byte("gzip")},
+			},
+		}
+
+		resp, err := p.ProcessResponseHeaders(context.Background(), headers)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, "gzip", p.responseEncoding)
+	})
+
+	t.Run("translator error", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:      t,
+			retErr: errors.New("translator error"),
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator: mockTranslator,
+			metrics:    &mockMetrics{},
+		}
+
+		_, err := p.ProcessResponseHeaders(context.Background(), &corev3.HeaderMap{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to transform response headers")
+	})
+}
+
+func TestAudioTranscriptionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
+	t.Run("success end of stream", func(t *testing.T) {
+		var tokenUsage metrics.TokenUsage
+		tokenUsage.SetInputTokens(100)
+		tokenUsage.SetTotalTokens(100)
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{},
+			retUsedToken:      tokenUsage,
+			retResponseModel:  "whisper-1",
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator:      mockTranslator,
+			requestHeaders:  map[string]string{},
+			responseHeaders: map[string]string{":status": "200"},
+			config:          &filterapi.RuntimeConfig{},
+			metrics:         &mockMetrics{},
+		}
+
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        []byte(`{"text": "transcribed text"}`),
+			EndOfStream: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("not end of stream", func(t *testing.T) {
+		var tokenUsage metrics.TokenUsage
+		tokenUsage.SetInputTokens(50)
+		tokenUsage.SetTotalTokens(50)
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{},
+			retUsedToken:      tokenUsage,
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator:      mockTranslator,
+			requestHeaders:  map[string]string{},
+			responseHeaders: map[string]string{":status": "200"},
+			config:          &filterapi.RuntimeConfig{},
+			metrics:         &mockMetrics{},
+		}
+
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        []byte(`{"text": "partial"}`),
+			EndOfStream: false,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator:      mockTranslator,
+			requestHeaders:  map[string]string{},
+			responseHeaders: map[string]string{":status": "400"},
+			config:          &filterapi.RuntimeConfig{},
+			metrics:         &mockMetrics{},
+		}
+
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        []byte("error"),
+			EndOfStream: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, mockTranslator.responseErrorCalled)
+	})
+
+	t.Run("translator error", func(t *testing.T) {
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:      t,
+			retErr: errors.New("translator error"),
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator:      mockTranslator,
+			requestHeaders:  map[string]string{},
+			responseHeaders: map[string]string{":status": "200"},
+			config:          &filterapi.RuntimeConfig{},
+			metrics:         &mockMetrics{},
+		}
+
+		_, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        []byte(`{"text": "test"}`),
+			EndOfStream: true,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to transform response")
+	})
+
+	t.Run("token override", func(t *testing.T) {
+		// First chunk returns empty token usage (not end of stream)
+		var emptyTokenUsage metrics.TokenUsage
+
+		// Final chunk returns the cumulative token usage
+		var finalTokenUsage metrics.TokenUsage
+		finalTokenUsage.SetInputTokens(100)
+		finalTokenUsage.SetTotalTokens(100)
+
+		mockTranslator := &mockAudioTranscriptionTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation:   &extprocv3.BodyMutation{},
+			retUsedToken:      emptyTokenUsage,
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			translator:      mockTranslator,
+			requestHeaders:  map[string]string{},
+			responseHeaders: map[string]string{":status": "200"},
+			config:          &filterapi.RuntimeConfig{},
+			metrics:         &mockMetrics{},
+		}
+
+		// First call (not end of stream) - translator returns empty token usage
+		_, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        []byte(`{"text": "test1"}`),
+			EndOfStream: false,
+		})
+		require.NoError(t, err)
+		// Costs should be empty since translator returned empty token usage
+		_, inputSet := p.costs.InputTokens()
+		_, totalSet := p.costs.TotalTokens()
+		require.False(t, inputSet)
+		require.False(t, totalSet)
+
+		// Update mock to return final token usage for end of stream
+		mockTranslator.retUsedToken = finalTokenUsage
+
+		// Second call (end of stream) - translator returns cumulative token usage
+		_, err = p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        []byte(`{"text": "test2"}`),
+			EndOfStream: true,
+		})
+		require.NoError(t, err)
+		inputTokens, _ := p.costs.InputTokens()
+		totalTokens, _ := p.costs.TotalTokens()
+		require.Equal(t, uint32(100), inputTokens)
+		require.Equal(t, uint32(100), totalTokens)
+	})
+}
+
+func TestAudioTranscriptionProcessorUpstreamFilter_SetBackend(t *testing.T) {
+	t.Run("openai backend", func(t *testing.T) {
+		routeProcessor := &audioTranscriptionProcessorRouterFilter{
+			originalRequestBody:    &openai.AudioTranscriptionRequest{Model: "whisper-1"},
+			originalRequestBodyRaw: []byte("test"),
+		}
+
+		backend := &filterapi.Backend{
+			Name:   "test-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{},
+			metrics:        &mockMetrics{},
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, routeProcessor)
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+		require.Equal(t, "test-backend", p.backendName)
+	})
+
+	t.Run("gcp vertex ai backend", func(t *testing.T) {
+		routeProcessor := &audioTranscriptionProcessorRouterFilter{
+			originalRequestBody:    &openai.AudioTranscriptionRequest{Model: "whisper-1"},
+			originalRequestBodyRaw: []byte("test"),
+		}
+
+		backend := &filterapi.Backend{
+			Name:   "gcp-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaGCPVertexAI},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{},
+			metrics:        &mockMetrics{},
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, routeProcessor)
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+	})
+
+	t.Run("model name override", func(t *testing.T) {
+		routeProcessor := &audioTranscriptionProcessorRouterFilter{
+			originalRequestBody:    &openai.AudioTranscriptionRequest{Model: "whisper-1"},
+			originalRequestBodyRaw: []byte("test"),
+			requestHeaders:         map[string]string{},
+		}
+
+		backend := &filterapi.Backend{
+			Name:              "test-backend",
+			Schema:            filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"},
+			ModelNameOverride: "override-model",
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{},
+			metrics:        &mockMetrics{},
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, routeProcessor)
+		require.NoError(t, err)
+		require.Equal(t, internalapi.ModelNameOverride("override-model"), p.modelNameOverride)
+	})
+
+	t.Run("unsupported schema", func(t *testing.T) {
+		routeProcessor := &audioTranscriptionProcessorRouterFilter{
+			originalRequestBody:    &openai.AudioTranscriptionRequest{Model: "whisper-1"},
+			originalRequestBodyRaw: []byte("test"),
+		}
+
+		backend := &filterapi.Backend{
+			Name:   "unsupported-backend",
+			Schema: filterapi.VersionedAPISchema{Name: "unsupported"},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			config:  &filterapi.RuntimeConfig{},
+			metrics: &mockMetrics{},
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, routeProcessor)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to select translator")
+	})
+
+	t.Run("panic on wrong processor type", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "test-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			config:  &filterapi.RuntimeConfig{},
+			metrics: &mockMetrics{},
+		}
+
+		require.Panics(t, func() {
+			_ = p.SetBackend(context.Background(), backend, nil, &mockProcessor{})
+		})
+	})
+
+	t.Run("retry scenario", func(t *testing.T) {
+		routeProcessor := &audioTranscriptionProcessorRouterFilter{
+			originalRequestBody:    &openai.AudioTranscriptionRequest{Model: "whisper-1"},
+			originalRequestBodyRaw: []byte("test"),
+			upstreamFilterCount:    1,
+		}
+
+		backend := &filterapi.Backend{
+			Name:   "test-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Version: "v1"},
+		}
+
+		p := &audioTranscriptionProcessorUpstreamFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{},
+			metrics:        &mockMetrics{},
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, routeProcessor)
+		require.NoError(t, err)
+		require.True(t, p.onRetry)
+		require.Equal(t, 2, routeProcessor.upstreamFilterCount)
+	})
+}
+
+func TestParseAudioTranscriptionBody(t *testing.T) {
+	t.Run("valid json body", func(t *testing.T) {
+		req := openai.AudioTranscriptionRequest{
+			Model:    "whisper-1",
+			Language: "en",
+			Prompt:   "test prompt",
+		}
+		body, _ := json.Marshal(req)
+
+		modelName, parsedReq, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: body}, "application/json")
+		require.NoError(t, err)
+		require.Equal(t, "whisper-1", modelName)
+		require.Equal(t, "en", parsedReq.Language)
+		require.Equal(t, "test prompt", parsedReq.Prompt)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, _, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: []byte("invalid")}, "application/json")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to unmarshal body")
+	})
+
+	t.Run("multipart with all fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		_ = writer.WriteField("model", "whisper-1")
+		_ = writer.WriteField("language", "en")
+		_ = writer.WriteField("prompt", "test prompt")
+		_ = writer.WriteField("response_format", "json")
+		_ = writer.WriteField("temperature", "0.5")
+
+		part, _ := writer.CreateFormFile("file", "test.mp3")
+		_, _ = part.Write([]byte("audio data"))
+
+		writer.Close()
+
+		modelName, parsedReq, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: buf.Bytes()}, writer.FormDataContentType())
+		require.NoError(t, err)
+		require.Equal(t, "whisper-1", modelName)
+		require.Equal(t, "en", parsedReq.Language)
+		require.Equal(t, "test prompt", parsedReq.Prompt)
+		require.Equal(t, "json", parsedReq.ResponseFormat)
+		require.NotNil(t, parsedReq.Temperature)
+		require.Equal(t, 0.5, *parsedReq.Temperature)
+	})
+
+	t.Run("multipart without model defaults to whisper-1", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		part, _ := writer.CreateFormFile("file", "test.mp3")
+		_, _ = part.Write([]byte("audio data"))
+
+		writer.Close()
+
+		modelName, parsedReq, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: buf.Bytes()}, writer.FormDataContentType())
+		require.NoError(t, err)
+		require.Equal(t, "whisper-1", modelName)
+		require.Equal(t, "whisper-1", parsedReq.Model)
+	})
+
+	t.Run("multipart missing boundary", func(t *testing.T) {
+		_, _, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: []byte("test")}, "multipart/form-data")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multipart content-type missing boundary")
+	})
+
+	t.Run("invalid content type", func(t *testing.T) {
+		_, _, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: []byte("test")}, "invalid;;content-type")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse content-type")
+	})
+
+	t.Run("multipart with temperature as invalid json", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		_ = writer.WriteField("model", "whisper-1")
+		_ = writer.WriteField("temperature", "not-a-number")
+
+		part, _ := writer.CreateFormFile("file", "test.mp3")
+		_, _ = part.Write([]byte("audio data"))
+
+		writer.Close()
+
+		modelName, parsedReq, err := parseAudioTranscriptionBody(&extprocv3.HttpBody{Body: buf.Bytes()}, writer.FormDataContentType())
+		require.NoError(t, err)
+		require.Equal(t, "whisper-1", modelName)
+		require.Nil(t, parsedReq.Temperature)
+	})
+}

--- a/internal/metrics/audio_transcription_metrics.go
+++ b/internal/metrics/audio_transcription_metrics.go
@@ -1,0 +1,21 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import (
+	"go.opentelemetry.io/otel/metric"
+)
+
+// AudioTranscriptionMetricsFactory is a type alias for Factory specialized for audio transcription metrics.
+type AudioTranscriptionMetricsFactory = Factory
+
+// AudioTranscriptionMetrics is a type alias for Metrics used by audio transcription processors.
+type AudioTranscriptionMetrics = Metrics
+
+// NewAudioTranscriptionFactory creates a new factory for audio transcription metrics.
+func NewAudioTranscriptionFactory(meter metric.Meter, requestHeaderAttributeMapping map[string]string) AudioTranscriptionMetricsFactory {
+	return NewMetricsFactory(meter, requestHeaderAttributeMapping, GenAIOperationAudioTranscription)
+}

--- a/internal/metrics/audio_transcription_metrics_test.go
+++ b/internal/metrics/audio_transcription_metrics_test.go
@@ -1,0 +1,277 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package metrics
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/testing/testotel"
+)
+
+func TestNewAudioTranscriptionFactory(t *testing.T) {
+	t.Parallel()
+	var (
+		mr    = metric.NewManualReader()
+		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+		am    = NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+	)
+
+	assert.NotNil(t, am)
+	assert.Equal(t, string(GenAIOperationAudioTranscription), am.operation)
+}
+
+func TestAudioTranscription_StartRequest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		t.Helper()
+		var (
+			mr    = metric.NewManualReader()
+			meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+			am    = NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+		)
+
+		before := time.Now()
+		am.StartRequest(nil)
+		after := time.Now()
+
+		assert.Equal(t, before, am.requestStart)
+		assert.Equal(t, after, am.requestStart)
+	})
+}
+
+func TestAudioTranscription_SetMethods(t *testing.T) {
+	t.Parallel()
+	var (
+		mr    = metric.NewManualReader()
+		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+		am    = NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+	)
+
+	am.SetOriginalModel("whisper-1")
+	assert.Equal(t, "whisper-1", am.originalModel)
+
+	am.SetRequestModel("whisper-1-large")
+	assert.Equal(t, "whisper-1-large", am.requestModel)
+
+	am.SetResponseModel("whisper-1-large-v2")
+	assert.Equal(t, "whisper-1-large-v2", am.responseModel)
+
+	am.SetBackend(&filterapi.Backend{Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}})
+	assert.Equal(t, genaiProviderOpenAI, am.backend)
+}
+
+func TestAudioTranscription_RecordTokenUsage(t *testing.T) {
+	t.Parallel()
+	var (
+		mr    = metric.NewManualReader()
+		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+		am    = NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+
+		attrs = []attribute.KeyValue{
+			attribute.Key(genaiAttributeOperationName).String(string(GenAIOperationAudioTranscription)),
+			attribute.Key(genaiAttributeProviderName).String(genaiProviderOpenAI),
+			attribute.Key(genaiAttributeOriginalModel).String("whisper-1"),
+			attribute.Key(genaiAttributeRequestModel).String("whisper-1"),
+			attribute.Key(genaiAttributeResponseModel).String("whisper-1"),
+		}
+		inputAttrs = attribute.NewSet(append(attrs, attribute.Key(genaiAttributeTokenType).String(genaiTokenTypeInput))...)
+	)
+
+	am.SetOriginalModel("whisper-1")
+	am.SetRequestModel("whisper-1")
+	am.SetResponseModel("whisper-1")
+	am.SetBackend(&filterapi.Backend{Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}})
+
+	var usage TokenUsage
+	usage.SetInputTokens(300)
+	am.RecordTokenUsage(t.Context(), usage, nil)
+
+	count, sum := testotel.GetHistogramValues(t, mr, genaiMetricClientTokenUsage, inputAttrs)
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, 300.0, sum)
+}
+
+func TestAudioTranscription_RecordTokenUsage_WithHeaders(t *testing.T) {
+	t.Parallel()
+	var (
+		mr    = metric.NewManualReader()
+		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+
+		headerMapping = map[string]string{
+			"x-user-id": "user.id",
+			"x-org-id":  "org.id",
+		}
+		am = NewAudioTranscriptionFactory(meter, headerMapping).NewMetrics().(*metricsImpl)
+
+		requestHeaders = map[string]string{
+			"x-user-id": "user456",
+			"x-org-id":  "org789",
+		}
+	)
+
+	am.SetOriginalModel("whisper-1")
+	am.SetRequestModel("whisper-1")
+	am.SetResponseModel("whisper-1")
+	am.SetBackend(&filterapi.Backend{Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}})
+
+	var usage TokenUsage
+	usage.SetInputTokens(250)
+	am.RecordTokenUsage(t.Context(), usage, requestHeaders)
+
+	attrs := attribute.NewSet(
+		attribute.Key(genaiAttributeOperationName).String(string(GenAIOperationAudioTranscription)),
+		attribute.Key(genaiAttributeProviderName).String(genaiProviderOpenAI),
+		attribute.Key(genaiAttributeOriginalModel).String("whisper-1"),
+		attribute.Key(genaiAttributeRequestModel).String("whisper-1"),
+		attribute.Key(genaiAttributeResponseModel).String("whisper-1"),
+		attribute.Key(genaiAttributeTokenType).String(genaiTokenTypeInput),
+		attribute.Key("user.id").String("user456"),
+		attribute.Key("org.id").String("org789"),
+	)
+
+	count, sum := testotel.GetHistogramValues(t, mr, genaiMetricClientTokenUsage, attrs)
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, 250.0, sum)
+}
+
+func TestAudioTranscription_RecordRequestCompletion(t *testing.T) {
+	synctest.Test(t, testAudioTranscriptionRecordRequestCompletion)
+}
+
+func testAudioTranscriptionRecordRequestCompletion(t *testing.T) {
+	t.Helper()
+
+	var (
+		mr    = metric.NewManualReader()
+		meter = metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+		am    = NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+		attrs = []attribute.KeyValue{
+			attribute.Key(genaiAttributeOperationName).String(string(GenAIOperationAudioTranscription)),
+			attribute.Key(genaiAttributeProviderName).String("custom"),
+			attribute.Key(genaiAttributeOriginalModel).String("whisper-1"),
+			attribute.Key(genaiAttributeRequestModel).String("whisper-1"),
+			attribute.Key(genaiAttributeResponseModel).String("whisper-1"),
+		}
+		attrsSuccess = attribute.NewSet(attrs...)
+		attrsFailure = attribute.NewSet(append(attrs, attribute.Key(genaiAttributeErrorType).String(genaiErrorTypeFallback))...)
+	)
+
+	am.StartRequest(nil)
+	am.SetOriginalModel("whisper-1")
+	am.SetRequestModel("whisper-1")
+	am.SetResponseModel("whisper-1")
+	am.SetBackend(&filterapi.Backend{Name: "custom"})
+
+	time.Sleep(15 * time.Millisecond)
+	am.RecordRequestCompletion(t.Context(), true, nil)
+	count, sum := testotel.GetHistogramValues(t, mr, genaiMetricServerRequestDuration, attrsSuccess)
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, 15*time.Millisecond.Seconds(), sum)
+
+	am.RecordRequestCompletion(t.Context(), false, nil)
+	count, sum = testotel.GetHistogramValues(t, mr, genaiMetricServerRequestDuration, attrsFailure)
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, 15*time.Millisecond.Seconds(), sum)
+}
+
+func TestAudioTranscription_ModelNameDiffers(t *testing.T) {
+	t.Parallel()
+	mr := metric.NewManualReader()
+	meter := metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+	am := NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+
+	am.SetBackend(&filterapi.Backend{Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}})
+	am.SetOriginalModel("whisper-1")
+	am.SetRequestModel("whisper-1-large")
+	am.SetResponseModel("whisper-1-large-v2-20231101")
+
+	var usage TokenUsage
+	usage.SetInputTokens(400)
+	am.RecordTokenUsage(t.Context(), usage, nil)
+
+	inputAttrs := attribute.NewSet(
+		attribute.Key(genaiAttributeOperationName).String(string(GenAIOperationAudioTranscription)),
+		attribute.Key(genaiAttributeProviderName).String(genaiProviderOpenAI),
+		attribute.Key(genaiAttributeOriginalModel).String("whisper-1"),
+		attribute.Key(genaiAttributeRequestModel).String("whisper-1-large"),
+		attribute.Key(genaiAttributeResponseModel).String("whisper-1-large-v2-20231101"),
+		attribute.Key(genaiAttributeTokenType).String(genaiTokenTypeInput),
+	)
+	count, sum := getHistogramValues(t, mr, genaiMetricClientTokenUsage, inputAttrs)
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, 400.0, sum)
+}
+
+func TestAudioTranscription_MultipleBackends(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		backendSchema   filterapi.APISchemaName
+		backendName     string
+		expectedBackend string
+	}{
+		{
+			name:            "OpenAI",
+			backendSchema:   filterapi.APISchemaOpenAI,
+			backendName:     "openai-backend",
+			expectedBackend: genaiProviderOpenAI,
+		},
+		{
+			name:            "AWS Bedrock",
+			backendSchema:   filterapi.APISchemaAWSBedrock,
+			backendName:     "bedrock-backend",
+			expectedBackend: genaiProviderAWSBedrock,
+		},
+		{
+			name:            "Custom Provider",
+			backendSchema:   "custom-schema",
+			backendName:     "custom-backend",
+			expectedBackend: "custom-backend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := metric.NewManualReader()
+			meter := metric.NewMeterProvider(metric.WithReader(mr)).Meter("test")
+			am := NewAudioTranscriptionFactory(meter, nil).NewMetrics().(*metricsImpl)
+
+			backend := &filterapi.Backend{
+				Name:   tt.backendName,
+				Schema: filterapi.VersionedAPISchema{Name: tt.backendSchema},
+			}
+
+			am.SetOriginalModel("whisper-1")
+			am.SetRequestModel("whisper-1")
+			am.SetResponseModel("whisper-1")
+			am.SetBackend(backend)
+
+			var usage TokenUsage
+			usage.SetInputTokens(100)
+			am.RecordTokenUsage(t.Context(), usage, nil)
+
+			attrs := attribute.NewSet(
+				attribute.Key(genaiAttributeOperationName).String(string(GenAIOperationAudioTranscription)),
+				attribute.Key(genaiAttributeProviderName).String(tt.expectedBackend),
+				attribute.Key(genaiAttributeOriginalModel).String("whisper-1"),
+				attribute.Key(genaiAttributeRequestModel).String("whisper-1"),
+				attribute.Key(genaiAttributeResponseModel).String("whisper-1"),
+				attribute.Key(genaiAttributeTokenType).String(genaiTokenTypeInput),
+			)
+
+			count, _ := getHistogramValues(t, mr, genaiMetricClientTokenUsage, attrs)
+			require.Equal(t, uint64(1), count)
+		})
+	}
+}

--- a/internal/metrics/genai.go
+++ b/internal/metrics/genai.go
@@ -24,16 +24,17 @@ const (
 	genaiAttributeTokenType     = "gen_ai.token.type" //nolint:gosec // metric name, not credential
 	genaiAttributeErrorType     = "error.type"
 
-	GenAIOperationChat            GenAIOperation = "chat"
-	GenAIOperationCompletion      GenAIOperation = "completion"
-	GenAIOperationEmbedding       GenAIOperation = "embeddings"
-	GenAIOperationMessages        GenAIOperation = "messages"
-	GenAIOperationImageGeneration GenAIOperation = "image_generation"
-	GenAIOperationRerank          GenAIOperation = "rerank"
-	genaiProviderOpenAI                          = "openai"
-	genaiProviderAWSBedrock                      = "aws.bedrock"
-	genaiTokenTypeInput                          = "input"
-	genaiTokenTypeOutput                         = "output"
+	GenAIOperationChat               GenAIOperation = "chat"
+	GenAIOperationCompletion         GenAIOperation = "completion"
+	GenAIOperationEmbedding          GenAIOperation = "embeddings"
+	GenAIOperationMessages           GenAIOperation = "messages"
+	GenAIOperationImageGeneration    GenAIOperation = "image_generation"
+	GenAIOperationRerank             GenAIOperation = "rerank"
+	GenAIOperationAudioTranscription GenAIOperation = "audio_transcription"
+	genaiProviderOpenAI                             = "openai"
+	genaiProviderAWSBedrock                         = "aws.bedrock"
+	genaiTokenTypeInput                             = "input"
+	genaiTokenTypeOutput                            = "output"
 	// "cached_input" is not yet part of the spec but has been proposed:
 	// https://github.com/open-telemetry/semantic-conventions/issues/1959
 	//

--- a/internal/translator/audio_openai_openai.go
+++ b/internal/translator/audio_openai_openai.go
@@ -1,0 +1,54 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"io"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+)
+
+// AudioTranscriptionTranslator is the interface for translating audio transcription requests and responses.
+type AudioTranscriptionTranslator interface {
+	RequestBody(rawBody []byte, body *openai.AudioTranscriptionRequest, onRetry bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error)
+	ResponseHeaders(headers map[string]string) (*extprocv3.HeaderMutation, error)
+	ResponseBody(headers map[string]string, body io.Reader, endOfStream bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, metrics.TokenUsage, internalapi.ResponseModel, error)
+	ResponseError(headers map[string]string, body io.Reader) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error)
+}
+
+type audioTranscriptionOpenAIToOpenAITranslator struct {
+	version           string
+	modelNameOverride internalapi.ModelNameOverride
+}
+
+func NewAudioTranscriptionOpenAIToOpenAITranslator(version string, modelNameOverride internalapi.ModelNameOverride) AudioTranscriptionTranslator {
+	return &audioTranscriptionOpenAIToOpenAITranslator{
+		version:           version,
+		modelNameOverride: modelNameOverride,
+	}
+}
+
+func (a *audioTranscriptionOpenAIToOpenAITranslator) RequestBody(rawBody []byte, _ *openai.AudioTranscriptionRequest, _ bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	return nil, &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{Body: rawBody},
+	}, nil
+}
+
+func (a *audioTranscriptionOpenAIToOpenAITranslator) ResponseHeaders(_ map[string]string) (*extprocv3.HeaderMutation, error) {
+	return nil, nil
+}
+
+func (a *audioTranscriptionOpenAIToOpenAITranslator) ResponseBody(_ map[string]string, _ io.Reader, _ bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, metrics.TokenUsage, internalapi.ResponseModel, error) {
+	return nil, nil, metrics.TokenUsage{}, "", nil
+}
+
+func (a *audioTranscriptionOpenAIToOpenAITranslator) ResponseError(_ map[string]string, _ io.Reader) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	return nil, nil, nil
+}

--- a/internal/translator/audio_openai_openai_test.go
+++ b/internal/translator/audio_openai_openai_test.go
@@ -1,0 +1,80 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+)
+
+func TestNewAudioTranscriptionOpenAIToOpenAITranslator(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToOpenAITranslator("v1", "override-model")
+	require.NotNil(t, translator)
+
+	impl, ok := translator.(*audioTranscriptionOpenAIToOpenAITranslator)
+	require.True(t, ok)
+	require.Equal(t, "v1", impl.version)
+	require.Equal(t, internalapi.ModelNameOverride("override-model"), impl.modelNameOverride)
+}
+
+func TestAudioTranscriptionOpenAIToOpenAITranslator_RequestBody(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToOpenAITranslator("v1", "")
+
+	rawBody := []byte("test-raw-body")
+	req := &openai.AudioTranscriptionRequest{
+		Model: "whisper-1",
+	}
+
+	headerMutation, bodyMutation, err := translator.RequestBody(rawBody, req, false)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+	require.NotNil(t, bodyMutation)
+	require.Equal(t, rawBody, bodyMutation.GetBody())
+}
+
+func TestAudioTranscriptionOpenAIToOpenAITranslator_ResponseHeaders(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToOpenAITranslator("v1", "")
+
+	headers := map[string]string{
+		"content-type": "application/json",
+	}
+
+	headerMutation, err := translator.ResponseHeaders(headers)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+}
+
+func TestAudioTranscriptionOpenAIToOpenAITranslator_ResponseBody(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToOpenAITranslator("v1", "")
+
+	headers := map[string]string{}
+	body := bytes.NewReader([]byte(`{"text":"transcribed text"}`))
+
+	headerMutation, bodyMutation, tokenUsage, responseModel, err := translator.ResponseBody(headers, body, true)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+	require.Nil(t, bodyMutation)
+	require.Equal(t, metrics.TokenUsage{}, tokenUsage)
+	require.Equal(t, internalapi.ResponseModel(""), responseModel)
+}
+
+func TestAudioTranscriptionOpenAIToOpenAITranslator_ResponseError(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToOpenAITranslator("v1", "")
+
+	headers := map[string]string{}
+	body := bytes.NewReader([]byte(`{"error":{"message":"error message"}}`))
+
+	headerMutation, bodyMutation, err := translator.ResponseError(headers, body)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+	require.Nil(t, bodyMutation)
+}

--- a/internal/translator/audio_transcription_openai_gcpvertexai.go
+++ b/internal/translator/audio_transcription_openai_gcpvertexai.go
@@ -1,0 +1,425 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"strings"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/genai"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/gcp"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+)
+
+const defaultTranscriptionPrompt = "Transcribe this audio clip"
+
+// detectAudioMimeType returns the MIME type based on the file extension
+func detectAudioMimeType(filename string) string {
+	ext := strings.ToLower(filename)
+	switch {
+	case strings.HasSuffix(ext, ".wav"):
+		return "audio/wav"
+	case strings.HasSuffix(ext, ".mp3"):
+		return "audio/mpeg"
+	case strings.HasSuffix(ext, ".m4a"):
+		return "audio/mp4"
+	case strings.HasSuffix(ext, ".ogg"):
+		return "audio/ogg"
+	case strings.HasSuffix(ext, ".flac"):
+		return "audio/flac"
+	case strings.HasSuffix(ext, ".webm"):
+		return "audio/webm"
+	case strings.HasSuffix(ext, ".aac"):
+		return "audio/aac"
+	default:
+		return "audio/wav" // default to WAV
+	}
+}
+
+// NewAudioTranscriptionOpenAIToGCPVertexAITranslator creates a translator for OpenAI audio/transcriptions to GCP Vertex AI.
+func NewAudioTranscriptionOpenAIToGCPVertexAITranslator(modelNameOverride internalapi.ModelNameOverride) AudioTranscriptionTranslator {
+	return &audioTranscriptionOpenAIToGCPVertexAITranslator{
+		modelNameOverride: modelNameOverride,
+	}
+}
+
+type audioTranscriptionOpenAIToGCPVertexAITranslator struct {
+	modelNameOverride internalapi.ModelNameOverride
+	requestModel      internalapi.RequestModel
+	audioData         []byte
+	contentType       string // Store content-type header
+	stream            bool   // Whether to use streaming or non-streaming
+	bufferedBody      []byte // Buffer for incomplete streaming chunks
+}
+
+// SetContentType sets the content-type header for multipart parsing
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) SetContentType(contentType string) {
+	a.contentType = contentType
+}
+
+// RequestBody translates OpenAI AudioTranscription request to GCP Gemini API request.
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) RequestBody(
+	rawBody []byte,
+	body *openai.AudioTranscriptionRequest,
+	_ bool,
+) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	a.requestModel = body.Model
+	if a.modelNameOverride != "" {
+		a.requestModel = a.modelNameOverride
+	}
+
+	// Check if streaming should be enabled based on response_format
+	// For now, we'll default to streaming to support both modes
+	a.stream = true
+
+	// Instruction / prompt
+	instruction := defaultTranscriptionPrompt
+	if body.Prompt != "" {
+		instruction = body.Prompt
+	}
+
+	var audioData []byte
+	mimeType := "audio/wav"
+
+	mediaType, params, err := mime.ParseMediaType(a.contentType)
+	if err == nil && strings.HasPrefix(mediaType, "multipart/") {
+		boundary := params["boundary"]
+		if boundary != "" {
+			reader := multipart.NewReader(bytes.NewReader(rawBody), boundary)
+			for {
+				part, partErr := reader.NextPart()
+				if partErr == io.EOF {
+					break
+				}
+				if partErr != nil {
+					return nil, nil, fmt.Errorf("error reading multipart: %w", partErr)
+				}
+				if part.FormName() == "file" {
+					audioData, _ = io.ReadAll(part)
+
+					// Try to get MIME type from Content-Type header first
+					if ct := part.Header.Get("Content-Type"); ct != "" {
+						mimeType = ct
+					} else if fn := part.FileName(); fn != "" {
+						// If no Content-Type, detect from filename extension
+						mimeType = detectAudioMimeType(fn)
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// Fallback if multipart parsing failed
+	if len(audioData) == 0 {
+		audioData = rawBody
+	}
+
+	a.audioData = audioData
+
+	// Build Gemini request with text instruction and inline audio data
+	geminiReq := gcp.GenerateContentRequest{
+		Contents: []genai.Content{
+			{
+				Role: "user",
+				Parts: []*genai.Part{
+					genai.NewPartFromText(instruction),
+					{
+						InlineData: &genai.Blob{
+							MIMEType: mimeType,
+							Data:     audioData,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	geminiReqBody, err := json.Marshal(geminiReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error marshaling Gemini request: %w", err)
+	}
+
+	// Log the actual request body being sent (for debugging)
+	slog.Debug("gemini request body", "body", string(geminiReqBody))
+
+	// Determine path based on streaming mode - always use GCP Vertex AI path
+	var pathSuffix string
+	if a.stream {
+		// Use streamGenerateContent for streaming
+		pathSuffix = buildGCPModelPathSuffix(gcpModelPublisherGoogle, a.requestModel, gcpMethodStreamGenerateContent, "alt=sse")
+	} else {
+		// Use generateContent for non-streaming
+		pathSuffix = buildGCPModelPathSuffix(gcpModelPublisherGoogle, a.requestModel, gcpMethodGenerateContent)
+	}
+
+	headerMutation := &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{
+			{
+				Header: &corev3.HeaderValue{
+					Key:      ":path",
+					RawValue: []byte(pathSuffix),
+				},
+			},
+		},
+	}
+
+	bodyMutation := &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{
+			Body: geminiReqBody,
+		},
+	}
+
+	if a.stream {
+		headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
+			Header: &corev3.HeaderValue{Key: "accept", Value: "text/event-stream"},
+		})
+	}
+
+	// Create debug version with placeholder for audio data
+	debugContents := []genai.Content{
+		{
+			Role: "user",
+			Parts: []*genai.Part{
+				genai.NewPartFromText(instruction),
+				{
+					InlineData: &genai.Blob{
+						MIMEType: mimeType,
+						Data:     []byte(fmt.Sprintf("<AUDIO_DATA_%d_BYTES>", len(audioData))),
+					},
+				},
+			},
+		},
+	}
+	contentsJSON, _ := json.MarshalIndent(debugContents, "", "  ")
+
+	// Logging
+	slog.Info("translated audio/transcriptions request to Gemini",
+		"contents_json", string(contentsJSON),
+		"streaming", a.stream,
+		"body", string(geminiReqBody))
+
+	return headerMutation, bodyMutation, nil
+}
+
+// ResponseHeaders processes response headers from GCP Vertex AI.
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) ResponseHeaders(_ map[string]string) (*extprocv3.HeaderMutation, error) {
+	if a.stream {
+		// For streaming responses, set content-type to text/event-stream to match OpenAI API
+		return &extprocv3.HeaderMutation{
+			SetHeaders: []*corev3.HeaderValueOption{
+				{Header: &corev3.HeaderValue{Key: "content-type", Value: "text/event-stream"}},
+			},
+		}, nil
+	}
+	// For non-streaming, ensure content-type is application/json
+	return &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{
+			{Header: &corev3.HeaderValue{Key: "content-type", Value: "application/json"}},
+		},
+	}, nil
+}
+
+// ResponseBody translates GCP Vertex AI response to OpenAI AudioTranscription response.
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) ResponseBody(
+	_ map[string]string,
+	body io.Reader,
+	endOfStream bool,
+) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, metrics.TokenUsage, internalapi.ResponseModel, error) {
+	if a.stream {
+		return a.handleStreamingResponse(body, endOfStream)
+	}
+	return a.handleNonStreamingResponse(body, endOfStream)
+}
+
+// handleNonStreamingResponse handles non-streaming responses from Gemini
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) handleNonStreamingResponse(
+	body io.Reader,
+	endOfStream bool,
+) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, metrics.TokenUsage, internalapi.ResponseModel, error) {
+	if !endOfStream {
+		return nil, nil, metrics.TokenUsage{}, "", nil
+	}
+
+	responseBody, err := io.ReadAll(body)
+	if err != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error reading response body: %w", err)
+	}
+
+	var geminiResp genai.GenerateContentResponse
+	if unmarshalErr := json.Unmarshal(responseBody, &geminiResp); unmarshalErr != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error unmarshaling Gemini response: %w", err)
+	}
+
+	// Extract transcription text from Gemini response
+	var transcriptionText string
+	if len(geminiResp.Candidates) > 0 && geminiResp.Candidates[0].Content != nil {
+		for _, part := range geminiResp.Candidates[0].Content.Parts {
+			if part.Text != "" {
+				transcriptionText += part.Text
+			}
+		}
+	}
+
+	// Build OpenAI-compatible response
+	openaiResp := openai.AudioTranscriptionResponse{
+		Text: transcriptionText,
+	}
+
+	openaiRespBody, err := json.Marshal(openaiResp)
+	if err != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error marshaling OpenAI response: %w", err)
+	}
+
+	// Calculate token usage
+	var tokenUsage metrics.TokenUsage
+	if geminiResp.UsageMetadata != nil {
+		tokenUsage.SetInputTokens(uint32(geminiResp.UsageMetadata.PromptTokenCount))      // nolint:gosec
+		tokenUsage.SetOutputTokens(uint32(geminiResp.UsageMetadata.CandidatesTokenCount)) // nolint:gosec
+		tokenUsage.SetTotalTokens(uint32(geminiResp.UsageMetadata.TotalTokenCount))       // nolint:gosec
+	}
+
+	inputTokens, _ := tokenUsage.InputTokens()
+	outputTokens, _ := tokenUsage.OutputTokens()
+	slog.Info("translated Gemini audio response to OpenAI (non-streaming)",
+		"input_tokens", inputTokens,
+		"output_tokens", outputTokens,
+		"transcription_length", len(transcriptionText))
+
+	return nil, &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{Body: openaiRespBody},
+	}, tokenUsage, a.requestModel, nil
+}
+
+// handleStreamingResponse handles streaming responses from Gemini
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) handleStreamingResponse(
+	body io.Reader,
+	endOfStream bool,
+) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, metrics.TokenUsage, internalapi.ResponseModel, error) {
+	// Parse streaming chunks
+	chunks, err := a.parseGeminiStreamingChunks(body)
+	if err != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error parsing Gemini streaming chunks: %w", err)
+	}
+
+	// Accumulate transcription text from all chunks
+	var transcriptionText string
+	var tokenUsage metrics.TokenUsage
+
+	for _, chunk := range chunks {
+		// Extract text from candidates
+		if len(chunk.Candidates) > 0 && chunk.Candidates[0].Content != nil {
+			for _, part := range chunk.Candidates[0].Content.Parts {
+				if part.Text != "" {
+					transcriptionText += part.Text
+				}
+			}
+		}
+
+		// Extract token usage if present (typically in last chunk)
+		if chunk.UsageMetadata != nil {
+			tokenUsage.SetInputTokens(uint32(chunk.UsageMetadata.PromptTokenCount))      // nolint:gosec
+			tokenUsage.SetOutputTokens(uint32(chunk.UsageMetadata.CandidatesTokenCount)) // nolint:gosec
+			tokenUsage.SetTotalTokens(uint32(chunk.UsageMetadata.TotalTokenCount))       // nolint:gosec
+		}
+	}
+
+	// Only return final response when stream ends
+	if !endOfStream {
+		return nil, nil, metrics.TokenUsage{}, "", nil
+	}
+
+	// Build OpenAI-compatible response
+	openaiResp := openai.AudioTranscriptionResponse{
+		Text: transcriptionText,
+	}
+
+	openaiRespBody, err := json.Marshal(openaiResp)
+	if err != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error marshaling OpenAI response: %w", err)
+	}
+
+	inputTokens, _ := tokenUsage.InputTokens()
+	outputTokens, _ := tokenUsage.OutputTokens()
+	slog.Info("translated Gemini audio response to OpenAI (streaming)",
+		"input_tokens", inputTokens,
+		"output_tokens", outputTokens,
+		"transcription_length", len(transcriptionText))
+
+	return nil, &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{Body: openaiRespBody},
+	}, tokenUsage, a.requestModel, nil
+}
+
+// parseGeminiStreamingChunks parses the buffered body to extract complete JSON chunks
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) parseGeminiStreamingChunks(body io.Reader) ([]genai.GenerateContentResponse, error) {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body: %w", err)
+	}
+
+	// Append new data to buffer
+	a.bufferedBody = append(a.bufferedBody, bodyBytes...)
+
+	var chunks []genai.GenerateContentResponse
+
+	// Normalize line endings: replace \r\n with \n
+	normalizedBody := bytes.ReplaceAll(a.bufferedBody, []byte("\r\n"), []byte("\n"))
+	lines := bytes.Split(normalizedBody, []byte("\n\n"))
+
+	// Keep the last incomplete chunk in buffer
+	var remainingBuffer []byte
+	for i, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		// Skip SSE event prefixes (data: prefix)
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			line = bytes.TrimPrefix(line, []byte("data: "))
+			line = bytes.TrimSpace(line)
+		}
+
+		// Check for end marker [DONE] - though Gemini doesn't send this
+		if bytes.Equal(line, []byte("[DONE]")) {
+			continue
+		}
+
+		// Try to parse as JSON
+		var chunk genai.GenerateContentResponse
+		if err := json.Unmarshal(line, &chunk); err != nil {
+			// If this is the last line and it's incomplete, keep it in buffer
+			if i == len(lines)-1 {
+				remainingBuffer = line
+			}
+			continue
+		}
+
+		chunks = append(chunks, chunk)
+	}
+
+	// Update buffer with remaining incomplete data
+	a.bufferedBody = remainingBuffer
+
+	return chunks, nil
+}
+
+// ResponseError handles error responses from GCP Vertex AI.
+func (a *audioTranscriptionOpenAIToGCPVertexAITranslator) ResponseError(_ map[string]string, _ io.Reader) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	return nil, nil, nil
+}

--- a/internal/translator/audio_transcription_openai_gcpvertexai_test.go
+++ b/internal/translator/audio_transcription_openai_gcpvertexai_test.go
@@ -1,0 +1,540 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genai"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+)
+
+func TestNewAudioTranscriptionOpenAIToGCPVertexAITranslator(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("override-model")
+	require.NotNil(t, translator)
+
+	impl, ok := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+	require.True(t, ok)
+	require.Equal(t, internalapi.ModelNameOverride("override-model"), impl.modelNameOverride)
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_SetContentType(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+	impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+	impl.SetContentType("multipart/form-data; boundary=test")
+	require.Equal(t, "multipart/form-data; boundary=test", impl.contentType)
+}
+
+func TestDetectAudioMimeType(t *testing.T) {
+	tests := []struct {
+		filename string
+		expected string
+	}{
+		{"test.wav", "audio/wav"},
+		{"test.mp3", "audio/mpeg"},
+		{"test.m4a", "audio/mp4"},
+		{"test.ogg", "audio/ogg"},
+		{"test.flac", "audio/flac"},
+		{"test.webm", "audio/webm"},
+		{"test.aac", "audio/aac"},
+		{"test.unknown", "audio/wav"},
+		{"TEST.WAV", "audio/wav"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			result := detectAudioMimeType(tt.filename)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_RequestBody(t *testing.T) {
+	t.Run("basic request with multipart", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		part, _ := writer.CreateFormFile("file", "test.wav")
+		_, _ = part.Write([]byte("audio data"))
+
+		field, _ := writer.CreateFormField("model")
+		_, _ = field.Write([]byte("whisper-1"))
+
+		writer.Close()
+
+		impl.SetContentType(writer.FormDataContentType())
+
+		req := &openai.AudioTranscriptionRequest{
+			Model: "whisper-1",
+		}
+
+		headerMutation, bodyMutation, err := translator.RequestBody(buf.Bytes(), req, false)
+		require.NoError(t, err)
+		require.NotNil(t, headerMutation)
+		require.NotNil(t, bodyMutation)
+
+		require.Len(t, headerMutation.SetHeaders, 2)
+		require.Equal(t, ":path", headerMutation.SetHeaders[0].Header.Key)
+		require.Contains(t, string(headerMutation.SetHeaders[0].Header.RawValue), "streamGenerateContent")
+	})
+
+	t.Run("with custom prompt", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		part, _ := writer.CreateFormFile("file", "test.wav")
+		_, _ = part.Write([]byte("audio data"))
+
+		writer.Close()
+
+		impl.SetContentType(writer.FormDataContentType())
+
+		req := &openai.AudioTranscriptionRequest{
+			Model:  "whisper-1",
+			Prompt: "Custom transcription prompt",
+		}
+
+		_, bodyMutation, err := translator.RequestBody(buf.Bytes(), req, false)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+	})
+
+	t.Run("model override", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("gemini-1.5-pro")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+
+		part, _ := writer.CreateFormFile("file", "test.wav")
+		_, _ = part.Write([]byte("audio data"))
+
+		writer.Close()
+
+		impl.SetContentType(writer.FormDataContentType())
+
+		req := &openai.AudioTranscriptionRequest{
+			Model: "whisper-1",
+		}
+
+		_, _, err := translator.RequestBody(buf.Bytes(), req, false)
+		require.NoError(t, err)
+		require.Equal(t, internalapi.RequestModel("gemini-1.5-pro"), impl.requestModel)
+	})
+
+	t.Run("different audio formats", func(t *testing.T) {
+		formats := []struct {
+			filename string
+			mimeType string
+		}{
+			{"test.mp3", "audio/mpeg"},
+			{"test.m4a", "audio/mp4"},
+			{"test.flac", "audio/flac"},
+		}
+
+		for _, format := range formats {
+			translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+			impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+			var buf bytes.Buffer
+			writer := multipart.NewWriter(&buf)
+
+			part, _ := writer.CreateFormFile("file", format.filename)
+			_, _ = part.Write([]byte("audio data"))
+
+			writer.Close()
+
+			impl.SetContentType(writer.FormDataContentType())
+
+			req := &openai.AudioTranscriptionRequest{Model: "whisper-1"}
+
+			_, bodyMutation, err := translator.RequestBody(buf.Bytes(), req, false)
+			require.NoError(t, err)
+			require.NotNil(t, bodyMutation)
+		}
+	})
+
+	t.Run("fallback without multipart", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+
+		audioData := []byte("raw audio data")
+		req := &openai.AudioTranscriptionRequest{Model: "whisper-1"}
+
+		_, bodyMutation, err := translator.RequestBody(audioData, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+	})
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_ResponseHeaders(t *testing.T) {
+	t.Run("streaming response", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = true
+
+		headerMutation, err := translator.ResponseHeaders(nil)
+		require.NoError(t, err)
+		require.NotNil(t, headerMutation)
+		require.Len(t, headerMutation.SetHeaders, 1)
+		require.Equal(t, "content-type", headerMutation.SetHeaders[0].Header.Key)
+		require.Equal(t, "text/event-stream", headerMutation.SetHeaders[0].Header.Value)
+	})
+
+	t.Run("non-streaming response", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = false
+
+		headerMutation, err := translator.ResponseHeaders(nil)
+		require.NoError(t, err)
+		require.NotNil(t, headerMutation)
+		require.Equal(t, "application/json", headerMutation.SetHeaders[0].Header.Value)
+	})
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_HandleStreamingResponse(t *testing.T) {
+	t.Run("complete streaming response", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = true
+		impl.requestModel = "gemini-1.5-pro"
+
+		resp := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{Text: "This is the transcription text"},
+						},
+					},
+				},
+			},
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     50,
+				CandidatesTokenCount: 100,
+				TotalTokenCount:      150,
+			},
+		}
+
+		respBody, _ := json.Marshal(resp)
+		sseBody := []byte("data: " + string(respBody) + "\n\n")
+
+		_, bodyMutation, tokenUsage, responseModel, err := impl.handleStreamingResponse(bytes.NewReader(sseBody), true)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+
+		body := bodyMutation.GetBody()
+		var openaiResp openai.AudioTranscriptionResponse
+		err = json.Unmarshal(body, &openaiResp)
+		require.NoError(t, err)
+		require.Equal(t, "This is the transcription text", openaiResp.Text)
+
+		inputTokens, _ := tokenUsage.InputTokens()
+		outputTokens, _ := tokenUsage.OutputTokens()
+		totalTokens, _ := tokenUsage.TotalTokens()
+		require.Equal(t, uint32(50), inputTokens)
+		require.Equal(t, uint32(100), outputTokens)
+		require.Equal(t, uint32(150), totalTokens)
+		require.Equal(t, internalapi.ResponseModel("gemini-1.5-pro"), responseModel)
+	})
+
+	t.Run("not end of stream", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = true
+
+		resp := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{Text: "partial text"},
+						},
+					},
+				},
+			},
+		}
+
+		respBody, _ := json.Marshal(resp)
+		sseBody := []byte("data: " + string(respBody) + "\n\n")
+
+		_, bodyMutation, _, _, err := impl.handleStreamingResponse(bytes.NewReader(sseBody), false)
+		require.NoError(t, err)
+		require.Nil(t, bodyMutation)
+	})
+
+	t.Run("multiple chunks", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = true
+		impl.requestModel = "gemini-1.5-pro"
+
+		chunk1 := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: "First part"}},
+					},
+				},
+			},
+		}
+
+		chunk2 := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: " second part"}},
+					},
+				},
+			},
+		}
+
+		body1, _ := json.Marshal(chunk1)
+		body2, _ := json.Marshal(chunk2)
+		sseBody := []byte("data: " + string(body1) + "\n\ndata: " + string(body2) + "\n\n")
+
+		_, bodyMutation, _, _, err := impl.handleStreamingResponse(bytes.NewReader(sseBody), true)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+
+		body := bodyMutation.GetBody()
+		var openaiResp openai.AudioTranscriptionResponse
+		err = json.Unmarshal(body, &openaiResp)
+		require.NoError(t, err)
+		require.Equal(t, "First part second part", openaiResp.Text)
+	})
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_HandleNonStreamingResponse(t *testing.T) {
+	t.Run("complete non-streaming response", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = false
+		impl.requestModel = "gemini-1.5-pro"
+
+		resp := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{Text: "Complete transcription"},
+						},
+					},
+				},
+			},
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     30,
+				CandidatesTokenCount: 50,
+				TotalTokenCount:      80,
+			},
+		}
+
+		respBody, _ := json.Marshal(resp)
+
+		_, bodyMutation, tokenUsage, responseModel, err := impl.handleNonStreamingResponse(bytes.NewReader(respBody), true)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+
+		body := bodyMutation.GetBody()
+		var openaiResp openai.AudioTranscriptionResponse
+		err = json.Unmarshal(body, &openaiResp)
+		require.NoError(t, err)
+		require.Equal(t, "Complete transcription", openaiResp.Text)
+
+		inputTokens, _ := tokenUsage.InputTokens()
+		outputTokens, _ := tokenUsage.OutputTokens()
+		totalTokens, _ := tokenUsage.TotalTokens()
+		require.Equal(t, uint32(30), inputTokens)
+		require.Equal(t, uint32(50), outputTokens)
+		require.Equal(t, uint32(80), totalTokens)
+		require.Equal(t, internalapi.ResponseModel("gemini-1.5-pro"), responseModel)
+	})
+
+	t.Run("not end of stream", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = false
+
+		_, bodyMutation, _, _, err := impl.handleNonStreamingResponse(bytes.NewReader([]byte("")), false)
+		require.NoError(t, err)
+		require.Nil(t, bodyMutation)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = false
+
+		_, _, _, _, err := impl.handleNonStreamingResponse(bytes.NewReader([]byte("invalid")), true)
+		require.Error(t, err)
+	})
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_ResponseBody(t *testing.T) {
+	t.Run("streaming mode", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = true
+		impl.requestModel = "gemini-1.5-pro"
+
+		resp := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: "test"}},
+					},
+				},
+			},
+		}
+
+		respBody, _ := json.Marshal(resp)
+		sseBody := []byte("data: " + string(respBody) + "\n\n")
+
+		_, bodyMutation, _, _, err := translator.ResponseBody(nil, bytes.NewReader(sseBody), true)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+	})
+
+	t.Run("non-streaming mode", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+		impl.stream = false
+		impl.requestModel = "gemini-1.5-pro"
+
+		resp := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: "test"}},
+					},
+				},
+			},
+		}
+
+		respBody, _ := json.Marshal(resp)
+
+		_, bodyMutation, _, _, err := translator.ResponseBody(nil, bytes.NewReader(respBody), true)
+		require.NoError(t, err)
+		require.NotNil(t, bodyMutation)
+	})
+}
+
+func TestAudioTranscriptionOpenAIToGCPVertexAITranslator_ResponseError(t *testing.T) {
+	translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+
+	headerMutation, bodyMutation, err := translator.ResponseError(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+	require.Nil(t, bodyMutation)
+}
+
+func TestParseGeminiStreamingChunks_Transcription(t *testing.T) {
+	t.Run("valid sse chunks", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		chunk := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: "test"}},
+					},
+				},
+			},
+		}
+		chunkBody, _ := json.Marshal(chunk)
+		sseBody := []byte("data: " + string(chunkBody) + "\n\n")
+
+		chunks, err := impl.parseGeminiStreamingChunks(bytes.NewReader(sseBody))
+		require.NoError(t, err)
+		require.Len(t, chunks, 1)
+	})
+
+	t.Run("multiple chunks with newlines", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		chunk1 := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []*genai.Part{{Text: "test1"}}}}},
+		}
+		chunk2 := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []*genai.Part{{Text: "test2"}}}}},
+		}
+
+		body1, _ := json.Marshal(chunk1)
+		body2, _ := json.Marshal(chunk2)
+		sseBody := []byte("data: " + string(body1) + "\n\ndata: " + string(body2) + "\n\n")
+
+		chunks, err := impl.parseGeminiStreamingChunks(bytes.NewReader(sseBody))
+		require.NoError(t, err)
+		require.Len(t, chunks, 2)
+	})
+
+	t.Run("done marker", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		sseBody := []byte("data: [DONE]\n\n")
+
+		chunks, err := impl.parseGeminiStreamingChunks(bytes.NewReader(sseBody))
+		require.NoError(t, err)
+		require.Empty(t, chunks)
+	})
+
+	t.Run("windows line endings", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		chunk := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []*genai.Part{{Text: "test"}}}}},
+		}
+		chunkBody, _ := json.Marshal(chunk)
+		sseBody := []byte("data: " + string(chunkBody) + "\r\n\r\n")
+
+		chunks, err := impl.parseGeminiStreamingChunks(bytes.NewReader(sseBody))
+		require.NoError(t, err)
+		require.Len(t, chunks, 1)
+	})
+
+	t.Run("incomplete chunk buffering", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		incompleteBody := []byte("data: {\"candidates\":")
+
+		chunks, err := impl.parseGeminiStreamingChunks(bytes.NewReader(incompleteBody))
+		require.NoError(t, err)
+		require.Empty(t, chunks)
+	})
+
+	t.Run("empty lines", func(t *testing.T) {
+		translator := NewAudioTranscriptionOpenAIToGCPVertexAITranslator("")
+		impl := translator.(*audioTranscriptionOpenAIToGCPVertexAITranslator)
+
+		chunk := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []*genai.Part{{Text: "test"}}}}},
+		}
+		chunkBody, _ := json.Marshal(chunk)
+		sseBody := []byte("\n\ndata: " + string(chunkBody) + "\n\n\n\n")
+
+		chunks, err := impl.parseGeminiStreamingChunks(bytes.NewReader(sseBody))
+		require.NoError(t, err)
+		require.Len(t, chunks, 1)
+	})
+}


### PR DESCRIPTION
**Description**

This PR adds support for the OpenAI-compatible `/v1/audio/transcriptions` speech-to-text endpoint with translation support for GCP Vertex AI  backends.


## Key features
- Streaming (SSE) and non-streaming response handling
- SSE streaming chunk parsing and accumulation of transcription text
- Token usage tracking (input/output/total) and metrics emission

Additional notes: clients may request server-sent-event (SSE) style streaming by passing an explicit `stream` boolean parameter (see table below). When `stream=true`, the gateway will select the streaming endpoint and translate SSE chunks into the OpenAI-compatible streaming behavior.

## Supported request parameters

| Parameter | Type | Description |
|---|---:|---|
| `model` | string | Model identifier (e.g., `whisper-1`) |
| `language` | string | Language of the audio (optional) |
| `prompt` | string | Custom transcription prompt (optional) |
| `response_format` | string | Output format (optional) |
| `temperature` | float | Sampling temperature (optional) |
| `stream` | bool | Request streaming (SSE) responses when `true` (optional) |
| `timestamp_granularities` | `[]string` | Timestamp detail level (optional) |


## Backend support

- **OpenAI**: passthrough translator that forwards request bodies with optional model override.
- **GCP Vertex AI / Gemini**: translator builds Gemini requests, handles streaming and non-streaming responses, and converts them back to OpenAI-compatible responses.


## Related issues / PRs

- Closes / relates to: #1499
**Special notes for reviewers (if applicable)**
- it can be conflict with PR https://github.com/envoyproxy/ai-gateway/pull/1584
