### PR TITLE
feat: add Realtime Client Secrets API support

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -257,6 +257,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Cohere, "/v2/rerank"), extproc.RerankProcessorFactory(rerankMetricsFactory))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/models"), extproc.NewModelsProcessor)
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Anthropic, "/v1/messages"), extproc.MessagesProcessorFactory(messagesMetricsFactory))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/realtime/client_secrets"), extproc.RealtimeClientSecretsProcessorFactory())
 
 	if watchErr := filterapi.StartConfigWatcher(ctx, flags.configPath, server, l, time.Second*5); watchErr != nil {
 		return fmt.Errorf("failed to start config watcher: %w", watchErr)

--- a/internal/apischema/gcp/gcp.go
+++ b/internal/apischema/gcp/gcp.go
@@ -36,3 +36,21 @@ type GenerateContentRequest struct {
 	// https://github.com/googleapis/go-genai/blob/6a8184fcaf8bf15f0c566616a7b356560309be9b/types.go#L1057
 	SafetySettings []*genai.SafetySetting `json:"safetySettings,omitempty"`
 }
+
+// CreateAuthTokenRequest represents a request to create an ephemeral auth token for Gemini Live API
+// Reference: https://ai.google.dev/api/generate-content#auth-tokens
+type CreateAuthTokenRequest struct {
+	// Uses specifies how many times the token can be used (typically 1)
+	Uses int `json:"uses"`
+	// ExpireTime is the ISO8601 formatted expiration time
+	ExpireTime string `json:"expireTime"`
+}
+
+// CreateAuthTokenResponse represents the response from creating an auth token
+// Reference: https://ai.google.dev/api/generate-content#auth-tokens
+type CreateAuthTokenResponse struct {
+	// Name is the resource name of the auth token in format "auth_tokens/{token}"
+	Name string `json:"name"`
+	// ExpireTime is the ISO8601 formatted expiration time
+	ExpireTime string `json:"expireTime,omitempty"`
+}

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1895,3 +1895,56 @@ type Usage struct {
 	// Only populated for /v1/chat/completions endpoint, not for /v1/completions.
 	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"` //nolint:tagliatelle //follow openai api
 }
+
+// RealtimeClientSecretRequest represents a request to create an ephemeral client secret for the Realtime API.
+// Reference: https://platform.openai.com/docs/api-reference/realtime-client-secret/create
+type RealtimeClientSecretRequest struct {
+	// ExpiresAfter configures when the ephemeral token expires
+	ExpiresAfter *RealtimeClientSecretExpiresAfter `json:"expires_after,omitempty"`
+	// Session configuration for the realtime session
+	Session *RealtimeClientSecretSession `json:"session,omitempty"`
+}
+
+// RealtimeClientSecretExpiresAfter specifies when the ephemeral token should expire
+type RealtimeClientSecretExpiresAfter struct {
+	// Anchor point for expiration calculation (e.g., "created_at")
+	Anchor string `json:"anchor"`
+	// Seconds from the anchor point until expiration
+	Seconds int `json:"seconds"`
+}
+
+// RealtimeClientSecretSession configures the realtime session
+type RealtimeClientSecretSession struct {
+	// Type of session (e.g., "realtime")
+	Type string `json:"type"`
+	// Model to use for the session (e.g., "gpt-realtime")
+	Model string `json:"model"`
+	// Instructions for the model
+	Instructions string `json:"instructions,omitempty"`
+}
+
+// RealtimeClientSecretResponse represents the response from creating a client secret
+// Reference: https://platform.openai.com/docs/api-reference/realtime-client-secret/create
+type RealtimeClientSecretResponse struct {
+	// Value is the ephemeral token (ephemeral key format: ek_*)
+	Value string `json:"value"`
+	// ExpiresAt is the Unix timestamp when the token expires
+	ExpiresAt int64 `json:"expires_at"`
+	// Session contains the full session configuration
+	Session *RealtimeClientSecretSessionResponse `json:"session,omitempty"`
+}
+
+// RealtimeClientSecretSessionResponse represents the session object in the response
+type RealtimeClientSecretSessionResponse struct {
+	Type             string                 `json:"type"`
+	Object           string                 `json:"object"`
+	ID               string                 `json:"id"`
+	Model            string                 `json:"model"`
+	OutputModalities []string               `json:"output_modalities,omitempty"`
+	Instructions     string                 `json:"instructions,omitempty"`
+	Tools            []interface{}          `json:"tools,omitempty"`
+	ToolChoice       string                 `json:"tool_choice,omitempty"`
+	MaxOutputTokens  interface{}            `json:"max_output_tokens,omitempty"` // Can be "inf" or number
+	Truncation       string                 `json:"truncation,omitempty"`
+	Audio            map[string]interface{} `json:"audio,omitempty"`
+}

--- a/internal/extproc/realtime_client_secrets_processor.go
+++ b/internal/extproc/realtime_client_secrets_processor.go
@@ -1,0 +1,308 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
+	"github.com/envoyproxy/ai-gateway/internal/translator"
+)
+
+// RealtimeClientSecretsProcessorFactory returns a ProcessorFactory for the realtime client_secrets endpoint.
+func RealtimeClientSecretsProcessorFactory() ProcessorFactory {
+	return func(config *filterapi.RuntimeConfig, requestHeaders map[string]string, logger *slog.Logger, _ tracing.Tracing, isUpstreamFilter bool) (Processor, error) {
+		logger = logger.With("processor", "realtime-client-secrets", "isUpstreamFilter", fmt.Sprintf("%v", isUpstreamFilter))
+		if !isUpstreamFilter {
+			return &realtimeClientSecretsProcessorRouterFilter{
+				config:         config,
+				requestHeaders: requestHeaders,
+				logger:         logger,
+			}, nil
+		}
+		return &realtimeClientSecretsProcessorUpstreamFilter{
+			config:         config,
+			requestHeaders: requestHeaders,
+			logger:         logger,
+		}, nil
+	}
+}
+
+// realtimeClientSecretsProcessorRouterFilter implements [Processor] for the `/v1/realtime/client_secrets` endpoint.
+type realtimeClientSecretsProcessorRouterFilter struct {
+	passThroughProcessor
+	upstreamFilter         Processor
+	logger                 *slog.Logger
+	config                 *filterapi.RuntimeConfig
+	requestHeaders         map[string]string
+	originalRequestBody    *openai.RealtimeClientSecretRequest
+	originalRequestBodyRaw []byte
+}
+
+// ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
+func (r *realtimeClientSecretsProcessorRouterFilter) ProcessRequestHeaders(_ context.Context, _ *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestHeaders{
+		RequestHeaders: &extprocv3.HeadersResponse{},
+	}}, nil
+}
+
+// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
+func (r *realtimeClientSecretsProcessorRouterFilter) ProcessResponseHeaders(ctx context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	if r.upstreamFilter != nil {
+		return r.upstreamFilter.ProcessResponseHeaders(ctx, headerMap)
+	}
+	return r.passThroughProcessor.ProcessResponseHeaders(ctx, headerMap)
+}
+
+// ProcessResponseBody implements [Processor.ProcessResponseBody].
+func (r *realtimeClientSecretsProcessorRouterFilter) ProcessResponseBody(ctx context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	if r.upstreamFilter != nil {
+		return r.upstreamFilter.ProcessResponseBody(ctx, body)
+	}
+	return r.passThroughProcessor.ProcessResponseBody(ctx, body)
+}
+
+// ProcessRequestBody implements [Processor.ProcessRequestBody].
+func (r *realtimeClientSecretsProcessorRouterFilter) ProcessRequestBody(_ context.Context, rawBody *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	// Parse the request body
+	var req openai.RealtimeClientSecretRequest
+	if err := json.Unmarshal(rawBody.Body, &req); err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	r.originalRequestBody = &req
+	r.originalRequestBodyRaw = rawBody.Body
+
+	// Use a default model if not specified
+	model := "gpt-realtime"
+	if req.Session != nil && req.Session.Model != "" {
+		model = req.Session.Model
+	}
+
+	// Set model header for routing and original path for upstream filter lookup
+	headerMutation := &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{
+			{
+				Header: &corev3.HeaderValue{
+					Key:      internalapi.ModelNameHeaderKeyDefault,
+					RawValue: []byte(model),
+				},
+			},
+			{
+				Header: &corev3.HeaderValue{
+					Key:      originalPathHeader,
+					RawValue: []byte(r.requestHeaders[":path"]),
+				},
+			},
+		},
+	}
+
+	// Preserve the original body for the upstream filter to process
+	bodyMutation := &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{
+			Body: rawBody.Body,
+		},
+	}
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation:  headerMutation,
+					BodyMutation:    bodyMutation,
+					ClearRouteCache: true,
+				},
+			},
+		},
+	}, nil
+}
+
+// SetBackend implements [Processor.SetBackend].
+func (r *realtimeClientSecretsProcessorRouterFilter) SetBackend(ctx context.Context, b *filterapi.Backend, backendHandler filterapi.BackendAuthHandler, routeProcessor Processor) error {
+	upstreamFilter, err := RealtimeClientSecretsProcessorFactory()(r.config, r.requestHeaders, r.logger, nil, true)
+	if err != nil {
+		return fmt.Errorf("failed to create upstream filter: %w", err)
+	}
+	if err := upstreamFilter.SetBackend(ctx, b, backendHandler, routeProcessor); err != nil {
+		return err
+	}
+	r.upstreamFilter = upstreamFilter
+	return nil
+}
+
+type realtimeClientSecretsProcessorUpstreamFilter struct {
+	logger         *slog.Logger
+	config         *filterapi.RuntimeConfig
+	requestHeaders map[string]string
+	translator     translator.RealtimeClientSecretsTranslator
+	handler        filterapi.BackendAuthHandler
+}
+
+func (r *realtimeClientSecretsProcessorUpstreamFilter) SetBackend(_ context.Context, b *filterapi.Backend, backendHandler filterapi.BackendAuthHandler, _ Processor) error {
+	// Store the handler first - it may be nil for backends without auth
+	r.handler = backendHandler
+
+	// Select translator based on backend schema
+	switch b.Schema.Name {
+	case filterapi.APISchemaOpenAI, filterapi.APISchemaAzureOpenAI:
+		r.translator = translator.NewRealtimeClientSecretsOpenAITranslator()
+	case filterapi.APISchemaGCPVertexAI:
+		r.translator = translator.NewRealtimeClientSecretsGCPTranslator(r.logger)
+	default:
+		return fmt.Errorf("unsupported schema for realtime client_secrets: %s", b.Schema.Name)
+	}
+
+	return nil
+}
+
+// ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
+func (r *realtimeClientSecretsProcessorUpstreamFilter) ProcessRequestHeaders(_ context.Context, _ *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	// Override processing mode to enable request body processing in upstream filter
+	// This is necessary because we need to translate the request body from OpenAI to GCP format
+	mode := &extprocv3http.ProcessingMode{
+		RequestBodyMode: extprocv3http.ProcessingMode_BUFFERED,
+	}
+
+	return &extprocv3.ProcessingResponse{
+		Response:     &extprocv3.ProcessingResponse_RequestHeaders{},
+		ModeOverride: mode,
+	}, nil
+}
+
+// ProcessRequestBody implements [Processor.ProcessRequestBody].
+func (r *realtimeClientSecretsProcessorUpstreamFilter) ProcessRequestBody(ctx context.Context, rawBody *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	// Parse the request
+	var req openai.RealtimeClientSecretRequest
+	if err := json.Unmarshal(rawBody.Body, &req); err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	// Translate the request
+	headerMutation, bodyMutation, err := r.translator.RequestBody(&req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to translate request: %w", err)
+	}
+
+	// Initialize header mutation if nil
+	if headerMutation == nil {
+		headerMutation = &extprocv3.HeaderMutation{}
+	}
+
+	// Update request headers with the translated path for auth handler
+	// The translator sets the new path in headerMutation, we need to apply it to requestHeaders
+	for _, setHeader := range headerMutation.SetHeaders {
+		if setHeader.Header.Key == ":path" {
+			r.requestHeaders[":path"] = string(setHeader.Header.RawValue)
+			break
+		}
+	}
+
+	// Apply authentication if handler exists (will append API key to the translated path)
+	if r.handler != nil {
+		authHeaders, err := r.handler.Do(ctx, r.requestHeaders, rawBody.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", err)
+		}
+
+		// Replace the path header with the auth-modified one (which includes API key)
+		// Remove the original translated path from headerMutation
+		var filteredHeaders []*corev3.HeaderValueOption
+		for _, setHeader := range headerMutation.SetHeaders {
+			if setHeader.Header.Key != ":path" {
+				filteredHeaders = append(filteredHeaders, setHeader)
+			}
+		}
+		headerMutation.SetHeaders = filteredHeaders
+
+		// Add auth headers (including the path with API key)
+		for _, h := range authHeaders {
+			headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
+				Header: &corev3.HeaderValue{
+					Key:      h.Key(),
+					RawValue: []byte(h.Value()),
+				},
+			})
+		}
+	}
+
+	// Remove Content-Length header since we're changing the body size
+	// Envoy will recalculate it automatically
+	headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, "content-length")
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+	}, nil
+}
+
+// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
+func (r *realtimeClientSecretsProcessorUpstreamFilter) ProcessResponseHeaders(_ context.Context, headerMap *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	// Log response headers for debugging
+	headers := make(map[string]string)
+	for _, h := range headerMap.Headers {
+		headers[h.Key] = string(h.RawValue)
+	}
+	slog.Info("[Realtime Client Secrets] Received response headers",
+		"processor", "realtime-client-secrets",
+		"isUpstreamFilter", true,
+		"headers", headers)
+
+	// Pass through without modification
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+			ResponseHeaders: &extprocv3.HeadersResponse{},
+		},
+		ModeOverride: &extprocv3http.ProcessingMode{
+			ResponseBodyMode: extprocv3http.ProcessingMode_BUFFERED,
+		},
+	}, nil
+}
+
+func (r *realtimeClientSecretsProcessorUpstreamFilter) ProcessResponseBody(_ context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	// Log the raw response body from backend for debugging
+	slog.Info("[Realtime Client Secrets] Received response from backend",
+		"processor", "realtime-client-secrets",
+		"isUpstreamFilter", true,
+		"raw_response_body", string(body.Body))
+
+	// Translate the response
+	headerMutation, bodyMutation, err := r.translator.ResponseBody(body.Body)
+	if err != nil {
+		slog.Error("[Realtime Client Secrets] Failed to translate response",
+			"processor", "realtime-client-secrets",
+			"isUpstreamFilter", true,
+			"error", err,
+			"raw_body", string(body.Body))
+		return nil, fmt.Errorf("failed to translate response: %w", err)
+	}
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseBody{
+			ResponseBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/extproc/realtime_client_secrets_processor_test.go
+++ b/internal/extproc/realtime_client_secrets_processor_test.go
@@ -1,0 +1,472 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extproc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
+	"github.com/envoyproxy/ai-gateway/internal/translator"
+)
+
+type mockRealtimeClientSecretsTranslator struct {
+	t                 *testing.T
+	expRequestBody    *openai.RealtimeClientSecretRequest
+	expResponseBody   []byte
+	retHeaderMutation *extprocv3.HeaderMutation
+	retBodyMutation   *extprocv3.BodyMutation
+	retErr            error
+}
+
+func (m *mockRealtimeClientSecretsTranslator) RequestBody(body *openai.RealtimeClientSecretRequest) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	if m.expRequestBody != nil {
+		require.Equal(m.t, m.expRequestBody, body)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
+}
+
+func (m *mockRealtimeClientSecretsTranslator) ResponseBody(body []byte) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	if m.expResponseBody != nil {
+		require.Equal(m.t, m.expResponseBody, body)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
+}
+
+var _ translator.RealtimeClientSecretsTranslator = &mockRealtimeClientSecretsTranslator{}
+
+func TestRealtimeClientSecretsProcessorFactory(t *testing.T) {
+	t.Run("router filter", func(t *testing.T) {
+		factory := RealtimeClientSecretsProcessorFactory()
+		processor, err := factory(&filterapi.RuntimeConfig{}, map[string]string{}, slog.Default(), tracing.NoopTracing{}, false)
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		require.IsType(t, &realtimeClientSecretsProcessorRouterFilter{}, processor)
+	})
+
+	t.Run("upstream filter", func(t *testing.T) {
+		factory := RealtimeClientSecretsProcessorFactory()
+		processor, err := factory(&filterapi.RuntimeConfig{}, map[string]string{}, slog.Default(), tracing.NoopTracing{}, true)
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		require.IsType(t, &realtimeClientSecretsProcessorUpstreamFilter{}, processor)
+	})
+}
+
+func TestRealtimeClientSecretsProcessorRouterFilter_ProcessRequestHeaders(t *testing.T) {
+	p := &realtimeClientSecretsProcessorRouterFilter{}
+	resp, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRequestHeaders())
+}
+
+func TestRealtimeClientSecretsProcessorRouterFilter_ProcessRequestBody(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			requestHeaders: map[string]string{":path": "/v1/realtime/client_secrets"},
+		}
+		_, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: []byte("invalid")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse request body")
+	})
+
+	t.Run("success with model", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{
+			Session: &openai.RealtimeClientSecretSession{
+				Model: "gpt-4o-realtime-preview",
+			},
+		}
+		reqBody, _ := json.Marshal(req)
+
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{":path": "/v1/realtime/client_secrets"},
+			logger:         slog.Default(),
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rb := resp.GetRequestBody()
+		require.NotNil(t, rb)
+		require.True(t, rb.Response.ClearRouteCache)
+
+		headers := rb.Response.HeaderMutation.SetHeaders
+		require.Len(t, headers, 2)
+		require.Equal(t, internalapi.ModelNameHeaderKeyDefault, headers[0].Header.Key)
+		require.Equal(t, "gpt-4o-realtime-preview", string(headers[0].Header.RawValue))
+		require.Equal(t, originalPathHeader, headers[1].Header.Key)
+	})
+
+	t.Run("success without model", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{}
+		reqBody, _ := json.Marshal(req)
+
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{":path": "/v1/realtime/client_secrets"},
+			logger:         slog.Default(),
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rb := resp.GetRequestBody()
+		headers := rb.Response.HeaderMutation.SetHeaders
+		require.Equal(t, "gpt-realtime", string(headers[0].Header.RawValue))
+	})
+
+	t.Run("success with nil session", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{
+			Session: nil,
+		}
+		reqBody, _ := json.Marshal(req)
+
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{":path": "/v1/realtime/client_secrets"},
+			logger:         slog.Default(),
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rb := resp.GetRequestBody()
+		headers := rb.Response.HeaderMutation.SetHeaders
+		require.Equal(t, "gpt-realtime", string(headers[0].Header.RawValue))
+	})
+}
+
+func TestRealtimeClientSecretsProcessorRouterFilter_ProcessResponseHeaders(t *testing.T) {
+	t.Run("with upstream filter", func(t *testing.T) {
+		headerMap := &corev3.HeaderMap{}
+		mockUpstream := &mockProcessor{
+			t:                     t,
+			expHeaderMap:          headerMap,
+			retProcessingResponse: &extprocv3.ProcessingResponse{},
+		}
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			upstreamFilter: mockUpstream,
+		}
+
+		resp, err := p.ProcessResponseHeaders(context.Background(), headerMap)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("without upstream filter", func(t *testing.T) {
+		p := &realtimeClientSecretsProcessorRouterFilter{}
+		resp, err := p.ProcessResponseHeaders(context.Background(), &corev3.HeaderMap{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+}
+
+func TestRealtimeClientSecretsProcessorRouterFilter_ProcessResponseBody(t *testing.T) {
+	t.Run("with upstream filter", func(t *testing.T) {
+		httpBody := &extprocv3.HttpBody{}
+		mockUpstream := &mockProcessor{
+			t:                     t,
+			expBody:               httpBody,
+			retProcessingResponse: &extprocv3.ProcessingResponse{},
+		}
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			upstreamFilter: mockUpstream,
+		}
+
+		resp, err := p.ProcessResponseBody(context.Background(), httpBody)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("without upstream filter", func(t *testing.T) {
+		p := &realtimeClientSecretsProcessorRouterFilter{}
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+}
+
+func TestRealtimeClientSecretsProcessorRouterFilter_SetBackend(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "test-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
+		}
+
+		p := &realtimeClientSecretsProcessorRouterFilter{
+			config:         &filterapi.RuntimeConfig{},
+			requestHeaders: map[string]string{},
+			logger:         slog.Default(),
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, p)
+		require.NoError(t, err)
+		require.NotNil(t, p.upstreamFilter)
+	})
+}
+
+func TestRealtimeClientSecretsProcessorUpstreamFilter_SetBackend(t *testing.T) {
+	t.Run("openai backend", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "openai-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			logger: slog.Default(),
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+	})
+
+	t.Run("azure openai backend", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "azure-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaAzureOpenAI},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			logger: slog.Default(),
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+	})
+
+	t.Run("gcp vertex ai backend", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "gcp-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaGCPVertexAI},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			logger: slog.Default(),
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, p.translator)
+	})
+
+	t.Run("unsupported schema", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "unsupported-backend",
+			Schema: filterapi.VersionedAPISchema{Name: "unsupported"},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			logger: slog.Default(),
+		}
+
+		err := p.SetBackend(context.Background(), backend, nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported schema for realtime client_secrets")
+	})
+
+	t.Run("with auth handler", func(t *testing.T) {
+		backend := &filterapi.Backend{
+			Name:   "openai-backend",
+			Schema: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			logger: slog.Default(),
+		}
+
+		err := p.SetBackend(context.Background(), backend, &mockBackendAuthHandler{}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, p.handler)
+	})
+}
+
+func TestRealtimeClientSecretsProcessorUpstreamFilter_ProcessRequestHeaders(t *testing.T) {
+	p := &realtimeClientSecretsProcessorUpstreamFilter{}
+	resp, err := p.ProcessRequestHeaders(context.Background(), &corev3.HeaderMap{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.ModeOverride)
+}
+
+func TestRealtimeClientSecretsProcessorUpstreamFilter_ProcessRequestBody(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator: &mockRealtimeClientSecretsTranslator{},
+		}
+		_, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: []byte("invalid")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse request body")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{
+			Session: &openai.RealtimeClientSecretSession{
+				Model: "gpt-4o-realtime-preview",
+			},
+		}
+		reqBody, _ := json.Marshal(req)
+
+		mockTranslator := &mockRealtimeClientSecretsTranslator{
+			t: t,
+			retHeaderMutation: &extprocv3.HeaderMutation{
+				SetHeaders: []*corev3.HeaderValueOption{
+					{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/v1/realtime")}},
+				},
+			},
+			retBodyMutation: &extprocv3.BodyMutation{
+				Mutation: &extprocv3.BodyMutation_Body{Body: []byte("translated")},
+			},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator:     mockTranslator,
+			requestHeaders: map[string]string{},
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("translator error", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{}
+		reqBody, _ := json.Marshal(req)
+
+		mockTranslator := &mockRealtimeClientSecretsTranslator{
+			t:      t,
+			retErr: errors.New("translator error"),
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator: mockTranslator,
+		}
+
+		_, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to translate request")
+	})
+
+	t.Run("with auth handler", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{}
+		reqBody, _ := json.Marshal(req)
+
+		mockTranslator := &mockRealtimeClientSecretsTranslator{
+			t: t,
+			retHeaderMutation: &extprocv3.HeaderMutation{
+				SetHeaders: []*corev3.HeaderValueOption{
+					{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/v1/realtime")}},
+				},
+			},
+			retBodyMutation: &extprocv3.BodyMutation{
+				Mutation: &extprocv3.BodyMutation_Body{Body: []byte("translated")},
+			},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator:     mockTranslator,
+			requestHeaders: map[string]string{},
+			handler:        &mockBackendAuthHandler{},
+		}
+
+		resp, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("auth handler error", func(t *testing.T) {
+		req := openai.RealtimeClientSecretRequest{}
+		reqBody, _ := json.Marshal(req)
+
+		mockTranslator := &mockRealtimeClientSecretsTranslator{
+			t: t,
+			retHeaderMutation: &extprocv3.HeaderMutation{
+				SetHeaders: []*corev3.HeaderValueOption{
+					{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/v1/realtime")}},
+				},
+			},
+			retBodyMutation: &extprocv3.BodyMutation{},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator:     mockTranslator,
+			requestHeaders: map[string]string{},
+			handler:        &mockBackendAuthHandlerError{},
+		}
+
+		_, err := p.ProcessRequestBody(context.Background(), &extprocv3.HttpBody{Body: reqBody})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to apply authentication")
+	})
+}
+
+func TestRealtimeClientSecretsProcessorUpstreamFilter_ProcessResponseHeaders(t *testing.T) {
+	p := &realtimeClientSecretsProcessorUpstreamFilter{}
+	headers := &corev3.HeaderMap{
+		Headers: []*corev3.HeaderValue{
+			{Key: "content-type", RawValue: []byte("application/json")},
+		},
+	}
+	resp, err := p.ProcessResponseHeaders(context.Background(), headers)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.ModeOverride)
+}
+
+func TestRealtimeClientSecretsProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockTranslator := &mockRealtimeClientSecretsTranslator{
+			t:                 t,
+			retHeaderMutation: &extprocv3.HeaderMutation{},
+			retBodyMutation: &extprocv3.BodyMutation{
+				Mutation: &extprocv3.BodyMutation_Body{Body: []byte("translated response")},
+			},
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator: mockTranslator,
+		}
+
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body: []byte("response"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("translator error", func(t *testing.T) {
+		mockTranslator := &mockRealtimeClientSecretsTranslator{
+			t:      t,
+			retErr: errors.New("translator error"),
+		}
+
+		p := &realtimeClientSecretsProcessorUpstreamFilter{
+			translator: mockTranslator,
+		}
+
+		_, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body: []byte("response"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to translate response")
+	})
+}

--- a/internal/translator/realtime_client_secrets_gcp.go
+++ b/internal/translator/realtime_client_secrets_gcp.go
@@ -1,0 +1,175 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/gcp"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+const (
+	// gcpAuthTokenPrefix is the prefix used by GCP in auth token names.
+	// Token format: "auth_tokens/<token_value>"
+	//nolint:gosec // Not a real secret, just a token prefix
+	gcpAuthTokenPrefix = "auth_tokens/"
+)
+
+// realtimeClientSecretsGCPTranslator implements RealtimeClientSecretsTranslator for GCP Vertex AI.
+// This translator converts OpenAI's RealtimeClientSecret format to GCP's CreateAuthToken format.
+type realtimeClientSecretsGCPTranslator struct {
+	logger *slog.Logger
+}
+
+// NewRealtimeClientSecretsGCPTranslator creates a new GCP Vertex AI realtime client secrets translator.
+func NewRealtimeClientSecretsGCPTranslator(logger *slog.Logger) RealtimeClientSecretsTranslator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &realtimeClientSecretsGCPTranslator{
+		logger: logger,
+	}
+}
+
+// RequestBody implements RealtimeClientSecretsTranslator.RequestBody.
+// Translates OpenAI RealtimeClientSecretRequest to GCP CreateAuthTokenRequest.
+func (r *realtimeClientSecretsGCPTranslator) RequestBody(req *openai.RealtimeClientSecretRequest) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	err error,
+) {
+	r.logger.Info("[GCP Realtime] Starting request translation")
+
+	// Calculate expiration time
+	now := time.Now().UTC()
+	var expireTime time.Time
+
+	if req.ExpiresAfter != nil && req.ExpiresAfter.Seconds > 0 {
+		expireTime = now.Add(time.Duration(req.ExpiresAfter.Seconds) * time.Second)
+	} else {
+		// Default to 30 minutes
+		expireTime = now.Add(30 * time.Minute)
+	}
+
+	// Create GCP request with flat structure
+	gcpReq := gcp.CreateAuthTokenRequest{
+		Uses:       1, // Single use token
+		ExpireTime: expireTime.Format(time.RFC3339),
+	}
+
+	// Marshal to JSON
+	body, err := json.Marshal(gcpReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal GCP request: %w", err)
+	}
+
+	path := "/v1alpha/auth_tokens"
+
+	r.logger.Info("[GCP Realtime] Translated request",
+		slog.String("path", path),
+		slog.String("translated_body", string(body)),
+	)
+
+	headerMutation = &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{
+			{
+				Header: &corev3.HeaderValue{
+					Key:      ":path",
+					RawValue: []byte(path),
+				},
+			},
+			{
+				Header: &corev3.HeaderValue{
+					Key:      "content-type",
+					RawValue: []byte("application/json"),
+				},
+			},
+		},
+	}
+
+	bodyMutation = &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{
+			Body: body,
+		},
+	}
+
+	return headerMutation, bodyMutation, nil
+}
+
+// ResponseBody implements RealtimeClientSecretsTranslator.ResponseBody.
+// Translates GCP CreateAuthTokenResponse to OpenAI RealtimeClientSecretResponse.
+func (r *realtimeClientSecretsGCPTranslator) ResponseBody(body []byte) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	err error,
+) {
+	r.logger.Info("[GCP Realtime] Received response",
+		slog.String("response_body", string(body)),
+	)
+	var gcpResp gcp.CreateAuthTokenResponse
+	if unmarshalErr := json.Unmarshal(body, &gcpResp); unmarshalErr != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal GCP response: %w", unmarshalErr)
+	}
+
+	token := strings.TrimPrefix(gcpResp.Name, gcpAuthTokenPrefix)
+
+	r.logger.Info("[GCP Realtime] Extracted token",
+		slog.String("original_name", gcpResp.Name),
+		slog.String("extracted_token", token),
+	)
+
+	var expiresAt int64
+	if gcpResp.ExpireTime != "" {
+		t, parseErr := time.Parse(time.RFC3339, gcpResp.ExpireTime)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("failed to parse expire time: %w", parseErr)
+		}
+		expiresAt = t.Unix()
+	}
+
+	// Create OpenAI response
+	openAIResp := openai.RealtimeClientSecretResponse{
+		Value:     token,
+		ExpiresAt: expiresAt,
+	}
+
+	// Marshal to JSON
+	respBody, err := json.Marshal(openAIResp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal OpenAI response: %w", err)
+	}
+
+	r.logger.Info("[GCP Realtime] Final OpenAI response",
+		slog.String("response_body", string(respBody)),
+	)
+
+	headerMutation = &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{
+			{
+				Header: &corev3.HeaderValue{
+					Key:      "content-type",
+					RawValue: []byte("application/json"),
+				},
+			},
+		},
+	}
+
+	bodyMutation = &extprocv3.BodyMutation{
+		Mutation: &extprocv3.BodyMutation_Body{
+			Body: respBody,
+		},
+	}
+
+	return headerMutation, bodyMutation, nil
+}

--- a/internal/translator/realtime_client_secrets_openai.go
+++ b/internal/translator/realtime_client_secrets_openai.go
@@ -1,0 +1,43 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+// realtimeClientSecretsOpenAITranslator implements RealtimeClientSecretsTranslator for OpenAI.
+// This is a pass-through translator since OpenAI's API is used as-is.
+type realtimeClientSecretsOpenAITranslator struct{}
+
+// NewRealtimeClientSecretsOpenAITranslator creates a new OpenAI realtime client secrets translator.
+func NewRealtimeClientSecretsOpenAITranslator() RealtimeClientSecretsTranslator {
+	return &realtimeClientSecretsOpenAITranslator{}
+}
+
+// RequestBody implements RealtimeClientSecretsTranslator.RequestBody.
+// For OpenAI, this is a pass-through - no transformation needed.
+func (r *realtimeClientSecretsOpenAITranslator) RequestBody(_ *openai.RealtimeClientSecretRequest) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	err error,
+) {
+	// Pass through - no mutations needed for OpenAI
+	return nil, nil, nil
+}
+
+// ResponseBody implements RealtimeClientSecretsTranslator.ResponseBody.
+// For OpenAI, this is a pass-through - no transformation needed.
+func (r *realtimeClientSecretsOpenAITranslator) ResponseBody(_ []byte) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	err error,
+) {
+	// Pass through - no mutations needed for OpenAI
+	return nil, nil, nil
+}

--- a/internal/translator/realtime_client_secrets_test.go
+++ b/internal/translator/realtime_client_secrets_test.go
@@ -1,0 +1,117 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/gcp"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+func TestRealtimeClientSecretsOpenAI_PassThrough(t *testing.T) {
+	translator := NewRealtimeClientSecretsOpenAITranslator()
+
+	req := &openai.RealtimeClientSecretRequest{
+		ExpiresAfter: &openai.RealtimeClientSecretExpiresAfter{
+			Anchor:  "created_at",
+			Seconds: 600,
+		},
+		Session: &openai.RealtimeClientSecretSession{
+			Type:         "realtime",
+			Model:        "gpt-realtime",
+			Instructions: "You are a friendly assistant.",
+		},
+	}
+
+	headerMutation, bodyMutation, err := translator.RequestBody(req)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+	require.Nil(t, bodyMutation)
+
+	respBody := []byte(`{"value":"test_secret","expires_at":1234567890}`)
+	headerMutation, bodyMutation, err = translator.ResponseBody(respBody)
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+	require.Nil(t, bodyMutation)
+}
+
+func TestRealtimeClientSecretsGCP_Translation(t *testing.T) {
+	translator := NewRealtimeClientSecretsGCPTranslator(nil)
+
+	req := &openai.RealtimeClientSecretRequest{
+		ExpiresAfter: &openai.RealtimeClientSecretExpiresAfter{
+			Anchor:  "created_at",
+			Seconds: 600,
+		},
+		Session: &openai.RealtimeClientSecretSession{
+			Type:         "realtime",
+			Model:        "gpt-realtime",
+			Instructions: "You are a friendly assistant.",
+		},
+	}
+
+	headerMutation, bodyMutation, err := translator.RequestBody(req)
+	require.NoError(t, err)
+	require.NotNil(t, headerMutation)
+	require.NotNil(t, bodyMutation)
+
+	require.Len(t, headerMutation.SetHeaders, 2)
+	require.Equal(t, ":path", headerMutation.SetHeaders[0].Header.Key)
+	require.Equal(t, "/v1alpha/auth_tokens", string(headerMutation.SetHeaders[0].Header.RawValue))
+
+	var gcpReq gcp.CreateAuthTokenRequest
+	err = json.Unmarshal(bodyMutation.GetBody(), &gcpReq)
+	require.NoError(t, err)
+	require.Equal(t, 1, gcpReq.Uses)
+	require.NotEmpty(t, gcpReq.ExpireTime)
+}
+
+func TestRealtimeClientSecretsGCP_ResponseTranslation(t *testing.T) {
+	translator := NewRealtimeClientSecretsGCPTranslator(nil)
+
+	gcpResp := gcp.CreateAuthTokenResponse{
+		Name:       "auth_tokens/test_gcp_token",
+		ExpireTime: "2025-01-01T00:00:00Z",
+	}
+	gcpRespBody, err := json.Marshal(gcpResp)
+	require.NoError(t, err)
+
+	headerMutation, bodyMutation, err := translator.ResponseBody(gcpRespBody)
+	require.NoError(t, err)
+	require.NotNil(t, headerMutation)
+	require.NotNil(t, bodyMutation)
+
+	var openAIResp openai.RealtimeClientSecretResponse
+	err = json.Unmarshal(bodyMutation.GetBody(), &openAIResp)
+	require.NoError(t, err)
+	require.Equal(t, "test_gcp_token", openAIResp.Value)
+	require.Equal(t, int64(1735689600), openAIResp.ExpiresAt)
+}
+
+func TestRealtimeClientSecretsGCP_DefaultExpiry(t *testing.T) {
+	translator := NewRealtimeClientSecretsGCPTranslator(nil)
+
+	req := &openai.RealtimeClientSecretRequest{
+		Session: &openai.RealtimeClientSecretSession{
+			Type:  "realtime",
+			Model: "gpt-realtime",
+		},
+	}
+
+	headerMutation, bodyMutation, err := translator.RequestBody(req)
+	require.NoError(t, err)
+	require.NotNil(t, headerMutation)
+	require.NotNil(t, bodyMutation)
+
+	var gcpReq gcp.CreateAuthTokenRequest
+	err = json.Unmarshal(bodyMutation.GetBody(), &gcpReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, gcpReq.ExpireTime)
+}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -8,6 +8,7 @@ package translator
 import (
 	"io"
 
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	openaisdk "github.com/openai/openai-go/v2"
 	"github.com/tidwall/sjson"
 
@@ -96,4 +97,19 @@ var sjsonOptions = &sjson.Options{
 	// Note: DO NOT set ReplaceInPlace to true since at the translation layer, which might be called multiple times per retry,
 	// it must be ensured that the original body is not modified, i.e. the operation must be idempotent.
 	ReplaceInPlace: false,
+}
+
+// RealtimeClientSecretsTranslator translates requests and responses for the /v1/realtime/client_secrets endpoint.
+type RealtimeClientSecretsTranslator interface {
+	RequestBody(req *openai.RealtimeClientSecretRequest) (
+		headerMutation *extprocv3.HeaderMutation,
+		bodyMutation *extprocv3.BodyMutation,
+		err error,
+	)
+
+	ResponseBody(body []byte) (
+		headerMutation *extprocv3.HeaderMutation,
+		bodyMutation *extprocv3.BodyMutation,
+		err error,
+	)
 }


### PR DESCRIPTION
**Description**

This PR adds support for the OpenAI-compatible `/v1/realtime/client_secrets` endpoint with translation support for GCP Vertex AI backends. This endpoint enables WebSocket authentication token generation for realtime API connections.

**Provider Support**:

| Provider | Endpoint | Description |
|----------|----------|-------------|
| OpenAI | `/v1/realtime/sessions` | Pass-through to native endpoint |
| GCP Vertex AI | `/v1alpha/auth_tokens` | Translated to GCP auth token format |


**Related Issues/PRs (if applicable)**
#1566
