### PR TITLE
refactor: removes unnecessary code for /models

### DIFF
--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -8,7 +8,6 @@ package extproc
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -77,23 +76,6 @@ func (m *modelsProcessor) ProcessRequestHeaders(_ context.Context, _ *corev3.Hea
 			},
 		},
 	}, nil
-}
-
-var errUnexpectedCall = errors.New("unexpected method call")
-
-// ProcessRequestBody implements [Processor.ProcessRequestBody].
-func (m *modelsProcessor) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
-	return nil, fmt.Errorf("%w: ProcessRequestBody", errUnexpectedCall)
-}
-
-// ProcessResponseHeaders implements [Processor.ProcessResponseHeaders].
-func (m *modelsProcessor) ProcessResponseHeaders(context.Context, *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
-	return nil, fmt.Errorf("%w: ProcessResponseHeaders", errUnexpectedCall)
-}
-
-// ProcessResponseBody implements [Processor.ProcessResponseBody].
-func (m *modelsProcessor) ProcessResponseBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
-	return nil, fmt.Errorf("%w: ProcessResponseBody", errUnexpectedCall)
 }
 
 func setHeader(headers *extprocv3.HeaderMutation, key, value string) {

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -61,16 +61,6 @@ func TestModels_ProcessRequestHeaders(t *testing.T) {
 	}
 }
 
-func TestModels_UnimplementedMethods(t *testing.T) {
-	p := &modelsProcessor{}
-	_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{})
-	require.ErrorIs(t, err, errUnexpectedCall)
-	_, err = p.ProcessResponseHeaders(t.Context(), &corev3.HeaderMap{})
-	require.ErrorIs(t, err, errUnexpectedCall)
-	_, err = p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{})
-	require.ErrorIs(t, err, errUnexpectedCall)
-}
-
 func headers(in []*corev3.HeaderValueOption) map[string]string {
 	h := make(map[string]string)
 	for _, v := range in {


### PR DESCRIPTION
**Description**

This removes the unnecessary code of the /models endpoint processor in extproc impl.


