### PR TITLE
deps: use Go 1.25.5 for CVE fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/envoyproxy/ai-gateway
 
 // Explicitly specify the Go patch version to be able to purge the CI cache correctly.
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0


### PR DESCRIPTION
**Description**
Go 1.25.5 has been released with some CVE fixes that do not affect our codebase

https://groups.google.com/g/golang-nuts/c/V3rHHW0KlkA
