### PR TITLE
fix: use full-path attributes to avoid text-proto encoded metadata

### DIFF
--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -301,7 +301,7 @@ func (s *Server) maybeModifyCluster(cluster *clusterv3.Cluster) error {
 	extProcConfig.RequestAttributes = []string{
 		internalapi.XDSUpstreamHostMetadataBackendNamePath,
 		internalapi.XDSClusterMetadataBackendNamePath,
-		// These two are for backward compatibility with older versions of AI Gateway extproc.
+		// These two are for backward compatibility. TODO: remove them after v0.5 is released.
 		internalapi.XDSUpstreamHostMetadataKey,
 		internalapi.XDSClusterMetadataKey,
 	}

--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -298,7 +298,13 @@ func (s *Server) maybeModifyCluster(cluster *clusterv3.Cluster) error {
 		},
 	}
 	extProcConfig.AllowModeOverride = true
-	extProcConfig.RequestAttributes = []string{internalapi.XDSUpstreamHostMetadataKey, internalapi.XDSClusterMetadataKey}
+	extProcConfig.RequestAttributes = []string{
+		internalapi.XDSUpstreamHostMetadataBackendNamePath,
+		internalapi.XDSClusterMetadataBackendNamePath,
+		// These two are for backward compatibility with older versions of AI Gateway extproc.
+		internalapi.XDSUpstreamHostMetadataKey,
+		internalapi.XDSClusterMetadataKey,
+	}
 	extProcConfig.ProcessingMode = &extprocv3.ProcessingMode{
 		RequestHeaderMode: extprocv3.ProcessingMode_SEND,
 		// At the upstream filter, it can access the original body in its memory, so it can perform the translation

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -298,55 +298,52 @@ func (s *Server) setBackend(ctx context.Context, p Processor, internalReqID stri
 	if attributes == nil || len(attributes.Fields) == 0 { // coverage-ignore
 		return status.Error(codes.Internal, "missing attributes in request")
 	}
-	var metadataFieldKey string
+	// metadataFieldKey is the key for the entire metadata field in the attributes for backward compatibility.
+	// backendNamePath is the path to the backend name in the metadata.
+	var metadataFieldKey, backendNamePath string
 	if isEndpointPicker {
 		metadataFieldKey = internalapi.XDSClusterMetadataKey
+		backendNamePath = internalapi.XDSClusterMetadataBackendNamePath
 	} else {
 		metadataFieldKey = internalapi.XDSUpstreamHostMetadataKey
-	}
-	// This should contain the endpoint metadata.
-	hostMetadata, ok := attributes.Fields[metadataFieldKey]
-	if !ok {
-		return status.Errorf(codes.Internal, "missing %s in request", metadataFieldKey)
-	}
-	// Unmarshal the text into the struct since the metadata is encoded as a proto string.
-	var metadata corev3.Metadata
-	// This is a *very* hacky workaround for a breaking change introduced in
-	// protobuf dependency used in Envoy since https://github.com/envoyproxy/envoy/pull/42435.
-	// More specifically, the string value of the metadata now contains a debug prefix that
-	// is not valid protobuf text format for the current Go protobuf library.
-	// The example of the prefix can be found here:
-	// https://github.com/protocolbuffers/protobuf/blob/ee9f0bccf0950e07070e43d8d53ca70876fa050a/src/google/protobuf/text_format.cc#L3087
-	//
-	// Ideally, the Go protobuf lib should be able to handle this natively, but until then,
-	// we manually strip the prefix.
-	//
-	// We are only interested in the `filter_metadata` part, so we find its index and slice from there.
-	hostMetadataStr := hostMetadata.GetStringValue()
-	index := strings.Index(hostMetadataStr, "filter_metadata")
-	if index != -1 {
-		hostMetadataStr = hostMetadataStr[index:]
-	}
-	opt := prototext.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
-	err := opt.Unmarshal([]byte(hostMetadataStr), &metadata)
-	if err != nil {
-		return status.Errorf(codes.Internal,
-			"cannot unmarshal host metadata '%s': %v",
-			hostMetadata.GetStringValue(),
-			err)
+		backendNamePath = internalapi.XDSUpstreamHostMetadataBackendNamePath
 	}
 
-	aiGatewayEndpointMetadata, ok := metadata.FilterMetadata[internalapi.InternalEndpointMetadataNamespace]
-	if !ok {
-		return status.Errorf(codes.Internal, "missing %s metadata", internalapi.InternalEndpointMetadataNamespace)
+	var backendName string
+	if b, ok := attributes.Fields[backendNamePath]; ok {
+		backendName = b.GetStringValue()
+	} else if hostMetadata, ok := attributes.Fields[metadataFieldKey]; ok {
+		// This is the backward compatible path where we read the full host metadata, which
+		// can be fragile due to how unstable proto text format can be. After v0.5 is release,
+		// we can remove this code path.
+
+		// Unmarshal the text into the struct since the metadata is encoded as a proto string.
+		var metadata corev3.Metadata
+		opt := prototext.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
+		err := opt.Unmarshal([]byte(hostMetadata.GetStringValue()), &metadata)
+		if err != nil {
+			return status.Errorf(codes.Internal,
+				"cannot unmarshal host metadata '%s': %v",
+				hostMetadata.GetStringValue(),
+				err)
+		}
+
+		aiGatewayEndpointMetadata, ok := metadata.FilterMetadata[internalapi.InternalEndpointMetadataNamespace]
+		if !ok {
+			return status.Errorf(codes.Internal, "missing %s metadata", internalapi.InternalEndpointMetadataNamespace)
+		}
+		b, ok := aiGatewayEndpointMetadata.Fields[internalapi.InternalMetadataBackendNameKey]
+		if !ok {
+			return status.Errorf(codes.Internal, "missing %s in endpoint metadata", internalapi.InternalMetadataBackendNameKey)
+		}
+		backendName = b.GetStringValue()
+	} else {
+		return status.Errorf(codes.Internal, "missing %s in request", metadataFieldKey)
 	}
-	backendName, ok := aiGatewayEndpointMetadata.Fields[internalapi.InternalMetadataBackendNameKey]
+
+	backend, ok := s.config.Backends[backendName]
 	if !ok {
-		return status.Errorf(codes.Internal, "missing %s in endpoint metadata", internalapi.InternalMetadataBackendNameKey)
-	}
-	backend, ok := s.config.Backends[backendName.GetStringValue()]
-	if !ok {
-		return status.Errorf(codes.Internal, "unknown backend: %s", backendName.GetStringValue())
+		return status.Errorf(codes.Internal, "unknown backend: %s", backendName)
 	}
 
 	s.routerProcessorsPerReqIDMutex.RLock()
@@ -354,7 +351,7 @@ func (s *Server) setBackend(ctx context.Context, p Processor, internalReqID stri
 	routerProcessor, ok := s.routerProcessorsPerReqID[internalReqID]
 	if !ok {
 		return status.Errorf(codes.Internal, "no router processor found, request_id=%s, backend=%s",
-			internalReqID, backendName.GetStringValue())
+			internalReqID, backendName)
 	}
 
 	if err := p.SetBackend(ctx, backend.Backend, backend.Handler, routerProcessor); err != nil {

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -64,10 +64,17 @@ const (
 )
 
 const (
+	xdsMetadataClusterPath = `.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']`
 	// XDSClusterMetadataKey is the key used to access cluster metadata in xDS attributes
+	// This is for backward compatibility with the older deployment. TODO: remove this after v0.5 is released.
 	XDSClusterMetadataKey = "xds.cluster_metadata"
+	// XDSClusterMetadataBackendNamePath is the full attribute path to access the backend name in cluster metadata in xDS attributes.
+	XDSClusterMetadataBackendNamePath = XDSClusterMetadataKey + xdsMetadataClusterPath
 	// XDSUpstreamHostMetadataKey is the key used to access upstream host metadata in xDS attributes
+	// This is for backward compatibility with the older deployment. TODO: remove this after v0.5 is released.
 	XDSUpstreamHostMetadataKey = "xds.upstream_host_metadata"
+	// XDSUpstreamHostMetadataBackendNamePath is the full attribute path to access the backend name in upstream host metadata in xDS attributes.
+	XDSUpstreamHostMetadataBackendNamePath = XDSUpstreamHostMetadataKey + xdsMetadataClusterPath
 )
 
 // PerRouteRuleRefBackendName generates a unique backend name for a per-route rule,

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -64,17 +64,17 @@ const (
 )
 
 const (
-	xdsMetadataClusterPath = `.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']`
+	xdsMetadataBackendNamePath = `.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']`
 	// XDSClusterMetadataKey is the key used to access cluster metadata in xDS attributes
 	// This is for backward compatibility with the older deployment. TODO: remove this after v0.5 is released.
 	XDSClusterMetadataKey = "xds.cluster_metadata"
 	// XDSClusterMetadataBackendNamePath is the full attribute path to access the backend name in cluster metadata in xDS attributes.
-	XDSClusterMetadataBackendNamePath = XDSClusterMetadataKey + xdsMetadataClusterPath
+	XDSClusterMetadataBackendNamePath = XDSClusterMetadataKey + xdsMetadataBackendNamePath
 	// XDSUpstreamHostMetadataKey is the key used to access upstream host metadata in xDS attributes
 	// This is for backward compatibility with the older deployment. TODO: remove this after v0.5 is released.
 	XDSUpstreamHostMetadataKey = "xds.upstream_host_metadata"
 	// XDSUpstreamHostMetadataBackendNamePath is the full attribute path to access the backend name in upstream host metadata in xDS attributes.
-	XDSUpstreamHostMetadataBackendNamePath = XDSUpstreamHostMetadataKey + xdsMetadataClusterPath
+	XDSUpstreamHostMetadataBackendNamePath = XDSUpstreamHostMetadataKey + xdsMetadataBackendNamePath
 )
 
 // PerRouteRuleRefBackendName generates a unique backend name for a per-route rule,

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -1566,7 +1566,7 @@ static_resources:
                 allow_mode_override: true
                 request_attributes:
                   - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
-                  - xds.cluster_metadata
+                  - xds.cluster_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "BUFFERED"
@@ -1625,7 +1625,7 @@ static_resources:
                 allow_mode_override: true
                 request_attributes:
                   - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
-                  - xds.cluster_metadata
+                  - xds.cluster_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "BUFFERED"

--- a/tests/extproc/envoy.yaml
+++ b/tests/extproc/envoy.yaml
@@ -337,7 +337,7 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 allow_mode_override: true
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -396,7 +396,7 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 allow_mode_override: true
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -454,7 +454,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -524,7 +524,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -582,7 +582,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -640,7 +640,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -710,7 +710,7 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 allow_mode_override: true
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -786,7 +786,7 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 allow_mode_override: true
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -850,7 +850,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -909,7 +909,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -968,7 +968,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1026,7 +1026,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1101,7 +1101,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1164,7 +1164,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1247,7 +1247,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1311,7 +1311,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1375,7 +1375,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1439,7 +1439,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1503,7 +1503,7 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                 processing_mode:
                   request_header_mode: "SEND"
                   request_body_mode: "NONE"
@@ -1565,7 +1565,7 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 allow_mode_override: true
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                   - xds.cluster_metadata
                 processing_mode:
                   request_header_mode: "SEND"
@@ -1624,7 +1624,7 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
                 allow_mode_override: true
                 request_attributes:
-                  - xds.upstream_host_metadata
+                  - xds.upstream_host_metadata.filter_metadata['aigateway.envoy.io']['per_route_rule_backend_name']
                   - xds.cluster_metadata
                 processing_mode:
                   request_header_mode: "SEND"


### PR DESCRIPTION
**Description**

Previously, we are getting the cluster/endpoint metadata as an attribute sent by envoy. Internally, Envoy serializes it as a protobuf text. However, since the recent change in the upstream protobuf, which in turn Envoy depends on, the breaking change in its format has been introduced. We added a workaround in #1651 but it's fragile fundamentally since it's still the text protobuf.

This switches our implementation to list the full path for the metadata that we want to get in the ExtProc fiter configuration which allows us to avoid encountering the text formatted full metadata. In order not to break the existing deployment, we keep the legacy code path until the next release.


**Related Issues/PRs (if applicable)**

Followup on #1651 and #1652
