### PR TITLE
docs: policy for AI use in contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,8 @@ want to run these tests locally, please prepare the necessary credentials by you
 
 ### Goals
 
-* Keep Envoy AI Gateway code consistent and high-quality.
-* Save reviewers time. Reviewers are often in short supply and time, so try to avoid wasted time.
+- Keep Envoy AI Gateway code consistent and high-quality.
+- Save reviewers time. Reviewers are often in short supply and time, so try to avoid wasted time.
 
 ### What is allowed
 
@@ -65,21 +65,21 @@ the code being submitted.
 
 All of the following are required:
 
-* You understand the change you are submitting.
-* You respond to questions and comments from the reviewer. If you use generative AI to help in your
+- You understand the change you are submitting.
+- You respond to questions and comments from the reviewer. If you use generative AI to help in your
   responses, you are required to edit and proof read the AI-generated responses, and ensure it is
   a reasonable response to the question or issue raised.
-* You are able to revise the AI-generated code if requested by the reviewer. You are responsible for
+- You are able to revise the AI-generated code if requested by the reviewer. You are responsible for
   ensuring issues are addressed, even if your AI assistant is unable.
-* You are transparent about your AI usage. It is often helpful to a reviewer to know that an AI tool
+- You are transparent about your AI usage. It is often helpful to a reviewer to know that an AI tool
   was used; please include that information in the PR description.
-* All generated code must be released under the same [license](LICENSE) as Envoy. You are responsible
+- All generated code must be released under the same [license](LICENSE) as Envoy. You are responsible
   for ensuring that the tools you use to generate code do not add any additional licensing restrictions.
 
 ### What is not allowed
 
-* PRs which the submitter does not understand or take full ownership of.
-* Code comments should be valuable to the codebase. Any comments which only help the AI interact with
+- PRs which the submitter does not understand or take full ownership of.
+- Code comments should be valuable to the codebase. Any comments which only help the AI interact with
   the code must be removed before the PR is submitted. Comments which explain what straightforward code
   does are not useful.
 


### PR DESCRIPTION
**Description**

This adds a policy for generative AI use when authoring PRs and contributing to this project.

**Related Issues/PRs (if applicable)**

This is exactly the same as Envoy core repository https://github.com/envoyproxy/envoy/pull/42314