### PR TITLE
site: make adopters linkable and unify style

### DIFF
--- a/site/src/components/Adopters/index.tsx
+++ b/site/src/components/Adopters/index.tsx
@@ -57,7 +57,7 @@ function AdopterLogo({ name, logoUrl, url, description }: Adopter) {
 
 export default function Adopters(): React.ReactElement {
   return (
-    <section className={styles.adoptersSection}>
+    <section id="adopters" className={styles.adoptersSection}>
       <div className="container">
         <div className={styles.sectionHeader}>
           <Heading as="h2" className={styles.sectionTitle}>

--- a/site/src/components/LLMProviders/index.tsx
+++ b/site/src/components/LLMProviders/index.tsx
@@ -119,7 +119,7 @@ function ProviderLogo({ name, logoUrl, status }: LLMProvider) {
 
 export default function LLMProviders(): React.ReactElement {
   return (
-    <section className={styles.providersSection}>
+    <section id="llm-providers" className={styles.providersSection}>
       <div className="container">
         <div className={styles.sectionHeader}>
           <Heading as="h2" className={styles.sectionTitle}>

--- a/site/src/pages/talks.tsx
+++ b/site/src/pages/talks.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
+import Link from '@docusaurus/Link';
 import talksData from '../data/talks.json';
 import styles from './talks.module.css';
 
@@ -68,13 +69,13 @@ export default function Talks(): React.ReactElement {
               Watch talks and presentations about Envoy AI Gateway from conferences, meetups, and community events.
             </p>
             <div className={styles.contributeButton}>
-              <a
+              <Link
+                className="button button--primary button--lg"
                 href="https://github.com/envoyproxy/ai-gateway/edit/main/site/src/data/talks.json"
                 target="_blank"
-                rel="noopener noreferrer"
-                className={styles.button}>
+                rel="noopener noreferrer">
                 Add your session!
-              </a>
+              </Link>
             </div>
           </div>
 


### PR DESCRIPTION
**Description**

Makes the adopters section in the main page linkable to make it easier to reference it directly, and updates the button in the talks section to align with better the site style.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A