### PR TITLE
fix: handle MaxCompletionTokens in gemini translation

### DIFF
--- a/internal/translator/gemini_helper.go
+++ b/internal/translator/gemini_helper.go
@@ -6,6 +6,7 @@
 package translator
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -621,9 +622,12 @@ func openAIReqToGeminiGenerationConfig(openAIReq *openai.ChatCompletionRequest, 
 	if openAIReq.N != nil {
 		gc.CandidateCount = int32(*openAIReq.N) // nolint:gosec
 	}
-	if openAIReq.MaxTokens != nil {
-		gc.MaxOutputTokens = int32(*openAIReq.MaxTokens) // nolint:gosec
+
+	maxTokens := cmp.Or(openAIReq.MaxCompletionTokens, openAIReq.MaxTokens)
+	if maxTokens != nil {
+		gc.MaxOutputTokens = int32(*maxTokens) // nolint:gosec
 	}
+
 	if openAIReq.PresencePenalty != nil {
 		gc.PresencePenalty = openAIReq.PresencePenalty
 	}

--- a/internal/translator/gemini_helper_test.go
+++ b/internal/translator/gemini_helper_test.go
@@ -1028,6 +1028,51 @@ func TestOpenAIReqToGeminiGenerationConfig(t *testing.T) {
 			expectedResponseMode:     responseModeNone,
 		},
 		{
+			name: "only MaxTokens set",
+			input: &openai.ChatCompletionRequest{
+				MaxTokens: ptr.To(int64(100)),
+			},
+			expectedGenerationConfig: &genai.GenerationConfig{
+				MaxOutputTokens: 100,
+			},
+			expectedResponseMode: responseModeNone,
+			requestModel:         "gemini-2.5-flash",
+		},
+		{
+			name: "only MaxCompletionTokens set",
+			input: &openai.ChatCompletionRequest{
+				MaxCompletionTokens: ptr.To(int64(200)),
+			},
+			expectedGenerationConfig: &genai.GenerationConfig{
+				MaxOutputTokens: 200,
+			},
+			expectedResponseMode: responseModeNone,
+			requestModel:         "gemini-2.5-flash",
+		},
+		{
+			name: "both MaxCompletionTokens and MaxTokens set - MaxCompletionTokens takes precedence",
+			input: &openai.ChatCompletionRequest{
+				MaxCompletionTokens: ptr.To(int64(300)),
+				MaxTokens:           ptr.To(int64(100)),
+			},
+			expectedGenerationConfig: &genai.GenerationConfig{
+				MaxOutputTokens: 300,
+			},
+			expectedResponseMode: responseModeNone,
+			requestModel:         "gemini-2.5-flash",
+		},
+		{
+			name: "neither MaxCompletionTokens nor MaxTokens set",
+			input: &openai.ChatCompletionRequest{
+				Temperature: ptr.To(0.5),
+			},
+			expectedGenerationConfig: &genai.GenerationConfig{
+				Temperature: ptr.To(float32(0.5)),
+			},
+			expectedResponseMode: responseModeNone,
+			requestModel:         "gemini-2.5-flash",
+		},
+		{
 			name: "stop sequences",
 			input: &openai.ChatCompletionRequest{
 				Stop: openaigo.ChatCompletionNewParamsStopUnion{


### PR DESCRIPTION
**Description**
Current OpenAI to Gemini request translation takes into account `max_tokens` but not `max_completion_tokens`. This PR updates the logic to `max_completion_tokens` check both. `max_completion_tokens` takes priority over `max_tokens`.
