### PR TITLE
fix: adds backward compat logic for OpenAI prefix; part2

### DIFF
--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -201,6 +201,7 @@ stringData:
       schema:
         name: OpenAI
         prefix: v1
+        version: v1
     - auth:
         aws:
           credentialFileLiteral: |
@@ -217,6 +218,7 @@ stringData:
       schema:
         name: OpenAI
         prefix: v1
+        version: v1
     models:
     - CreatedAt: "2025-05-23T00:00:00Z"
       Name: gpt-4o-mini

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -165,6 +165,8 @@ func schemaToFilterAPI(schema aigv1a1.VersionedAPISchema, l logr.Logger) filtera
 				"Please set 'prefix' field explicitly as this use of 'version' field will be removed in future releases.",
 			)
 		}
+		// This is for backward compatibility. TODO: remove this after v0.5.0 release.
+		ret.Version = ret.Prefix
 	} else {
 		ret.Version = ptr.Deref(schema.Version, "")
 	}
@@ -340,7 +342,11 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 				b.ModelNameOverride = backendRef.ModelNameOverride
 				if backendRef.IsInferencePool() {
 					// We assume that InferencePools are all OpenAI schema.
-					b.Schema = filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v1"}
+					b.Schema = filterapi.VersionedAPISchema{
+						Name: filterapi.APISchemaOpenAI,
+						// This is for backward compatibility. TODO: Remove the 'version' field usage after v0.5.0 release.
+						Version: "v1", Prefix: "v1",
+					}
 				} else {
 					var backendObj *aigv1a1.AIServiceBackend
 					var bsp *aigv1a1.BackendSecurityPolicy

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -879,16 +879,16 @@ func Test_schemaToFilterAPI(t *testing.T) {
 		{
 			// Backward compatible case.
 			in:       aigv1a1.VersionedAPISchema{Name: aigv1a1.APISchemaOpenAI, Version: ptr.To("v123")},
-			expected: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v123"},
+			expected: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v123", Version: "v123"},
 		},
 		{
 			// Backward compatible case.
 			in:       aigv1a1.VersionedAPISchema{Name: aigv1a1.APISchemaOpenAI},
-			expected: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v1"},
+			expected: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v1", Version: "v1"},
 		},
 		{
 			in:       aigv1a1.VersionedAPISchema{Name: aigv1a1.APISchemaOpenAI, Prefix: ptr.To("v1/foo")},
-			expected: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v1/foo"},
+			expected: filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI, Prefix: "v1/foo", Version: "v1/foo"},
 		},
 		{
 			in:       aigv1a1.VersionedAPISchema{Name: aigv1a1.APISchemaAWSBedrock},


### PR DESCRIPTION
**Description**
This adds an additional backward compatible pass for OpenAI's prefix field handling 

**Related Issues/PRs (if applicable)**
Follow up on #1666 and #1674

