### PR TITLE
deps: use goccy/go-json instead of encoding/json

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters:
               desc: use sigs.k8s.io/yaml instead
             - pkg: k8s.io/utils/pointer
               desc: use k8s.io/utils/ptr instead
+            - pkg: encoding/json
+              desc: use github.com/goccy/go-json instead
     govet:
       disable:
         - fieldalignment

--- a/cmd/aigw/main.go
+++ b/cmd/aigw/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
+	"github.com/goccy/go-json"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.14.0
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/go-logr/logr v1.4.3
+	github.com/goccy/go-json v0.10.5
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/cel-go v0.26.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/internal/apischema/anthropic/anthropic.go
+++ b/internal/apischema/anthropic/anthropic.go
@@ -6,11 +6,11 @@
 package anthropic
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/gjson"
 )
 

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -11,7 +11,6 @@ package openai
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/responses"
 	"github.com/tidwall/gjson"

--- a/internal/apischema/openai/openai_bench_test.go
+++ b/internal/apischema/openai/openai_bench_test.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go/v2"
 )
 

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openai/openai-go/v2"

--- a/internal/apischema/openai/union.go
+++ b/internal/apischema/openai/union.go
@@ -6,9 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/goccy/go-json"
 )
 
 // unmarshalJSONNestedUnion is tuned to be faster with substantially reduced

--- a/internal/apischema/openai/vendor_fields_test.go
+++ b/internal/apischema/openai/vendor_fields_test.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openai/openai-go/v2"

--- a/internal/bodymutator/body_mutator_test.go
+++ b/internal/bodymutator/body_mutator_test.go
@@ -6,9 +6,9 @@
 package bodymutator
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"

--- a/internal/controller/backend_security_policy_test.go
+++ b/internal/controller/backend_security_policy_test.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +18,7 @@ import (
 	stsTypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	oidcv3 "github.com/coreos/go-oidc/v3/oidc"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/controller/mcp_route_security_policy.go
+++ b/internal/controller/mcp_route_security_policy.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/goccy/go-json"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/internal/controller/mcp_route_security_policy_test.go
+++ b/internal/controller/mcp_route_security_policy_test.go
@@ -6,7 +6,6 @@
 package controller
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +15,7 @@ import (
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/rotators/aws_oidc_rotator_test.go
+++ b/internal/controller/rotators/aws_oidc_rotator_test.go
@@ -7,7 +7,6 @@ package rotators
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	oidcv3 "github.com/coreos/go-oidc/v3/oidc"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"

--- a/internal/controller/tokenprovider/oidc_token_provider_test.go
+++ b/internal/controller/tokenprovider/oidc_token_provider_test.go
@@ -7,7 +7,6 @@ package tokenprovider
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +14,7 @@ import (
 
 	oidcv3 "github.com/coreos/go-oidc/v3/oidc"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/endpointspec/endpointspec.go
+++ b/internal/endpointspec/endpointspec.go
@@ -8,9 +8,9 @@
 package endpointspec
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"

--- a/internal/endpointspec/endpointspec_test.go
+++ b/internal/endpointspec/endpointspec_test.go
@@ -6,9 +6,9 @@
 package endpointspec
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/openai/openai-go/v2/responses"
 	"github.com/stretchr/testify/require"

--- a/internal/extensionserver/inferencepool.go
+++ b/internal/extensionserver/inferencepool.go
@@ -6,7 +6,6 @@
 package extensionserver
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	upstreamsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/goccy/go-json"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -7,13 +7,13 @@ package extproc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/goccy/go-json"
 	"google.golang.org/grpc/codes"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -6,7 +6,6 @@
 package extproc
 
 import (
-	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/extproc/processor_impl_test.go
+++ b/internal/extproc/processor_impl_test.go
@@ -7,7 +7,6 @@ package extproc
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -16,6 +15,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"

--- a/internal/mcpproxy/handlers_test.go
+++ b/internal/mcpproxy/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"

--- a/internal/mcpproxy/mcpproxy.go
+++ b/internal/mcpproxy/mcpproxy.go
@@ -8,7 +8,6 @@ package mcpproxy
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"

--- a/internal/mcpproxy/session.go
+++ b/internal/mcpproxy/session.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"

--- a/internal/tracing/openinference/anthropic/messages.go
+++ b/internal/tracing/openinference/anthropic/messages.go
@@ -6,9 +6,9 @@
 package anthropic
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/anthropic/messages_test.go
+++ b/internal/tracing/openinference/anthropic/messages_test.go
@@ -6,9 +6,9 @@
 package anthropic
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/cohere/rerank.go
+++ b/internal/tracing/openinference/cohere/rerank.go
@@ -8,8 +8,7 @@
 package cohere
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/cohere/rerank_test.go
+++ b/internal/tracing/openinference/cohere/rerank_test.go
@@ -6,9 +6,9 @@
 package cohere
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/openai/chat_completion.go
+++ b/internal/tracing/openinference/openai/chat_completion.go
@@ -8,8 +8,7 @@
 package openai
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/openai/chat_completion_config_test.go
+++ b/internal/tracing/openinference/openai/chat_completion_config_test.go
@@ -6,9 +6,9 @@
 package openai
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/openai/chat_completion_test.go
+++ b/internal/tracing/openinference/openai/chat_completion_test.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/openai/completion.go
+++ b/internal/tracing/openinference/openai/completion.go
@@ -6,8 +6,7 @@
 package openai
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/openai/completion_test.go
+++ b/internal/tracing/openinference/openai/completion_test.go
@@ -6,11 +6,11 @@
 package openai
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/openai/embeddings.go
+++ b/internal/tracing/openinference/openai/embeddings.go
@@ -6,8 +6,7 @@
 package openai
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/openai/embeddings_config_test.go
+++ b/internal/tracing/openinference/openai/embeddings_config_test.go
@@ -6,9 +6,9 @@
 package openai
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/openai/embeddings_test.go
+++ b/internal/tracing/openinference/openai/embeddings_test.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/tracing/openinference/openai/image_generation.go
+++ b/internal/tracing/openinference/openai/image_generation.go
@@ -8,8 +8,7 @@
 package openai
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/openai/request_attrs.go
+++ b/internal/tracing/openinference/openai/request_attrs.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/tracing/openinference/openai/responses.go
+++ b/internal/tracing/openinference/openai/responses.go
@@ -6,8 +6,7 @@
 package openai
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/tracing/openinference/openai/sse_converter_test.go
+++ b/internal/tracing/openinference/openai/sse_converter_test.go
@@ -6,10 +6,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/tracing/openinference/test_helpers.go
+++ b/internal/tracing/openinference/test_helpers.go
@@ -6,10 +6,10 @@
 package openinference
 
 import (
-	"encoding/json"
 	"regexp"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"

--- a/internal/tracing/span_test.go
+++ b/internal/tracing/span_test.go
@@ -6,9 +6,9 @@
 package tracing
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -7,10 +7,10 @@ package tracing
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/contrib/propagators/autoprop"
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/translator/anthropic_anthropic.go
+++ b/internal/translator/anthropic_anthropic.go
@@ -8,11 +8,11 @@ package translator
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"

--- a/internal/translator/anthropic_awsanthropic_test.go
+++ b/internal/translator/anthropic_awsanthropic_test.go
@@ -6,9 +6,9 @@
 package translator
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/translator/anthropic_gcpanthropic_test.go
+++ b/internal/translator/anthropic_gcpanthropic_test.go
@@ -7,10 +7,10 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"

--- a/internal/translator/cohere_rerank_v2.go
+++ b/internal/translator/cohere_rerank_v2.go
@@ -6,13 +6,13 @@
 package translator
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"

--- a/internal/translator/cohere_rerank_v2_test.go
+++ b/internal/translator/cohere_rerank_v2_test.go
@@ -6,11 +6,11 @@
 package translator
 
 import (
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/sjson"
 

--- a/internal/translator/gemini_helper.go
+++ b/internal/translator/gemini_helper.go
@@ -7,7 +7,6 @@ package translator
 
 import (
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"mime"
@@ -15,6 +14,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/google/uuid"
 	openaisdk "github.com/openai/openai-go/v2"
 	"google.golang.org/genai"

--- a/internal/translator/gemini_helper_test.go
+++ b/internal/translator/gemini_helper_test.go
@@ -6,10 +6,10 @@
 package translator
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	openaigo "github.com/openai/openai-go/v2"

--- a/internal/translator/imagegeneration_openai_openai.go
+++ b/internal/translator/imagegeneration_openai_openai.go
@@ -7,12 +7,12 @@ package translator
 
 import (
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
 	"strconv"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/imagegeneration_openai_openai_test.go
+++ b/internal/translator/imagegeneration_openai_openai_test.go
@@ -7,10 +7,10 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/jsonschema_helper.go
+++ b/internal/translator/jsonschema_helper.go
@@ -6,10 +6,10 @@
 package translator
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"google.golang.org/genai"
 )
 

--- a/internal/translator/jsonschema_helper_test.go
+++ b/internal/translator/jsonschema_helper_test.go
@@ -6,9 +6,9 @@
 package translator
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"

--- a/internal/translator/openai_awsbedrock.go
+++ b/internal/translator/openai_awsbedrock.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/goccy/go-json"
 	"k8s.io/utils/ptr"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/awsbedrock"

--- a/internal/translator/openai_awsbedrock_test.go
+++ b/internal/translator/openai_awsbedrock_test.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	openaigo "github.com/openai/openai-go/v2"

--- a/internal/translator/openai_azureopenai_embeddings_test.go
+++ b/internal/translator/openai_azureopenai_embeddings_test.go
@@ -6,10 +6,10 @@
 package translator
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_azureopenai_test.go
+++ b/internal/translator/openai_azureopenai_test.go
@@ -7,10 +7,10 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_completions.go
+++ b/internal/translator/openai_completions.go
@@ -7,12 +7,12 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
 	"strconv"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_completions_test.go
+++ b/internal/translator/openai_completions_test.go
@@ -6,10 +6,10 @@
 package translator
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_embeddings.go
+++ b/internal/translator/openai_embeddings.go
@@ -6,13 +6,13 @@
 package translator
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_embeddings_test.go
+++ b/internal/translator/openai_embeddings_test.go
@@ -6,10 +6,10 @@
 package translator
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_gcpanthropic.go
+++ b/internal/translator/openai_gcpanthropic.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"cmp"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	anthropicParam "github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
 	anthropicVertex "github.com/anthropics/anthropic-sdk-go/vertex"
+	"github.com/goccy/go-json"
 	openAIconstant "github.com/openai/openai-go/shared/constant"
 	"github.com/tidwall/sjson"
 

--- a/internal/translator/openai_gcpanthropic_stream.go
+++ b/internal/translator/openai_gcpanthropic_stream.go
@@ -7,13 +7,13 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+	"github.com/goccy/go-json"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"

--- a/internal/translator/openai_gcpanthropic_stream_test.go
+++ b/internal/translator/openai_gcpanthropic_stream_test.go
@@ -6,11 +6,11 @@
 package translator
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/translator/openai_gcpanthropic_test.go
+++ b/internal/translator/openai_gcpanthropic_test.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/shared"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
 	anthropicVertex "github.com/anthropics/anthropic-sdk-go/vertex"
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	openaigo "github.com/openai/openai-go/v2"

--- a/internal/translator/openai_gcpvertexai.go
+++ b/internal/translator/openai_gcpvertexai.go
@@ -7,11 +7,11 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
 
+	"github.com/goccy/go-json"
 	"github.com/google/uuid"
 	"google.golang.org/genai"
 	"k8s.io/utils/ptr"

--- a/internal/translator/openai_gcpvertexai_test.go
+++ b/internal/translator/openai_gcpvertexai_test.go
@@ -7,13 +7,13 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	openaigo "github.com/openai/openai-go/v2"

--- a/internal/translator/openai_openai.go
+++ b/internal/translator/openai_openai.go
@@ -8,13 +8,13 @@ package translator
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_openai_test.go
+++ b/internal/translator/openai_openai_test.go
@@ -7,12 +7,12 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"

--- a/internal/translator/openai_responses.go
+++ b/internal/translator/openai_responses.go
@@ -8,13 +8,13 @@ package translator
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/tidwall/sjson"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/internal/translator/openai_responses_test.go
+++ b/internal/translator/openai_responses_test.go
@@ -7,11 +7,11 @@ package translator
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"strconv"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/openai/openai-go/v2/responses"
 	"github.com/stretchr/testify/require"

--- a/internal/translator/util.go
+++ b/internal/translator/util.go
@@ -8,9 +8,10 @@ package translator
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"regexp"
+
+	"github.com/goccy/go-json"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 )

--- a/tests/e2e-aigw/examples_mcp_test.go
+++ b/tests/e2e-aigw/examples_mcp_test.go
@@ -7,7 +7,6 @@ package e2emcp
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 

--- a/tests/e2e-inference-extension/inference_pool_test.go
+++ b/tests/e2e-inference-extension/inference_pool_test.go
@@ -7,7 +7,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"

--- a/tests/e2e/mcp_route_oauth_test.go
+++ b/tests/e2e/mcp_route_oauth_test.go
@@ -7,7 +7,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -8,7 +8,6 @@ package e2e
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"

--- a/tests/extproc/mcp/env.go
+++ b/tests/extproc/mcp/env.go
@@ -8,7 +8,6 @@ package mcp
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -17,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"

--- a/tests/extproc/mcp/publicmcp_test.go
+++ b/tests/extproc/mcp/publicmcp_test.go
@@ -6,7 +6,6 @@
 package mcp
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 

--- a/tests/extproc/real_providers_test.go
+++ b/tests/extproc/real_providers_test.go
@@ -8,7 +8,6 @@ package extproc
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/stretchr/testify/assert"

--- a/tests/extproc/testupstream_test.go
+++ b/tests/extproc/testupstream_test.go
@@ -8,7 +8,6 @@ package extproc
 import (
 	"cmp"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	openaigo "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/stretchr/testify/require"

--- a/tests/extproc/vcr/otel_test.go
+++ b/tests/extproc/vcr/otel_test.go
@@ -8,12 +8,12 @@ package vcr
 import (
 	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/sjson"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"

--- a/tests/internal/e2elib/e2elib.go
+++ b/tests/internal/e2elib/e2elib.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/singleflight"
 

--- a/tests/internal/testopenai/cassettes.go
+++ b/tests/internal/testopenai/cassettes.go
@@ -8,10 +8,11 @@ package testopenai
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/goccy/go-json"
 )
 
 // Cassette is an HTTP interaction recording.

--- a/tests/internal/testopenai/cassettes_test.go
+++ b/tests/internal/testopenai/cassettes_test.go
@@ -6,7 +6,6 @@
 package testopenai
 
 import (
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/internal/testopenai/chat_requests.go
+++ b/tests/internal/testopenai/chat_requests.go
@@ -6,8 +6,7 @@
 package testopenai
 
 import (
-	"encoding/json"
-
+	"github.com/goccy/go-json"
 	"k8s.io/utils/ptr"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"

--- a/tests/internal/testopenai/handler_test.go
+++ b/tests/internal/testopenai/handler_test.go
@@ -7,7 +7,6 @@ package testopenai
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -18,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 )

--- a/tests/internal/testopenai/openai.go
+++ b/tests/internal/testopenai/openai.go
@@ -6,9 +6,10 @@
 package testopenai
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/goccy/go-json"
 )
 
 // extractModel extracts the Model field from an OpenAI request body using reflection.

--- a/tests/internal/testopenai/vcr.go
+++ b/tests/internal/testopenai/vcr.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"embed"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -20,6 +19,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 	"gopkg.in/yaml.v3" //nolint:depguard // sigs.k8s.io/yaml breaks Duration unmarshaling in cassettes

--- a/tests/internal/testopenai/vcr_test.go
+++ b/tests/internal/testopenai/vcr_test.go
@@ -8,7 +8,6 @@ package testopenai
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 	"gopkg.in/yaml.v3" //nolint:depguard // Testing that this specific library works with Duration fields.

--- a/tests/internal/testopeninference/assertions.go
+++ b/tests/internal/testopeninference/assertions.go
@@ -7,13 +7,13 @@ package testopeninference
 
 import (
 	"cmp"
-	"encoding/json"
 	"reflect"
 	"regexp"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	gocmp "github.com/google/go-cmp/cmp"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"

--- a/tests/internal/testopeninference/recorder.go
+++ b/tests/internal/testopeninference/recorder.go
@@ -8,7 +8,6 @@ package testopeninference
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -22,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-json"
 	collecttracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/tests/internal/testupstreamlib/testupstream/main.go
+++ b/tests/internal/testupstreamlib/testupstream/main.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -21,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/goccy/go-json"
 	"github.com/tidwall/gjson"
 	"golang.org/x/exp/rand"
 

--- a/tests/internal/testupstreamlib/testupstream/main_test.go
+++ b/tests/internal/testupstreamlib/testupstream/main_test.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -21,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/goccy/go-json"
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
**Description**

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/envoyproxy/ai-gateway/tests/extproc
cpu: Apple M1 Pro
                                             │    old.txt    │               new.txt                │
                                             │    sec/op     │    sec/op     vs base                │
ChatCompletions/OpenAI_-_small-10               218.1µ ±  3%   186.5µ ± 14%  -14.49% (p=0.000 n=10)
ChatCompletions/OpenAI_-_medium-10              3.419m ±  1%   1.887m ±  1%  -44.82% (p=0.000 n=10)
ChatCompletions/OpenAI_-_large-10               36.14m ±  1%   19.14m ± 13%  -47.05% (p=0.000 n=10)
ChatCompletions/OpenAI_-_xlarge-10             178.69m ± 13%   90.97m ± 25%  -49.09% (p=0.000 n=10)
ChatCompletions/AWS_Bedrock_-_small-10          239.5µ ±  3%   206.4µ ± 64%        ~ (p=0.436 n=10)
ChatCompletions/AWS_Bedrock_-_medium-10         5.067m ±  8%   2.741m ±  5%  -45.90% (p=0.000 n=10)
ChatCompletions/AWS_Bedrock_-_large-10          53.07m ±  5%   26.73m ±  2%  -49.63% (p=0.000 n=10)
ChatCompletions/AWS_Bedrock_-_xlarge-10         545.3m ± 86%   150.1m ± 25%  -72.47% (p=0.000 n=10)
ChatCompletions/GCP_VertexAI_-_small-10         331.0µ ±  2%   261.3µ ±  6%  -21.04% (p=0.000 n=10)
ChatCompletions/GCP_VertexAI_-_medium-10        214.0m ±  8%   223.1m ±  5%   +4.26% (p=0.035 n=10)
ChatCompletions/GCP_VertexAI_-_large-10          27.75 ±  2%    25.92 ±  3%   -6.59% (p=0.000 n=10)
ChatCompletions/GCP_VertexAI_-_xlarge-10         21.83 ±  4%    21.34 ±  4%        ~ (p=0.105 n=10)
ChatCompletions/GCP_AnthropicAI_-_small-10      379.0µ ±  4%   322.3µ ± 22%  -14.95% (p=0.011 n=10)
ChatCompletions/GCP_AnthropicAI_-_medium-10    12.826m ±  3%   9.622m ±  7%  -24.98% (p=0.000 n=10)
ChatCompletions/GCP_AnthropicAI_-_large-10      125.7m ±  6%   114.3m ± 10%   -9.12% (p=0.005 n=10)
ChatCompletions/GCP_AnthropicAI_-_xlarge-10      2.363 ±  2%    1.722 ±  3%  -27.14% (p=0.000 n=10)
ChatCompletionsStreaming/OpenAI_Streaming-10                   24.31m ±  2%
ChatCompletionsStreaming/AWS_Streaming-10                      24.33m ±  0%
geomean                                         36.62m         25.15m        -31.05%
```