### PR TITLE
fix: inefficient string concatenation in gcp vertex ai translation

### DIFF
--- a/internal/translator/gemini_helper.go
+++ b/internal/translator/gemini_helper.go
@@ -755,12 +755,13 @@ func geminiFinishReasonToOpenAI[T toolCallSlice](reason genai.FinishReason, tool
 
 // extractTextAndThoughtSummaryFromGeminiParts extracts thought summary and text from Gemini parts.
 func extractTextAndThoughtSummaryFromGeminiParts(parts []*genai.Part, responseMode geminiResponseMode) (string, string) {
-	text := ""
-	thoughtSummary := ""
+	var textBuilder strings.Builder
+	var thoughtBuilder strings.Builder
+
 	for _, part := range parts {
 		if part != nil && part.Text != "" {
 			if part.Thought {
-				thoughtSummary += part.Text
+				thoughtBuilder.WriteString(part.Text)
 			} else {
 				if responseMode == responseModeRegex {
 					// GCP doesn't natively support REGEX response modes, so we instead express them as json schema.
@@ -770,11 +771,11 @@ func extractTextAndThoughtSummaryFromGeminiParts(parts []*genai.Part, responseMo
 					part.Text = strings.TrimPrefix(part.Text, "\"")
 					part.Text = strings.TrimSuffix(part.Text, "\"")
 				}
-				text += part.Text
+				textBuilder.WriteString(part.Text)
 			}
 		}
 	}
-	return thoughtSummary, text
+	return thoughtBuilder.String(), textBuilder.String()
 }
 
 // extractToolCallsFromGeminiParts extracts tool calls from Gemini parts.


### PR DESCRIPTION
**Description**
Inefficient string concatenation is a bottleneck for vertex ai translation as += in Go creates a new string object each time and creates GC pressure. 

Before Fix (from old.txt):
  GCP_VertexAI - large:    ~25,000ms (25 seconds)
  GCP_VertexAI - xlarge:   ~20,000ms (20 seconds)
  
After Fix (just measured):
  GCP_VertexAI - large:    ~60ms (0.06 seconds)  
  GCP_VertexAI - xlarge:   ~1,020ms (1.02 seconds)

