### PR TITLE
fix: update doc for max cache breakpoints

### DIFF
--- a/examples/cache/cache_control.md
+++ b/examples/cache/cache_control.md
@@ -43,12 +43,12 @@ Choose your preferred provider and ensure you have:
 
 ## Provider-Specific Considerations
 
-| Feature             | Anthropic Direct | GCP Vertex AI | AWS Bedrock                                                                               |
-| ------------------- | ---------------- | ------------- | ----------------------------------------------------------------------------------------- |
-| Max Cache Points    | [4 per request](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#when-to-use-multiple-breakpoints)         | 4 per request | [4 per request](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) |
-| Min Token Threshold | 1,024+ tokens    | 1,024+ tokens | 1,024+ tokens                                                                             |
-| Billing Integration | Native           | Native        | Native                                                                                    |
-| Cache Types         | ephemeral        | ephemeral     | ephemeral                                                                                 |
+| Feature             | Anthropic Direct                                                                                                       | GCP Vertex AI | AWS Bedrock                                                                               |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------- |
+| Max Cache Points    | [4 per request](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#when-to-use-multiple-breakpoints) | 4 per request | [4 per request](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) |
+| Min Token Threshold | 1,024+ tokens                                                                                                          | 1,024+ tokens | 1,024+ tokens                                                                             |
+| Billing Integration | Native                                                                                                                 | Native        | Native                                                                                    |
+| Cache Types         | ephemeral                                                                                                              | ephemeral     | ephemeral                                                                                 |
 
 ## Example Requests
 


### PR DESCRIPTION
**Description**
Based on testing GCP also limits to max 4 cache breakpoints for anthropic claude models.
```
{"type":"error","error":{"type":"invalid_request_error","code":"400","message":"A maximum of 4 blocks with cache_control may be provided. Found 5."}}
```