### PR TITLE
test: fix `make test` when OPENAI_API_KEY is present

### DIFF
--- a/tests/internal/testopenai/server_test.go
+++ b/tests/internal/testopenai/server_test.go
@@ -17,6 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	// Unset API keys to ensure tests behave consistently regardless of environment.
+	_ = os.Unsetenv("OPENAI_API_KEY")
+	_ = os.Unsetenv("AZURE_OPENAI_API_KEY")
+	os.Exit(m.Run())
+}
+
 func TestServer_ExistingCassette(t *testing.T) {
 	// Test that an existing cassette (chat-basic) works.
 	server := newTestServer(t)


### PR DESCRIPTION
**Description**

Previously the existence of theOPENAI_API_KEY interfered with the unit tests of the tests/internal/testopenai package. This fixes it


Thanks for the report @dimm0 