### PR TITLE
chore: ignore generated clinets from codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -14,6 +14,7 @@ coverage:
 ignore:
   - "cmd"
   - "examples"
+  - "api/v1alpha1/client"
   - "**/zz_generated.*.go"
   - "internal/testing"
   - "tests/internal"


### PR DESCRIPTION
**Description**

This ignores generated client SDK from codecov target