### PR TITLE
translator: use DeleteBytesOptions to avoid unnecessary copies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/tetratelabs/func-e v1.3.0
 	github.com/tidwall/gjson v1.18.0
-	github.com/tidwall/sjson v1.2.5
+	github.com/tidwall/sjson v1.2.6-0.20251103175603-13f6455cf849
 	go.opentelemetry.io/contrib/exporters/autoexport v0.64.0
 	go.opentelemetry.io/contrib/propagators/autoprop v0.64.0
 	go.opentelemetry.io/otel v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,8 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
-github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/tidwall/sjson v1.2.6-0.20251103175603-13f6455cf849 h1:Dr30VIDr3+YL0YeGEfzggxxzjFD5yz0Rc/oNHIZeRFw=
+github.com/tidwall/sjson v1.2.6-0.20251103175603-13f6455cf849/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=

--- a/internal/translator/anthropic_awsanthropic.go
+++ b/internal/translator/anthropic_awsanthropic.go
@@ -68,8 +68,10 @@ func (a *anthropicToAWSAnthropicTranslator) RequestBody(rawBody []byte, body *an
 	}
 	// Remove the model field from the body as AWS Bedrock expects the model to be specified in the path.
 	// Otherwise, AWS complains "extra inputs are not permitted".
-	newBody, _ = sjson.DeleteBytes(newBody, "model")
-	newBody, _ = sjson.DeleteBytes(newBody, "stream")
+	//
+	// It is safe to use sjsonOptionsInPlace here since we have already created a new mutatedBody above.
+	newBody, _ = sjson.DeleteBytesOptions(newBody, "model", sjsonOptionsInPlace)
+	newBody, _ = sjson.DeleteBytesOptions(newBody, "stream", sjsonOptionsInPlace)
 
 	// Determine the AWS Bedrock path based on whether streaming is requested.
 	var pathTemplate string

--- a/internal/translator/anthropic_gcpanthropic.go
+++ b/internal/translator/anthropic_gcpanthropic.go
@@ -51,9 +51,9 @@ func (a *anthropicToGCPAnthropicTranslator) RequestBody(raw []byte, req *anthrop
 	mutatedBody, _ := sjson.SetBytesOptions(raw, anthropicVersionKey, a.apiVersion, sjsonOptions)
 
 	// Remove the model field since GCP doesn't want it in the body.
-	// Note: Do not operate on raw here, as that would mutate the original request body.
-	// Hence, we do the SetBytesOptions above to create mutatedBody first.
-	newBody, _ = sjson.DeleteBytes(mutatedBody, "model")
+	newBody, _ = sjson.DeleteBytesOptions(mutatedBody, "model",
+		// It is safe to use sjsonOptionsInPlace here since we have already created a new mutatedBody above.
+		sjsonOptionsInPlace)
 
 	// Determine the GCP path based on whether streaming is requested.
 	specifier := "rawPredict"

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -91,10 +91,18 @@ type (
 	OpenAIResponsesTranslator = Translator[openai.ResponseRequest, tracingapi.ResponsesSpan]
 )
 
-// sjsonOptions are the options used for sjson operations in the translator.
-var sjsonOptions = &sjson.Options{
-	Optimistic: true,
-	// Note: DO NOT set ReplaceInPlace to true since at the translation layer, which might be called multiple times per retry,
-	// it must be ensured that the original body is not modified, i.e. the operation must be idempotent.
-	ReplaceInPlace: false,
-}
+var (
+	// sjsonOptions are the options used for sjson operations in the translator.
+	sjsonOptions = &sjson.Options{
+		Optimistic: true,
+		// Note: DO NOT set ReplaceInPlace to true since at the translation layer, which might be called multiple times per retry,
+		// it must be ensured that the original body is not modified, i.e. the operation must be idempotent.
+		ReplaceInPlace: false,
+	}
+	// sjsonOptionsInPlace are the options used for sjson operations that modify the body in place.
+	// Note: make sure the original body is not modified when using this in the translation layer.
+	sjsonOptionsInPlace = &sjson.Options{
+		Optimistic:     true,
+		ReplaceInPlace: true,
+	}
+)


### PR DESCRIPTION
**Description**

sjson got a new commit on the master branch which allows us to do "in-place deletion":  https://github.com/tidwall/sjson/pull/90. This commit starts utilizing it to avoid unnecessary body copies in anthropic messages translators
