### PR TITLE
aigw: add download-envoy prefetch for docker builds

### DIFF
--- a/cmd/aigw/download_envoy.go
+++ b/cmd/aigw/download_envoy.go
@@ -1,0 +1,60 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	func_e "github.com/tetratelabs/func-e"
+	func_e_api "github.com/tetratelabs/func-e/api"
+)
+
+var envoyVersionRe = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// downloadEnvoy downloads the Envoy binary used by Envoy Gateway.
+func downloadEnvoy(ctx context.Context, funcERun func_e_api.RunFunc, tmpDir, dataHome string, stdout, stderr io.Writer) error {
+	version, err := getEnvoyVersion(egv1a1.DefaultEnvoyProxyImage)
+	if err != nil {
+		return err
+	}
+
+	return funcERun(ctx, []string{"--version"},
+		func_e_api.ConfigHome(tmpDir),
+		func_e_api.DataHome(dataHome),
+		func_e_api.StateHome(tmpDir),
+		func_e_api.RuntimeDir(tmpDir),
+		func_e_api.RunID("0"),
+		func_e_api.EnvoyVersion(version),
+		func_e_api.Out(stdout),
+		func_e_api.EnvoyOut(stdout),
+		func_e_api.EnvoyErr(stderr),
+	)
+}
+
+func downloadEnvoyCmd(ctx context.Context, c *cmdDownloadEnvoy, stdout, stderr io.Writer) error {
+	return downloadEnvoy(ctx, func_e.Run, os.TempDir(), c.dataHome, stdout, stderr)
+}
+
+func getEnvoyVersion(image string) (string, error) {
+	if version := os.Getenv("ENVOY_VERSION"); version != "" {
+		return version, nil
+	}
+	parts := strings.Split(image, ":")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("no tag in default Envoy image: %s", image)
+	}
+	semver := envoyVersionRe.FindString(parts[len(parts)-1])
+	if semver == "" {
+		return "", fmt.Errorf("no semver in tag: %s", parts[len(parts)-1])
+	}
+	return semver, nil
+}

--- a/cmd/aigw/download_envoy_test.go
+++ b/cmd/aigw/download_envoy_test.go
@@ -1,0 +1,59 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	func_e_api "github.com/tetratelabs/func-e/api"
+)
+
+func Test_downloadEnvoy(t *testing.T) {
+	err := downloadEnvoy(t.Context(), func(_ context.Context, args []string, opts ...func_e_api.RunOption) error {
+		require.Equal(t, []string{"--version"}, args)
+		require.Len(t, opts, 9) // opts are internal so we can just count them
+		return nil
+	}, t.TempDir(), t.TempDir(), io.Discard, io.Discard)
+	require.NoError(t, err)
+}
+
+func Test_getEnvoyVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		envVersion      string
+		egVersion       string
+		expectedVersion string
+	}{
+		{
+			name:            "env override wins",
+			envVersion:      "1.37.0",
+			egVersion:       "1.36.2",
+			expectedVersion: "1.37.0",
+		},
+		{
+			name:            "fallback to default",
+			envVersion:      "",
+			egVersion:       "1.36.2",
+			expectedVersion: "1.36.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ENVOY_VERSION", tt.envVersion)
+			version, err := getEnvoyVersion("docker.io/envoyproxy/envoy:distroless-v" + tt.egVersion)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedVersion, version)
+		})
+	}
+	t.Run("invalid image tag", func(t *testing.T) {
+		_, err := getEnvoyVersion("docker.io/envoyproxy/envoy")
+		require.Error(t, err)
+	})
+}

--- a/cmd/aigw/main.go
+++ b/cmd/aigw/main.go
@@ -38,6 +38,8 @@ type (
 		Run cmdRun `cmd:"" help:"Run the AI Gateway locally for given configuration."`
 		// Healthcheck is the sub-command to check if the aigw server is healthy.
 		Healthcheck cmdHealthcheck `cmd:"" help:"Docker HEALTHCHECK command."`
+		// DownloadEnvoy downloads the Envoy binary used by Envoy Gateway.
+		DownloadEnvoy cmdDownloadEnvoy `cmd:"" help:"Download Envoy binary for the Envoy Gateway default version."`
 	}
 	// cmdRun corresponds to `aigw run` command.
 	cmdRun struct {
@@ -56,6 +58,10 @@ type (
 	}
 	// cmdHealthcheck corresponds to `aigw healthcheck` command.
 	cmdHealthcheck struct{}
+	// cmdDownloadEnvoy corresponds to `aigw download-envoy` command.
+	cmdDownloadEnvoy struct {
+		dataHome string `kong:"-"`
+	}
 )
 
 // BeforeApply is called by Kong before applying defaults to set XDG directory defaults.
@@ -89,6 +95,8 @@ func (c *cmd) BeforeApply(_ *kong.Context) error {
 		StateHome:  c.StateHome,
 		RuntimeDir: c.RuntimeDir,
 	}
+	// Populate DownloadEnvoy dataHome with expanded data directory.
+	c.DownloadEnvoy.dataHome = c.DataHome
 
 	return nil
 }
@@ -153,12 +161,13 @@ func (c *cmdRun) Validate() error {
 }
 
 type (
-	runFn         func(context.Context, *cmdRun, *runOpts, io.Writer, io.Writer) error
-	healthcheckFn func(context.Context, io.Writer, io.Writer) error
+	runFn           func(context.Context, *cmdRun, *runOpts, io.Writer, io.Writer) error
+	healthcheckFn   func(context.Context, io.Writer, io.Writer) error
+	downloadEnvoyFn func(context.Context, *cmdDownloadEnvoy, io.Writer, io.Writer) error
 )
 
 func main() {
-	doMain(ctrl.SetupSignalHandler(), os.Stdout, os.Stderr, os.Args[1:], os.Exit, run, healthcheck)
+	doMain(ctrl.SetupSignalHandler(), os.Stdout, os.Stderr, os.Args[1:], os.Exit, run, healthcheck, downloadEnvoyCmd)
 }
 
 // doMain is the main entry point for the CLI. It parses the command line arguments and executes the appropriate command.
@@ -171,6 +180,7 @@ func main() {
 func doMain(ctx context.Context, stdout, stderr io.Writer, args []string, exitFn func(int),
 	rf runFn,
 	hf healthcheckFn,
+	df downloadEnvoyFn,
 ) {
 	var c cmd
 	parser, err := kong.New(&c,
@@ -197,6 +207,11 @@ func doMain(ctx context.Context, stdout, stderr io.Writer, args []string, exitFn
 		err = hf(ctx, stdout, stderr)
 		if err != nil {
 			log.Fatalf("Health check failed: %v", err)
+		}
+	case "download-envoy":
+		err = df(ctx, &c.DownloadEnvoy, stdout, stderr)
+		if err != nil {
+			log.Fatalf("Download Envoy failed: %v", err)
 		}
 	default:
 		panic("unreachable")

--- a/cmd/aigw/main_test.go
+++ b/cmd/aigw/main_test.go
@@ -25,6 +25,7 @@ func Test_doMain(t *testing.T) {
 		env          map[string]string
 		rf           runFn
 		hf           healthcheckFn
+		df           downloadEnvoyFn
 		expOut       string
 		expPanicCode *int
 	}{
@@ -55,6 +56,9 @@ Commands:
 
   healthcheck [flags]
     Docker HEALTHCHECK command.
+
+  download-envoy [flags]
+    Download Envoy binary for the Envoy Gateway default version.
 
 Run "aigw <command> --help" for more information on a command.
 `,
@@ -152,6 +156,35 @@ Flags:
 				return nil
 			},
 		},
+		{
+			name: "download-envoy",
+			args: []string{"download-envoy"},
+			df: func(_ context.Context, c *cmdDownloadEnvoy, _, _ io.Writer) error {
+				require.NotNil(t, c)
+				require.NotEmpty(t, c.dataHome)
+				return nil
+			},
+		},
+		{
+			name:         "download-envoy help",
+			args:         []string{"download-envoy", "--help"},
+			expPanicCode: ptr.To(0),
+			expOut: `Usage: aigw download-envoy [flags]
+
+Download Envoy binary for the Envoy Gateway default version.
+
+Flags:
+  -h, --help                  Show context-sensitive help.
+      --config-home=STRING    Configuration files directory. Defaults to
+                              ~/.config/aigw ($AIGW_CONFIG_HOME)
+      --data-home=STRING      Downloaded Envoy binaries directory. Defaults to
+                              ~/.local/share/aigw ($AIGW_DATA_HOME)
+      --state-home=STRING     Persistent state and logs directory. Defaults to
+                              ~/.local/state/aigw ($AIGW_STATE_HOME)
+      --runtime-dir=STRING    Ephemeral runtime files directory. Defaults to
+                              /tmp/aigw-$UID ($AIGW_RUNTIME_DIR)
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -162,10 +195,10 @@ Flags:
 			out := &bytes.Buffer{}
 			if tt.expPanicCode != nil {
 				require.PanicsWithValue(t, *tt.expPanicCode, func() {
-					doMain(t.Context(), out, os.Stderr, tt.args, func(code int) { panic(code) }, tt.rf, tt.hf)
+					doMain(t.Context(), out, os.Stderr, tt.args, func(code int) { panic(code) }, tt.rf, tt.hf, tt.df)
 				})
 			} else {
-				doMain(t.Context(), out, os.Stderr, tt.args, nil, tt.rf, tt.hf)
+				doMain(t.Context(), out, os.Stderr, tt.args, nil, tt.rf, tt.hf, tt.df)
 			}
 			fmt.Println(out.String())
 			require.Equal(t, tt.expOut, out.String())


### PR DESCRIPTION
**Description**

Before this, we have a race condition where EG defaults to a version of envoy older than current. This resulted in docker builds having skew defeating the purpose of caching envoy. While there's always a chance that we'll have a skew, we can improve this.

This change adds an `aigw download-envoy` command that resolves the Envoy Gateway default Envoy version (preferring `ENVOY_VERSION` when set) and prefetches it via the func-e library `run --version`, writing into the AIGW data directory. This is similar to utilities for health check we also added for aigw.
