### PR TITLE
fix: add cached token metrics for openai chat/completions where missed

### DIFF
--- a/internal/translator/openai_completions.go
+++ b/internal/translator/openai_completions.go
@@ -119,6 +119,14 @@ func (o *openAIToOpenAITranslatorV1Completion) ResponseBody(_ map[string]string,
 		if resp.Usage.TotalTokens >= 0 {
 			tokenUsage.SetTotalTokens(uint32(resp.Usage.TotalTokens)) // #nosec G115
 		}
+		if resp.Usage.PromptTokensDetails != nil {
+			if resp.Usage.PromptTokensDetails.CachedTokens >= 0 {
+				tokenUsage.SetCachedInputTokens(uint32(resp.Usage.PromptTokensDetails.CachedTokens)) //nolint:gosec
+			}
+			if resp.Usage.PromptTokensDetails.CacheCreationTokens >= 0 {
+				tokenUsage.SetCacheCreationInputTokens(uint32(resp.Usage.PromptTokensDetails.CacheCreationTokens)) //nolint:gosec
+			}
+		}
 	}
 
 	// Record non-streaming response to span if tracing is enabled.

--- a/internal/translator/openai_completions_test.go
+++ b/internal/translator/openai_completions_test.go
@@ -137,6 +137,33 @@ func TestOpenAIToOpenAITranslatorV1CompletionResponseBody(t *testing.T) {
 			expModel:      "gpt-3.5-turbo-instruct",
 		},
 		{
+			name: "valid_response_with_cached_tokens",
+			responseBody: `{
+				"id": "cmpl-123",
+				"object": "text_completion",
+				"created": 1677649420,
+				"model": "gpt-3.5-turbo-instruct",
+				"choices": [
+					{
+						"text": "Hello! How can I help you today?",
+						"index": 0,
+						"finish_reason": "stop"
+					}
+				],
+				"usage": {
+					"prompt_tokens": 5,
+					"completion_tokens": 8,
+					"total_tokens": 13,
+					"prompt_tokens_details": {
+						"cached_tokens": 2,
+						"cache_creation_input_tokens": 1
+					}
+				}
+			}`,
+			expTokenUsage: tokenUsageFrom(5, 2, 1, 8, 13),
+			expModel:      "gpt-3.5-turbo-instruct",
+		},
+		{
 			name:          "invalid_json",
 			responseBody:  `invalid json`,
 			expError:      true,

--- a/internal/translator/openai_openai.go
+++ b/internal/translator/openai_openai.go
@@ -183,6 +183,10 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) extractUsageFromBufferEvent(s
 			tokenUsage.SetInputTokens(uint32(usage.PromptTokens))      //nolint:gosec
 			tokenUsage.SetOutputTokens(uint32(usage.CompletionTokens)) //nolint:gosec
 			tokenUsage.SetTotalTokens(uint32(usage.TotalTokens))       //nolint:gosec
+			if usage.PromptTokensDetails != nil {
+				tokenUsage.SetCachedInputTokens(uint32(usage.PromptTokensDetails.CachedTokens))               //nolint:gosec
+				tokenUsage.SetCacheCreationInputTokens(uint32(usage.PromptTokensDetails.CacheCreationTokens)) //nolint:gosec
+			}
 			// Do not mark buffering done; keep scanning to return the latest usage in this batch.
 		}
 	}

--- a/internal/translator/openai_openai_test.go
+++ b/internal/translator/openai_openai_test.go
@@ -435,6 +435,14 @@ func TestExtractUsageFromBufferEvent(t *testing.T) {
 		require.Empty(t, o.buffered)
 	})
 
+	t.Run("valid usage data with cached tokens", func(t *testing.T) {
+		o := &openAIToOpenAITranslatorV1ChatCompletion{}
+		o.buffered = []byte("data: {\"usage\": {\"prompt_tokens\": 5, \"completion_tokens\": 3, \"total_tokens\": 8, \"prompt_tokens_details\": {\"cached_tokens\": 2, \"cache_creation_input_tokens\": 1}}}\n")
+		usedToken := o.extractUsageFromBufferEvent(nil)
+		require.Equal(t, tokenUsageFrom(5, 2, 1, 3, 8), usedToken)
+		require.Empty(t, o.buffered)
+	})
+
 	t.Run("invalid JSON", func(t *testing.T) {
 		o := &openAIToOpenAITranslatorV1ChatCompletion{}
 		o.buffered = []byte("data: invalid\n")


### PR DESCRIPTION
**Description**

This PR adds recording of cached token metrics that were previously missing in the translators.
The gaps existed in the following paths:
- OpenAI Chat Completions (streaming responses)
- OpenAI Completions (non-streaming responses)