### PR TITLE
aigw: support IPs in openai and MCP env config

### DIFF
--- a/internal/autoconfig/anthropic.go
+++ b/internal/autoconfig/anthropic.go
@@ -42,6 +42,7 @@ func PopulateAnthropicEnvConfig(data *ConfigData) error {
 	backend := Backend{
 		Name:     "anthropic",
 		Hostname: parsed.hostname,
+		IP:       parsed.ip,
 		Port:     parsed.port,
 		NeedsTLS: parsed.needsTLS,
 	}

--- a/internal/autoconfig/config.yaml.tmpl
+++ b/internal/autoconfig/config.yaml.tmpl
@@ -229,9 +229,15 @@ metadata:
   namespace: default
 spec:
   endpoints:
+    {{- if .IP }}
+    - ip:
+        address: {{ .IP }}
+        port: {{ .Port }}
+    {{- else }}
     - fqdn:
         hostname: {{ .Hostname }}
         port: {{ .Port }}
+    {{- end }}
 ---
 {{- end }}
 {{- if .OpenAI }}
@@ -302,7 +308,7 @@ spec:
       name: {{ .Name }}
   validation:
     wellKnownCACertificates: "System"
-    hostname: {{ .Hostname }}
+    hostname: {{ if .Hostname }}{{ .Hostname }}{{ else }}{{ .IP }}{{ end }}
 ---
 {{- end }}
 {{- end }}

--- a/internal/autoconfig/config_test.go
+++ b/internal/autoconfig/config_test.go
@@ -34,6 +34,9 @@ var (
 	//go:embed testdata/openai.yaml
 	openaiDefaultYAML string
 
+	//go:embed testdata/openai-ip.yaml
+	openaiIPYAML string
+
 	//go:embed testdata/tars.yaml
 	tarsYAML string
 
@@ -95,6 +98,25 @@ func TestWriteConfig(t *testing.T) {
 				},
 			},
 			expected: openaiDefaultYAML,
+		},
+		{
+			name: "OpenAI with IP endpoint",
+			input: ConfigData{
+				Backends: []Backend{
+					{
+						Name:     "openai",
+						IP:       "127.0.0.1",
+						Port:     11434,
+						NeedsTLS: false,
+					},
+				},
+				OpenAI: &OpenAIConfig{
+					BackendName: "openai",
+					SchemaName:  "OpenAI",
+					Version:     "",
+				},
+			},
+			expected: openaiIPYAML,
 		},
 		{
 			name: "Azure OpenAI",

--- a/internal/autoconfig/mcp.go
+++ b/internal/autoconfig/mcp.go
@@ -136,9 +136,11 @@ func AddMCPServers(data *ConfigData, input *MCPServers) error {
 		}
 
 		// Create Backend for this MCP server
+		hostname, ip := splitHost(serverURL.Hostname())
 		backend := Backend{
 			Name:     name,
-			Hostname: serverURL.Hostname(),
+			Hostname: hostname,
+			IP:       ip,
 			Port:     port,
 			NeedsTLS: serverURL.Scheme == "https",
 		}

--- a/internal/autoconfig/mcp_test.go
+++ b/internal/autoconfig/mcp_test.go
@@ -179,6 +179,34 @@ func TestAddMCPServersConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "add MCP server with IP endpoint",
+			input: &MCPServers{
+				McpServers: map[string]MCPServer{
+					"local": {
+						Type: "http",
+						URL:  "http://127.0.0.1:8080/mcp",
+					},
+				},
+			},
+			expected: ConfigData{
+				Backends: []Backend{
+					{
+						Name:     "local",
+						IP:       "127.0.0.1",
+						Port:     8080,
+						NeedsTLS: false,
+					},
+				},
+				MCPBackendRefs: []MCPBackendRef{
+					{
+						BackendName: "local",
+						Path:        "/mcp",
+						Headers:     map[string]string{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/autoconfig/openai.go
+++ b/internal/autoconfig/openai.go
@@ -72,6 +72,7 @@ func PopulateOpenAIEnvConfig(data *ConfigData) error {
 	backend := Backend{
 		Name:     "openai",
 		Hostname: parsed.hostname,
+		IP:       parsed.ip,
 		Port:     parsed.port,
 		NeedsTLS: parsed.needsTLS,
 	}

--- a/internal/autoconfig/openai_test.go
+++ b/internal/autoconfig/openai_test.go
@@ -112,6 +112,28 @@ func TestPopulateOpenAIEnvConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "OpenAI with IP base URL",
+			envVars: map[string]string{
+				"OPENAI_API_KEY":  "sk-test123",
+				"OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+			},
+			expected: ConfigData{
+				Backends: []Backend{
+					{
+						Name:     "openai",
+						IP:       "127.0.0.1",
+						Port:     11434,
+						NeedsTLS: false,
+					},
+				},
+				OpenAI: &OpenAIConfig{
+					BackendName: "openai",
+					SchemaName:  "OpenAI",
+					Version:     "",
+				},
+			},
+		},
+		{
 			name: "OpenAI with organization ID",
 			envVars: map[string]string{
 				"OPENAI_API_KEY": "sk-test123",

--- a/internal/autoconfig/testdata/openai-ip.yaml
+++ b/internal/autoconfig/testdata/openai-ip.yaml
@@ -1,0 +1,216 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+# Configuration for Envoy AI Gateway with OpenAI compatible endpoint
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: aigw-run
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: aigw-run
+  namespace: default
+spec:
+  gatewayClassName: aigw-run
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 1975
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: envoy-ai-gateway
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-ai-gateway
+  namespace: default
+spec:
+  logging:
+    level:
+      default: error
+  telemetry:
+    accessLog:
+      settings:
+        - matches:
+            # MCP metadata only exists on backend-listener requests, which do not carry /mcp paths.
+            # Match LLM by x-ai-eg-model and MCP by x-ai-eg-mcp-backend.
+            - "request.headers['x-ai-eg-model'] != ''"
+          sinks:
+            - type: File
+              file:
+                path: /dev/stdout
+          format:
+            type: JSON
+            json:
+              # LLM specific fields. Dynamic metadata expressions must match
+              # the ones defined in the AIGatewayRoute llmRequestCosts field or
+              # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
+              gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
+              gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
+              gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
+              # Common fields
+              start_time: "%START_TIME%"
+              method: "%REQ(:METHOD)%"
+              request.path: "%REQ(:PATH)%"
+              x-envoy-origin-path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+              response_code: "%RESPONSE_CODE%"
+              connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+              upstream_transport_failure_reason: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"
+              bytes_received: "%BYTES_RECEIVED%"
+              bytes_sent: "%BYTES_SENT%"
+              duration: "%DURATION%"
+              x-envoy-upstream-service-time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+              x-forwarded-for: "%REQ(X-FORWARDED-FOR)%"
+              user-agent: "%REQ(USER-AGENT)%"
+              x-request-id: "%REQ(X-REQUEST-ID)%"
+              upstream_host: "%UPSTREAM_HOST%"
+              upstream_cluster: "%UPSTREAM_CLUSTER%"
+              upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+              downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+              downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+        - matches:
+            - "request.headers['x-ai-eg-mcp-backend'] != ''"
+          sinks:
+            - type: File
+              file:
+                path: /dev/stdout
+          format:
+            type: JSON
+            json:
+              # MCP specific fields
+              jsonrpc.request.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
+              mcp.session.id: "%REQ(MCP-SESSION-ID)%"
+              mcp.method.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
+              session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
+              mcp.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
+              # Common fields
+              start_time: "%START_TIME%"
+              method: "%REQ(:METHOD)%"
+              request.path: "%REQ(:PATH)%"
+              x-envoy-origin-path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+              response_code: "%RESPONSE_CODE%"
+              connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+              upstream_transport_failure_reason: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"
+              bytes_received: "%BYTES_RECEIVED%"
+              bytes_sent: "%BYTES_SENT%"
+              duration: "%DURATION%"
+              x-envoy-upstream-service-time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+              x-forwarded-for: "%REQ(X-FORWARDED-FOR)%"
+              user-agent: "%REQ(USER-AGENT)%"
+              x-request-id: "%REQ(X-REQUEST-ID)%"
+              upstream_host: "%UPSTREAM_HOST%"
+              upstream_cluster: "%UPSTREAM_CLUSTER%"
+              upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+              downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+              downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: aigw-run
+  namespace: default
+spec:
+  parentRefs:
+    - name: aigw-run
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  # Simple rule: route everything to OpenAI backend
+  rules:
+    - matches:
+        - headers:
+            - type: RegularExpression
+              name: x-ai-eg-model
+              value: .*
+      backendRefs:
+        - name: openai
+          namespace: default
+      timeouts:
+        request: 120s
+  # Configure the LLM request costs so they can be included in the Envoy access logs
+  llmRequestCosts:
+    - metadataKey: llm_input_token
+      type: InputToken
+    - metadataKey: llm_output_token
+      type: OutputToken
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: openai
+  namespace: default
+spec:
+  endpoints:
+    - ip:
+        address: 127.0.0.1
+        port: 11434
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIServiceBackend
+metadata:
+  name: openai
+  namespace: default
+spec:
+  timeouts:
+    request: 3m
+  schema:
+    name: OpenAI
+  backendRef:
+    name: openai
+    kind: Backend
+    group: gateway.envoyproxy.io
+    namespace: default
+---
+# By default, Envoy Gateway sets the buffer limit to 32kiB which is not
+# sufficient for AI workloads. This ClientTrafficPolicy sets the buffer limit
+# to 50MiB as an example.
+# TODO: Remove after https://github.com/envoyproxy/ai-gateway/issues/1212
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: client-buffer-limit
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: aigw-run
+  connection:
+    bufferLimit: 50Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-apikey
+  namespace: default
+type: Opaque
+stringData:
+  apiKey: ${OPENAI_API_KEY}
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: BackendSecurityPolicy
+metadata:
+  name: openai-apikey
+  namespace: default
+spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: openai
+  type: APIKey
+  apiKey:
+    secretRef:
+      name: openai-apikey
+---

--- a/tests/e2e-aigw/aigw_test.go
+++ b/tests/e2e-aigw/aigw_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 var localOllamaEnv = []string{
-	"OPENAI_BASE_URL=http://localhost:11434/v1",
+	"OPENAI_BASE_URL=http://127.0.0.1:11434/v1",
 	"OPENAI_API_KEY=unused",
 }
 
@@ -62,9 +62,9 @@ func TestAIGWRun_AdminEndpoints(t *testing.T) {
 	statusOK := func(r *http.Response) bool { return r.StatusCode == 200 }
 
 	for endpoint, condition := range map[string]func(r *http.Response) bool{
-		"http://localhost:1064/health":                      statusOK,
-		"http://localhost:1064/metrics":                     statusOK,
-		fmt.Sprintf("http://localhost:%d/stats", adminPort): statusOK,
+		"http://127.0.0.1:1064/health":                      statusOK,
+		"http://127.0.0.1:1064/metrics":                     statusOK,
+		fmt.Sprintf("http://127.0.0.1:%d/stats", adminPort): statusOK,
 	} {
 		t.Logf("Waiting for endpoint %q to be available...", endpoint)
 		internaltesting.RequireEventuallyNoError(t, func() error {
@@ -154,7 +154,7 @@ func startAIGWCLI(t *testing.T, aigwBin string, env []string, arg ...string) (ad
 	t.Log("Waiting for MCP endpoint to be available...")
 	internaltesting.RequireEventuallyNoError(t, func() error {
 		return checkEndpointAvailable(t.Context(),
-			fmt.Sprintf("http://localhost:%d/mcp", gatewayPort),
+			fmt.Sprintf("http://127.0.0.1:%d/mcp", gatewayPort),
 			func(r *http.Response) bool { return r.StatusCode < 500 },
 		)
 	}, 120*time.Second, 2*time.Second, "MCP endpoint never became available")

--- a/tests/e2e-aigw/examples_mcp_test.go
+++ b/tests/e2e-aigw/examples_mcp_test.go
@@ -44,7 +44,7 @@ func TestMCP_standalone(t *testing.T) {
 	exampleYaml := path.Join(examplesDir, "mcp_example.yaml")
 	startAIGWCLI(t, aigwBin, nil, "run", "--debug", exampleYaml)
 
-	url := fmt.Sprintf("http://localhost:%d/mcp", 1975)
+	url := fmt.Sprintf("http://127.0.0.1:%d/mcp", 1975)
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "public-mcp-client", Version: "0.1.0"}, &mcp.ClientOptions{})
 	session, err := mcpClient.Connect(t.Context(), &mcp.StreamableClientTransport{
 		Endpoint: url,
@@ -148,7 +148,7 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func TestMCP_standalone_oauth(t *testing.T) {
 	startAIGWCLI(t, aigwBin, nil, "run", "--debug", path.Join(examplesDir, "mcp_oauth_example.yaml"))
 
-	url := fmt.Sprintf("http://localhost:%d/mcp", 1975)
+	url := fmt.Sprintf("http://127.0.0.1:%d/mcp", 1975)
 
 	t.Run("fail to connect to MCP server without token", func(t *testing.T) {
 		mcpClient := mcp.NewClient(&mcp.Implementation{Name: "public-mcp-client", Version: "0.1.0"}, &mcp.ClientOptions{})

--- a/tests/e2e-aigw/llm_test.go
+++ b/tests/e2e-aigw/llm_test.go
@@ -23,7 +23,7 @@ func TestAIGWRun_LLM(t *testing.T) {
 
 	internaltesting.RequireEventuallyNoError(t, func() error {
 		t.Logf("model to use: %q", ollamaModel)
-		client := openai.NewClient(option.WithBaseURL("http://localhost:1975/v1/"))
+		client := openai.NewClient(option.WithBaseURL("http://127.0.0.1:1975/v1/"))
 		chatReq := openai.ChatCompletionNewParams{
 			Messages: []openai.ChatCompletionMessageParamUnion{
 				openai.UserMessage("Say this is a test"),


### PR DESCRIPTION
**Description**

Before, in aigw (standalone) mode, we couldn't pass IP addresses, notably 127.0.0.1 as everything assumed endpoints were hostnames. Now, we can.


Besides text tests, I updated our E2E to always use 127.0.0.1 instead of localhost, as a secondary tripwire