### PR TITLE
feat: allow overriding base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,14 @@
 ARG VARIANT=static
 ARG COMMAND_NAME
 
+# Base image configuration
+ARG GOLANG_BASE_IMAGE=golang:1.25
+ARG RUNTIME_BASE_IMAGE=gcr.io/distroless/${VARIANT}-debian12:nonroot
+
 # Pre-download Envoy for aigw using func-e. This reduces latency and avoids
 # needing to declare a volume for the Envoy binary, which is tricky in Docker
 # Compose v2 because volumes end up owned by root.
-FROM golang:1.25 AS build
+FROM ${GOLANG_BASE_IMAGE} AS build
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMMAND_NAME
@@ -24,7 +28,7 @@ RUN if [ "$COMMAND_NAME" = "aigw" ]; then \
     && chown -R 65532:65532 /home/nonroot \
     && chmod -R 755 /home/nonroot /app
 
-FROM gcr.io/distroless/${VARIANT}-debian12:nonroot
+FROM ${RUNTIME_BASE_IMAGE}
 ARG COMMAND_NAME
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**Description**
Added GOLANG_BASE_IMAGE and RUNTIME_BASE_IMAGE ARG for build and runtime stage.
- Override the Go build image:                                                                                                  
  docker build --build-arg GOLANG_BASE_IMAGE=golang:1.24
- Override the runtime image:                                                                                                   
  docker build --build-arg RUNTIME_BASE_IMAGE=ubuntu:22.04 .