### PR TITLE
test: use v0.5 as a base for upgrade test

### DIFF
--- a/tests/e2e-upgrade/upgrade_test.go
+++ b/tests/e2e-upgrade/upgrade_test.go
@@ -107,7 +107,7 @@ func TestUpgrade(t *testing.T) {
 		{
 			name: "control-plane upgrade",
 			initFunc: func(ctx context.Context) string {
-				const previousEnvoyAIGatewayVersion = "v0.4.0"
+				const previousEnvoyAIGatewayVersion = "v0.5.0"
 				const kindClusterName = "envoy-ai-gateway-cp-upgrade"
 				require.NoError(t, e2elib.SetupAll(ctx, kindClusterName, e2elib.AIGatewayHelmOption{
 					ChartVersion: previousEnvoyAIGatewayVersion,


### PR DESCRIPTION
**Description**

This upgrades the base version of CP upgrading test to the recently released v0.5

**Related Issues/PRs (if applicable)**

Ensures #1820 is false report 
