### PR TITLE
feat: add OpenAI image edit endpoint support

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -261,6 +261,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	completionMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationCompletion)
 	embeddingsMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationEmbedding)
 	imageGenerationMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationImageGeneration)
+	imageEditMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationImageEdit)
 	responsesMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationResponses)
 	rerankMetricsFactory := metrics.NewMetricsFactory(meter, metricsRequestHeaderAttributes, metrics.GenAIOperationRerank)
 	mcpMetrics := metrics.NewMCP(meter, metricsRequestHeaderAttributes)
@@ -284,6 +285,8 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 		responsesMetricsFactory, tracing.ResponsesTracer(), endpointspec.ResponsesEndpointSpec{}))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/images/generations"), extproc.NewFactory(
 		imageGenerationMetricsFactory, tracing.ImageGenerationTracer(), endpointspec.ImageGenerationEndpointSpec{}))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/images/edits"), extproc.NewFactory(
+		imageEditMetricsFactory, tracing.ImageEditTracer(), endpointspec.ImageEditEndpointSpec{}))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Cohere, "/v2/rerank"), extproc.NewFactory(
 		rerankMetricsFactory, tracing.RerankTracer(), endpointspec.RerankEndpointSpec{}))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/models"), extproc.NewModelsProcessor)

--- a/internal/apischema/openai/image_edit.go
+++ b/internal/apischema/openai/image_edit.go
@@ -1,0 +1,59 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package openai
+
+// ImageEditRequest represents the request body for /v1/images/edits.
+// https://platform.openai.com/docs/api-reference/images/createEdit
+type ImageEditRequest struct {
+	// Required: The image to edit. Must be a valid PNG file, less than 4MB, and square.
+	// If mask is not provided, image must have transparency, which will be used as the mask.
+	Image string `json:"image"`
+
+	// Required: A text description of the desired image(s). The maximum length is 1000 characters.
+	Prompt string `json:"prompt"`
+
+	// The model to use for image generation. Only dall-e-2 is supported at this time.
+	// Defaults to dall-e-2.
+	Model string `json:"model,omitempty"`
+
+	// An additional image whose fully transparent areas (e.g. where alpha is zero)
+	// indicate where image should be edited. Must be a valid PNG file, less than 4MB,
+	// and have the same dimensions as image.
+	Mask string `json:"mask,omitempty"`
+
+	// The number of images to generate. Must be between 1 and 10.
+	// Defaults to 1.
+	N int `json:"n,omitempty"`
+
+	// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+	// Defaults to 1024x1024.
+	Size string `json:"size,omitempty"`
+
+	// The format in which the generated images are returned. Must be one of url or b64_json.
+	// URLs are only valid for 60 minutes after the image has been generated.
+	// Defaults to url.
+	ResponseFormat string `json:"response_format,omitempty"`
+
+	// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+	User string `json:"user,omitempty"`
+}
+
+// ImageEditResponse represents the response body for /v1/images/edits.
+// This is the same structure as ImageGenerationResponse.
+// https://platform.openai.com/docs/api-reference/images/object
+type ImageEditResponse struct {
+	// The Unix timestamp (in seconds) of when the image was created.
+	Created int64 `json:"created"`
+	// The list of generated/edited images.
+	Data []ImageEditResponseData `json:"data"`
+}
+
+// ImageEditResponseData represents a single edited image in the response.
+type ImageEditResponseData struct {
+	B64JSON       string `json:"b64_json,omitempty"`
+	URL           string `json:"url,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+}

--- a/internal/apischema/openai/image_edit.go
+++ b/internal/apischema/openai/image_edit.go
@@ -6,18 +6,20 @@
 package openai
 
 // ImageEditRequest represents the request body for /v1/images/edits.
+// For gpt-image-1 models, the request is sent as JSON. For DALL-E 2, multipart/form-data
+// is used, but the gateway only handles JSON bodies through the extproc pipeline.
 // https://platform.openai.com/docs/api-reference/images/createEdit
 type ImageEditRequest struct {
-	// Required: The image to edit. Must be a valid PNG file, less than 4MB, and square.
-	// If mask is not provided, image must have transparency, which will be used as the mask.
-	Image string `json:"image"`
-
-	// Required: A text description of the desired image(s). The maximum length is 1000 characters.
+	// Required: A text description of the desired image(s). The maximum length is 1000 characters
+	// for dall-e-2 and 32000 characters for gpt-image-1.
 	Prompt string `json:"prompt"`
 
-	// The model to use for image generation. Only dall-e-2 is supported at this time.
-	// Defaults to dall-e-2.
+	// The model to use for image edit. Defaults to dall-e-2.
 	Model string `json:"model,omitempty"`
+
+	// The image(s) to edit. For gpt-image-1, this is an array of image objects
+	// (with file_id or image_url). For dall-e-2, a single PNG file reference.
+	Image any `json:"image,omitempty"`
 
 	// An additional image whose fully transparent areas (e.g. where alpha is zero)
 	// indicate where image should be edited. Must be a valid PNG file, less than 4MB,
@@ -28,32 +30,56 @@ type ImageEditRequest struct {
 	// Defaults to 1.
 	N int `json:"n,omitempty"`
 
-	// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
-	// Defaults to 1024x1024.
+	// The size of the generated images.
+	// - dall-e-2: 256x256, 512x512, or 1024x1024.
+	// - gpt-image-1: 1024x1024, 1536x1024, 1024x1536, or auto.
+	// Defaults to 1024x1024 (dall-e-2) or auto (gpt-image-1).
 	Size string `json:"size,omitempty"`
+
+	// The quality of the image that will be generated.
+	// high, medium, or low for gpt-image-1.
+	// Defaults to auto.
+	Quality string `json:"quality,omitempty"`
 
 	// The format in which the generated images are returned. Must be one of url or b64_json.
 	// URLs are only valid for 60 minutes after the image has been generated.
+	// This parameter isn't supported for gpt-image-1.
 	// Defaults to url.
 	ResponseFormat string `json:"response_format,omitempty"`
 
 	// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
 	User string `json:"user,omitempty"`
+
+	// The output format of the image. Either png, webp, or jpeg.
+	// This parameter is only supported for gpt-image-1.
+	// Defaults to png.
+	OutputFormat string `json:"output_format,omitempty"`
+
+	// The background parameter for the edited image. Either transparent, opaque, or auto.
+	// This parameter is only supported for gpt-image-1.
+	// Defaults to auto.
+	Background string `json:"background,omitempty"`
+
+	// Control the content-moderation level. Must be either low or auto.
+	// This parameter is only supported for gpt-image-1.
+	// Defaults to auto.
+	Moderation string `json:"moderation,omitempty"`
+
+	// The compression level (0-100%) for the generated images.
+	// This parameter is only supported for gpt-image-1 with webp or jpeg output formats.
+	OutputCompression *int `json:"output_compression,omitempty"`
+
+	// The number of partial images to generate for streaming responses.
+	// Value must be between 0 and 3. Defaults to 0.
+	PartialImages int `json:"partial_images,omitempty"`
 }
 
 // ImageEditResponse represents the response body for /v1/images/edits.
-// This is the same structure as ImageGenerationResponse.
+// OpenAI returns the same ImagesResponse schema for both image generation and image edit endpoints,
+// so we reuse ImageGenerationResponse directly.
 // https://platform.openai.com/docs/api-reference/images/object
-type ImageEditResponse struct {
-	// The Unix timestamp (in seconds) of when the image was created.
-	Created int64 `json:"created"`
-	// The list of generated/edited images.
-	Data []ImageEditResponseData `json:"data"`
-}
+type ImageEditResponse = ImageGenerationResponse
 
 // ImageEditResponseData represents a single edited image in the response.
-type ImageEditResponseData struct {
-	B64JSON       string `json:"b64_json,omitempty"`
-	URL           string `json:"url,omitempty"`
-	RevisedPrompt string `json:"revised_prompt,omitempty"`
-}
+// This is the same structure as ImageGenerationResponseData.
+type ImageEditResponseData = ImageGenerationResponseData

--- a/internal/metrics/genai.go
+++ b/internal/metrics/genai.go
@@ -29,6 +29,7 @@ const (
 	GenAIOperationEmbedding       GenAIOperation = "embeddings"
 	GenAIOperationMessages        GenAIOperation = "messages"
 	GenAIOperationImageGeneration GenAIOperation = "image_generation"
+	GenAIOperationImageEdit       GenAIOperation = "image_edit"
 	GenAIOperationResponses       GenAIOperation = "responses"
 	GenAIOperationRerank          GenAIOperation = "rerank"
 

--- a/internal/tracing/openinference/openai/image_edit.go
+++ b/internal/tracing/openinference/openai/image_edit.go
@@ -1,0 +1,105 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package openai provides OpenInference semantic conventions hooks for
+// OpenAI instrumentation used by the ExtProc router filter.
+package openai
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/openinference"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
+)
+
+// ImageEditRecorder implements recorders for OpenInference image edit spans.
+type ImageEditRecorder struct {
+	tracingapi.NoopChunkRecorder[struct{}]
+	traceConfig *openinference.TraceConfig
+}
+
+// NewImageEditRecorderFromEnv creates an tracingapi.ImageEditRecorder
+// from environment variables using the OpenInference configuration specification.
+//
+// See: https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
+func NewImageEditRecorderFromEnv() tracingapi.ImageEditRecorder {
+	return NewImageEditRecorder(nil)
+}
+
+// NewImageEditRecorder creates a tracingapi.ImageEditRecorder with the
+// given config using the OpenInference configuration specification.
+//
+// Parameters:
+//   - config: configuration for redaction. Defaults to NewTraceConfigFromEnv().
+//
+// See: https://github.com/Arize-ai/openinference/blob/main/spec/configuration.md
+func NewImageEditRecorder(config *openinference.TraceConfig) tracingapi.ImageEditRecorder {
+	if config == nil {
+		config = openinference.NewTraceConfigFromEnv()
+	}
+	return &ImageEditRecorder{traceConfig: config}
+}
+
+// startOpts sets trace.SpanKindInternal as that's the span kind used in
+// OpenInference.
+var imageEditStartOpts = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}
+
+// StartParams implements the same method as defined in tracingapi.ImageEditRecorder.
+func (r *ImageEditRecorder) StartParams(*openai.ImageEditRequest, []byte) (spanName string, opts []trace.SpanStartOption) {
+	return "ImagesEditResponse", imageEditStartOpts
+}
+
+// RecordRequest implements the same method as defined in tracingapi.ImageEditRecorder.
+func (r *ImageEditRecorder) RecordRequest(span trace.Span, req *openai.ImageEditRequest, body []byte) {
+	span.SetAttributes(buildImageEditRequestAttributes(req, string(body), r.traceConfig)...)
+}
+
+// RecordResponse implements the same method as defined in tracingapi.ImageEditRecorder.
+func (r *ImageEditRecorder) RecordResponse(span trace.Span, resp *openai.ImageEditResponse) {
+	// Set output attributes.
+	var attrs []attribute.KeyValue
+	bodyString := openinference.RedactedValue
+	if !r.traceConfig.HideOutputs {
+		marshaled, err := json.Marshal(resp)
+		if err == nil {
+			bodyString = string(marshaled)
+		}
+	}
+	// Match ChatCompletion recorder: include output MIME type and value
+	attrs = append(attrs,
+		attribute.String(openinference.OutputMimeType, openinference.MimeTypeJSON),
+		attribute.String(openinference.OutputValue, bodyString),
+	)
+	span.SetAttributes(attrs...)
+	span.SetStatus(codes.Ok, "")
+}
+
+// RecordResponseOnError implements the same method as defined in tracingapi.ImageEditRecorder.
+func (r *ImageEditRecorder) RecordResponseOnError(span trace.Span, statusCode int, body []byte) {
+	openinference.RecordResponseError(span, statusCode, string(body))
+}
+
+// buildImageEditRequestAttributes builds OpenInference attributes from the image edit request.
+func buildImageEditRequestAttributes(_ *openai.ImageEditRequest, body string, config *openinference.TraceConfig) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(openinference.SpanKind, openinference.SpanKindLLM),
+		attribute.String(openinference.LLMSystem, openinference.LLMSystemOpenAI),
+	}
+
+	if config.HideInputs {
+		attrs = append(attrs, attribute.String(openinference.InputValue, openinference.RedactedValue))
+	} else {
+		attrs = append(attrs,
+			attribute.String(openinference.InputValue, body),
+			attribute.String(openinference.InputMimeType, openinference.MimeTypeJSON),
+		)
+	}
+
+	return attrs
+}

--- a/internal/tracing/openinference/openai/image_edit.go
+++ b/internal/tracing/openinference/openai/image_edit.go
@@ -46,7 +46,7 @@ func NewImageEditRecorder(config *openinference.TraceConfig) tracingapi.ImageEdi
 	return &ImageEditRecorder{traceConfig: config}
 }
 
-// startOpts sets trace.SpanKindInternal as that's the span kind used in
+// imageEditStartOpts sets trace.SpanKindInternal as that's the span kind used in
 // OpenInference.
 var imageEditStartOpts = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}
 
@@ -99,6 +99,10 @@ func buildImageEditRequestAttributes(_ *openai.ImageEditRequest, body string, co
 			attribute.String(openinference.InputValue, body),
 			attribute.String(openinference.InputMimeType, openinference.MimeTypeJSON),
 		)
+	}
+
+	if !config.HideLLMInvocationParameters {
+		attrs = append(attrs, attribute.String(openinference.LLMInvocationParameters, body))
 	}
 
 	return attrs

--- a/internal/tracing/span.go
+++ b/internal/tracing/span.go
@@ -50,6 +50,7 @@ type (
 	completionSpan      = span[openai.CompletionResponse, openai.CompletionResponse]
 	embeddingsSpan      = span[openai.EmbeddingResponse, struct{}]
 	imageGenerationSpan = span[openai.ImageGenerationResponse, struct{}]
+	imageEditSpan       = span[openai.ImageEditResponse, struct{}]
 	responsesSpan       = span[openai.Response, openai.ResponseStreamEventUnion]
 	rerankSpan          = span[cohereschema.RerankV2Response, struct{}]
 	messageSpan         = span[anthropicschema.MessagesResponse, anthropicschema.MessagesStreamChunk]

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -35,6 +35,7 @@ var (
 	_ tracingapi.EmbeddingsTracer      = (*embeddingsTracer)(nil)
 	_ tracingapi.CompletionTracer      = (*completionTracer)(nil)
 	_ tracingapi.ImageGenerationTracer = (*imageGenerationTracer)(nil)
+	_ tracingapi.ImageEditTracer       = (*imageEditTracer)(nil)
 	_ tracingapi.ResponsesTracer       = (*responsesTracer)(nil)
 	_ tracingapi.RerankTracer          = (*rerankTracer)(nil)
 )
@@ -44,6 +45,7 @@ type (
 	embeddingsTracer      = requestTracerImpl[openai.EmbeddingRequest, openai.EmbeddingResponse, struct{}]
 	completionTracer      = requestTracerImpl[openai.CompletionRequest, openai.CompletionResponse, openai.CompletionResponse]
 	imageGenerationTracer = requestTracerImpl[openai.ImageGenerationRequest, openai.ImageGenerationResponse, struct{}]
+	imageEditTracer       = requestTracerImpl[openai.ImageEditRequest, openai.ImageEditResponse, struct{}]
 	responsesTracer       = requestTracerImpl[openai.ResponseRequest, openai.Response, openai.ResponseStreamEventUnion]
 	rerankTracer          = requestTracerImpl[cohereschema.RerankV2Request, cohereschema.RerankV2Response, struct{}]
 )
@@ -146,6 +148,18 @@ func newImageGenerationTracer(tracer trace.Tracer, propagator propagation.TextMa
 		nil,
 		func(span trace.Span, recorder tracingapi.ImageGenerationRecorder) tracingapi.ImageGenerationSpan {
 			return &imageGenerationSpan{span: span, recorder: recorder}
+		},
+	)
+}
+
+func newImageEditTracer(tracer trace.Tracer, propagator propagation.TextMapPropagator, recorder tracingapi.ImageEditRecorder) tracingapi.ImageEditTracer {
+	return newRequestTracer(
+		tracer,
+		propagator,
+		recorder,
+		nil,
+		func(span trace.Span, recorder tracingapi.ImageEditRecorder) tracingapi.ImageEditSpan {
+			return &imageEditSpan{span: span, recorder: recorder}
 		},
 	)
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -30,6 +30,7 @@ type tracingImpl struct {
 	chatCompletionTracer  tracingapi.ChatCompletionTracer
 	completionTracer      tracingapi.CompletionTracer
 	imageGenerationTracer tracingapi.ImageGenerationTracer
+	imageEditTracer       tracingapi.ImageEditTracer
 	embeddingsTracer      tracingapi.EmbeddingsTracer
 	responsesTracer       tracingapi.ResponsesTracer
 	rerankTracer          tracingapi.RerankTracer
@@ -57,6 +58,11 @@ func (t *tracingImpl) EmbeddingsTracer() tracingapi.EmbeddingsTracer {
 // ImageGenerationTracer implements the same method as documented on tracingapi.Tracing.
 func (t *tracingImpl) ImageGenerationTracer() tracingapi.ImageGenerationTracer {
 	return t.imageGenerationTracer
+}
+
+// ImageEditTracer implements the same method as documented on tracingapi.Tracing.
+func (t *tracingImpl) ImageEditTracer() tracingapi.ImageEditTracer {
+	return t.imageEditTracer
 }
 
 // ResponsesTracer implements the same method as documented on tracingapi.Tracing.
@@ -184,6 +190,7 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer, headerAttributeMap
 	// Default to OpenInference trace span semantic conventions.
 	chatRecorder := openai.NewChatCompletionRecorderFromEnv()
 	imageRecorder := openai.NewImageGenerationRecorderFromEnv()
+	imageEditRecorder := openai.NewImageEditRecorderFromEnv()
 	completionRecorder := openai.NewCompletionRecorderFromEnv()
 	embeddingsRecorder := openai.NewEmbeddingsRecorderFromEnv()
 	responsesRecorder := openai.NewResponsesRecorderFromEnv()
@@ -202,6 +209,11 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer, headerAttributeMap
 			tracer,
 			propagator,
 			imageRecorder,
+		),
+		imageEditTracer: newImageEditTracer(
+			tracer,
+			propagator,
+			imageEditRecorder,
 		),
 		completionTracer: newCompletionTracer(
 			tracer,

--- a/internal/tracing/tracingapi/api.go
+++ b/internal/tracing/tracingapi/api.go
@@ -26,6 +26,8 @@ type (
 		ChatCompletionTracer() ChatCompletionTracer
 		// ImageGenerationTracer creates spans for OpenAI image generation requests.
 		ImageGenerationTracer() ImageGenerationTracer
+		// ImageEditTracer creates spans for OpenAI image edit requests.
+		ImageEditTracer() ImageEditTracer
 		// CompletionTracer creates spans for OpenAI completion requests on /completions endpoint.
 		CompletionTracer() CompletionTracer
 		// EmbeddingsTracer creates spans for OpenAI embeddings requests on /embeddings endpoint.
@@ -63,6 +65,8 @@ type (
 	EmbeddingsTracer = RequestTracer[openai.EmbeddingRequest, openai.EmbeddingResponse, struct{}]
 	// ImageGenerationTracer creates spans for OpenAI image generation requests.
 	ImageGenerationTracer = RequestTracer[openai.ImageGenerationRequest, openai.ImageGenerationResponse, struct{}]
+	// ImageEditTracer creates spans for OpenAI image edit requests.
+	ImageEditTracer = RequestTracer[openai.ImageEditRequest, openai.ImageEditResponse, struct{}]
 	// ResponsesTracer creates spans for OpenAI responses requests.
 	ResponsesTracer = RequestTracer[openai.ResponseRequest, openai.Response, openai.ResponseStreamEventUnion]
 	// RerankTracer creates spans for rerank requests.
@@ -92,6 +96,8 @@ type (
 	EmbeddingsSpan = Span[openai.EmbeddingResponse, struct{}]
 	// ImageGenerationSpan represents an OpenAI image generation.
 	ImageGenerationSpan = Span[openai.ImageGenerationResponse, struct{}]
+	// ImageEditSpan represents an OpenAI image edit.
+	ImageEditSpan = Span[openai.ImageEditResponse, struct{}]
 	// ResponsesSpan represents an OpenAI responses request span.
 	ResponsesSpan = Span[openai.Response, openai.ResponseStreamEventUnion]
 	// RerankSpan represents a rerank request span.
@@ -133,6 +139,8 @@ type (
 	CompletionRecorder = SpanRecorder[openai.CompletionRequest, openai.CompletionResponse, openai.CompletionResponse]
 	// ImageGenerationRecorder records attributes to a span according to a semantic convention.
 	ImageGenerationRecorder = SpanRecorder[openai.ImageGenerationRequest, openai.ImageGenerationResponse, struct{}]
+	// ImageEditRecorder records attributes to a span according to a semantic convention.
+	ImageEditRecorder = SpanRecorder[openai.ImageEditRequest, openai.ImageEditResponse, struct{}]
 	// EmbeddingsRecorder records attributes to a span according to a semantic convention.
 	EmbeddingsRecorder = SpanRecorder[openai.EmbeddingRequest, openai.EmbeddingResponse, struct{}]
 	// ResponsesRecorder records attributes to a span according to a semantic convention.
@@ -176,6 +184,11 @@ func (NoopTracing) ImageGenerationTracer() ImageGenerationTracer {
 	return NoopImageGenerationTracer{}
 }
 
+// ImageEditTracer implements Tracing.ImageEditTracer.
+func (NoopTracing) ImageEditTracer() ImageEditTracer {
+	return NoopImageEditTracer{}
+}
+
 // ResponsesTracer implements Tracing.ResponsesTracer.
 func (NoopTracing) ResponsesTracer() ResponsesTracer {
 	return NoopResponsesTracer{}
@@ -206,6 +219,8 @@ type (
 	NoopEmbeddingsTracer = NoopTracer[openai.EmbeddingRequest, openai.EmbeddingResponse, struct{}]
 	// NoopImageGenerationTracer implements ImageGenerationTracer.
 	NoopImageGenerationTracer = NoopTracer[openai.ImageGenerationRequest, openai.ImageGenerationResponse, struct{}]
+	// NoopImageEditTracer implements ImageEditTracer.
+	NoopImageEditTracer = NoopTracer[openai.ImageEditRequest, openai.ImageEditResponse, struct{}]
 	// NoopResponsesTracer implements ResponsesTracer.
 	NoopResponsesTracer = NoopTracer[openai.ResponseRequest, openai.Response, openai.ResponseStreamEventUnion]
 	// NoopRerankTracer implements RerankTracer.

--- a/internal/translator/imageedit_openai_openai.go
+++ b/internal/translator/imageedit_openai_openai.go
@@ -1,0 +1,96 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/tidwall/sjson"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
+)
+
+// NewImageEditOpenAIToOpenAITranslator implements [Factory] for OpenAI to OpenAI image edit translation.
+func NewImageEditOpenAIToOpenAITranslator(apiVersion string, modelNameOverride internalapi.ModelNameOverride) OpenAIImageEditTranslator {
+	return &openAIToOpenAIImageEditTranslator{modelNameOverride: modelNameOverride, path: path.Join("/", apiVersion, "images/edits")}
+}
+
+// openAIToOpenAIImageEditTranslator implements [ImageEditTranslator] for /v1/images/edits.
+type openAIToOpenAIImageEditTranslator struct {
+	modelNameOverride internalapi.ModelNameOverride
+	// The path of the images edits endpoint to be used for the request. It is prefixed with the OpenAI path prefix.
+	path string
+	// requestModel stores the effective model for this request (override or provided)
+	// so we can attribute metrics later; the OpenAI Images response omits a model field.
+	requestModel internalapi.RequestModel
+}
+
+// RequestBody implements [ImageEditTranslator.RequestBody].
+func (o *openAIToOpenAIImageEditTranslator) RequestBody(original []byte, p *openai.ImageEditRequest, forceBodyMutation bool) (
+	newHeaders []internalapi.Header, newBody []byte, err error,
+) {
+	if o.modelNameOverride != "" {
+		// If modelName is set we override the model to be used for the request.
+		newBody, err = sjson.SetBytesOptions(original, "model", o.modelNameOverride, sjsonOptions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
+		}
+	}
+	// Persist the effective model used. The Images endpoint omits model in responses,
+	// so we derive it from the request (or override) for downstream metrics.
+	o.requestModel = cmp.Or(o.modelNameOverride, p.Model)
+
+	// Always set the path header to the images edits endpoint so that the request is routed correctly.
+	if forceBodyMutation && len(newBody) == 0 {
+		newBody = original
+	}
+	newHeaders = []internalapi.Header{{pathHeaderName, o.path}}
+
+	if len(newBody) > 0 {
+		newHeaders = append(newHeaders, internalapi.Header{contentLengthHeaderName, fmt.Sprintf("%d", len(newBody))})
+	}
+	return
+}
+
+// ResponseError implements [ImageEditTranslator.ResponseError]
+// For OpenAI based backend we return the OpenAI error type as is.
+// If connection fails the error body is translated to OpenAI error type for events such as HTTP 503 or 504.
+func (o *openAIToOpenAIImageEditTranslator) ResponseError(respHeaders map[string]string, body io.Reader) ([]internalapi.Header, []byte, error) {
+	return convertErrorOpenAIToOpenAIError(respHeaders, body)
+}
+
+// ResponseHeaders implements [ImageEditTranslator.ResponseHeaders].
+func (o *openAIToOpenAIImageEditTranslator) ResponseHeaders(map[string]string) (newHeaders []internalapi.Header, err error) {
+	return nil, nil
+}
+
+// ResponseBody implements [ImageEditTranslator.ResponseBody].
+func (o *openAIToOpenAIImageEditTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool, span tracingapi.ImageEditSpan) (
+	newHeaders []internalapi.Header, newBody []byte, tokenUsage metrics.TokenUsage, responseModel internalapi.ResponseModel, err error,
+) {
+	// Decode using OpenAI SDK v2 schema to avoid drift.
+	resp := &openai.ImageEditResponse{}
+	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+		return nil, nil, tokenUsage, responseModel, fmt.Errorf("failed to decode response body: %w", err)
+	}
+
+	// There is no response model field, so use the request one.
+	responseModel = o.requestModel
+
+	// Record the response in the span if tracing is enabled.
+	if span != nil {
+		span.RecordResponse(resp)
+	}
+
+	return nil, nil, tokenUsage, responseModel, nil
+}

--- a/internal/translator/imageedit_openai_openai.go
+++ b/internal/translator/imageedit_openai_openai.go
@@ -84,6 +84,13 @@ func (o *openAIToOpenAIImageEditTranslator) ResponseBody(_ map[string]string, bo
 		return nil, nil, tokenUsage, responseModel, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
+	// Populate token usage if provided (gpt-image-1); otherwise remain zero.
+	if resp.Usage != nil {
+		tokenUsage.SetInputTokens(uint32(resp.Usage.InputTokens))   //nolint:gosec
+		tokenUsage.SetOutputTokens(uint32(resp.Usage.OutputTokens)) //nolint:gosec
+		tokenUsage.SetTotalTokens(uint32(resp.Usage.TotalTokens))   //nolint:gosec
+	}
+
 	// There is no response model field, so use the request one.
 	responseModel = o.requestModel
 

--- a/internal/translator/imageedit_openai_openai_test.go
+++ b/internal/translator/imageedit_openai_openai_test.go
@@ -1,0 +1,65 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+func TestNewImageEditOpenAIToOpenAITranslator(t *testing.T) {
+	t.Run("path header set", func(t *testing.T) {
+		translator := NewImageEditOpenAIToOpenAITranslator("v1", "")
+		req := &openai.ImageEditRequest{
+			Prompt: "A sunlit indoor lounge area with a pool",
+			Model:  "dall-e-2",
+		}
+		hm, _, err := translator.RequestBody([]byte(`{"prompt":"A sunlit indoor lounge area with a pool","model":"dall-e-2"}`), req, false)
+		require.NoError(t, err)
+		require.Len(t, hm, 1)
+		require.Equal(t, "/v1/images/edits", hm[0].Value())
+	})
+
+	t.Run("model override", func(t *testing.T) {
+		translator := NewImageEditOpenAIToOpenAITranslator("v1", "dalle-custom")
+		req := &openai.ImageEditRequest{
+			Prompt: "A sunlit indoor lounge area with a pool",
+			Model:  "dall-e-2",
+		}
+		hm, body, err := translator.RequestBody([]byte(`{"prompt":"A sunlit indoor lounge area with a pool","model":"dall-e-2"}`), req, false)
+		require.NoError(t, err)
+		require.Len(t, hm, 2) // path header + content-length
+		require.Contains(t, string(body), `"model":"dalle-custom"`)
+	})
+
+	t.Run("response body", func(t *testing.T) {
+		translator := NewImageEditOpenAIToOpenAITranslator("v1", "")
+		req := &openai.ImageEditRequest{
+			Prompt: "A sunlit indoor lounge area with a pool",
+			Model:  "dall-e-2",
+		}
+		_, _, _ = translator.RequestBody([]byte(`{"prompt":"test","model":"dall-e-2"}`), req, false)
+
+		respBody := `{"created":1589478378,"data":[{"url":"https://example.com/image.png"}]}`
+		_, _, _, responseModel, err := translator.ResponseBody(nil, bytes.NewReader([]byte(respBody)), false, nil)
+		require.NoError(t, err)
+		require.Equal(t, "dall-e-2", string(responseModel))
+	})
+
+	t.Run("response error", func(t *testing.T) {
+		translator := NewImageEditOpenAIToOpenAITranslator("v1", "")
+		errBody := `{"error":{"message":"Invalid image","type":"invalid_request_error"}}`
+		headers, body, err := translator.ResponseError(nil, strings.NewReader(errBody))
+		require.NoError(t, err)
+		require.NotNil(t, headers) // Headers are set for content-type and content-length
+		require.Contains(t, string(body), "Invalid image")
+	})
+}

--- a/internal/translator/imageedit_openai_openai_test.go
+++ b/internal/translator/imageedit_openai_openai_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/json"
 )
 
 func TestNewImageEditOpenAIToOpenAITranslator(t *testing.T) {
@@ -49,9 +50,10 @@ func TestNewImageEditOpenAIToOpenAITranslator(t *testing.T) {
 		_, _, _ = translator.RequestBody([]byte(`{"prompt":"test","model":"dall-e-2"}`), req, false)
 
 		respBody := `{"created":1589478378,"data":[{"url":"https://example.com/image.png"}]}`
-		_, _, _, responseModel, err := translator.ResponseBody(nil, bytes.NewReader([]byte(respBody)), false, nil)
+		_, _, usage, responseModel, err := translator.ResponseBody(nil, bytes.NewReader([]byte(respBody)), false, nil)
 		require.NoError(t, err)
 		require.Equal(t, "dall-e-2", string(responseModel))
+		require.Equal(t, tokenUsageFrom(-1, -1, -1, -1, -1), usage)
 	})
 
 	t.Run("response error", func(t *testing.T) {
@@ -62,4 +64,149 @@ func TestNewImageEditOpenAIToOpenAITranslator(t *testing.T) {
 		require.NotNil(t, headers) // Headers are set for content-type and content-length
 		require.Contains(t, string(body), "Invalid image")
 	})
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_RequestBody_NoOverrideNoForce(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	req := &openai.ImageEditRequest{Model: "dall-e-2", Prompt: "a cat"}
+	original, _ := json.Marshal(req)
+
+	hm, bm, err := tr.RequestBody(original, req, false)
+	require.NoError(t, err)
+	require.NotNil(t, hm)
+	// Only path header present; content-length should not be set when no mutation.
+	require.Len(t, hm, 1)
+	require.Equal(t, pathHeaderName, hm[0].Key())
+	require.Nil(t, bm)
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_RequestBody_ForceMutation(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	req := &openai.ImageEditRequest{Model: "dall-e-2", Prompt: "a cat"}
+	original, _ := json.Marshal(req)
+
+	hm, bm, err := tr.RequestBody(original, req, true)
+	require.NoError(t, err)
+	require.NotNil(t, hm)
+	// Content-Length is set only when body mutated; with force it should be mutated to original.
+	foundCL := false
+	for _, h := range hm {
+		if h.Key() == contentLengthHeaderName {
+			foundCL = true
+			break
+		}
+	}
+	require.True(t, foundCL)
+	require.NotNil(t, bm)
+	require.Equal(t, original, bm)
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseHeaders_NoOp(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	hm, err := tr.ResponseHeaders(map[string]string{"foo": "bar"})
+	require.NoError(t, err)
+	require.Nil(t, hm)
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseBody_OK(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	resp := &openai.ImageEditResponse{}
+	buf, _ := json.Marshal(resp)
+	hm, bm, usage, responseModel, err := tr.ResponseBody(map[string]string{}, bytes.NewReader(buf), true, nil)
+	require.NoError(t, err)
+	require.Nil(t, hm)
+	require.Nil(t, bm)
+	require.Equal(t, tokenUsageFrom(-1, -1, -1, -1, -1), usage)
+	require.Empty(t, responseModel)
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseBody_DecodeError(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	_, _, _, _, err := tr.ResponseBody(map[string]string{}, bytes.NewReader([]byte("not-json")), true, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to decode response body")
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseBody_ModelPropagatesFromRequest(t *testing.T) {
+	// Use override so effective model differs from original.
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "gpt-image-1")
+	req := &openai.ImageEditRequest{Model: "dall-e-2", Prompt: "a cat"}
+	original, _ := json.Marshal(req)
+	// Call RequestBody first to set requestModel inside translator.
+	_, _, err := tr.RequestBody(original, req, false)
+	require.NoError(t, err)
+
+	resp := &openai.ImageEditResponse{
+		Data: make([]openai.ImageEditResponseData, 2),
+	}
+	buf, _ := json.Marshal(resp)
+	_, _, _, respModel, err := tr.ResponseBody(map[string]string{}, bytes.NewReader(buf), true, nil)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-image-1", string(respModel))
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseBody_RecordsSpan(t *testing.T) {
+	mockSpan := &mockImageEditSpan{}
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+
+	resp := &openai.ImageEditResponse{
+		Data: []openai.ImageEditResponseData{{URL: "https://example.com/img.png"}},
+	}
+	buf, _ := json.Marshal(resp)
+	_, _, _, _, err := tr.ResponseBody(map[string]string{}, bytes.NewReader(buf), true, mockSpan)
+	require.NoError(t, err)
+	require.NotNil(t, mockSpan.recordedResponse)
+}
+
+type mockImageEditSpan struct {
+	recordedResponse *openai.ImageEditResponse
+}
+
+func (m *mockImageEditSpan) RecordResponse(resp *openai.ImageEditResponse) {
+	m.recordedResponse = resp
+}
+
+func (m *mockImageEditSpan) EndSpanOnError(int, []byte)    {}
+func (m *mockImageEditSpan) EndSpan()                      {}
+func (m *mockImageEditSpan) RecordResponseChunk(*struct{}) {}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseBody_Usage(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	resp := &openai.ImageEditResponse{
+		Usage: &openai.ImageGenerationUsage{
+			TotalTokens:  100,
+			InputTokens:  40,
+			OutputTokens: 60,
+		},
+	}
+	buf, _ := json.Marshal(resp)
+	_, _, usage, _, err := tr.ResponseBody(map[string]string{}, bytes.NewReader(buf), true, nil)
+	require.NoError(t, err)
+	require.Equal(t, tokenUsageFrom(40, -1, -1, 60, 100), usage)
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseError_NonJSON(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	headers := map[string]string{contentTypeHeaderName: "text/plain", statusHeaderName: "503"}
+	hm, bm, err := tr.ResponseError(headers, bytes.NewReader([]byte("backend error")))
+	require.NoError(t, err)
+	require.NotNil(t, hm)
+	require.NotNil(t, bm)
+
+	// Body should be OpenAI error JSON.
+	var actual struct {
+		Error openai.ErrorType `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(bm, &actual))
+	require.Equal(t, openAIBackendError, actual.Error.Type)
+}
+
+func TestOpenAIToOpenAIImageEditTranslator_ResponseError_JSONPassthrough(t *testing.T) {
+	tr := NewImageEditOpenAIToOpenAITranslator("v1", "")
+	headers := map[string]string{contentTypeHeaderName: jsonContentType, statusHeaderName: "500"}
+	// Already JSON — should be passed through (no mutation).
+	hm, bm, err := tr.ResponseError(headers, bytes.NewReader([]byte(`{"error":"msg"}`)))
+	require.NoError(t, err)
+	require.Nil(t, hm)
+	require.Nil(t, bm)
 }

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -87,6 +87,8 @@ type (
 	AnthropicMessagesTranslator = Translator[anthropicschema.MessagesRequest, tracingapi.MessageSpan]
 	// OpenAIImageGenerationTranslator translates the OpenAI's /images/generations endpoint.
 	OpenAIImageGenerationTranslator = Translator[openai.ImageGenerationRequest, tracingapi.ImageGenerationSpan]
+	// OpenAIImageEditTranslator translates the OpenAI's /images/edits endpoint.
+	OpenAIImageEditTranslator = Translator[openai.ImageEditRequest, tracingapi.ImageEditSpan]
 	// OpenAIResponsesTranslator translates the OpenAI's /responses endpoint.
 	OpenAIResponsesTranslator = Translator[openai.ResponseRequest, tracingapi.ResponsesSpan]
 )

--- a/scripts/test_image_edit.sh
+++ b/scripts/test_image_edit.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Test script for OpenAI Image Edit endpoint through AI Gateway
+# Usage: ./test_image_edit.sh <gateway_url> <openai_api_key> <image_path>
+
+GATEWAY_URL="${1:-http://localhost:8080}"
+OPENAI_API_KEY="${2:-$OPENAI_API_KEY}"
+IMAGE_PATH="${3:-test_image.png}"
+
+# Check if image exists
+if [ ! -f "$IMAGE_PATH" ]; then
+    echo "Creating a simple test PNG image..."
+    # Create a simple 256x256 PNG using Python (requires PIL)
+    python3 -c "
+from PIL import Image
+img = Image.new('RGBA', (256, 256), (255, 200, 200, 255))
+img.save('$IMAGE_PATH')
+print('Created test image: $IMAGE_PATH')
+" 2>/dev/null || {
+        echo "Could not create test image. Please provide a PNG file."
+        exit 1
+    }
+fi
+
+# Base64 encode the image
+IMAGE_B64=$(base64 < "$IMAGE_PATH" | tr -d '\n')
+
+echo "Testing Image Edit endpoint: $GATEWAY_URL/v1/images/edits"
+echo "Image size: $(wc -c < "$IMAGE_PATH") bytes"
+echo ""
+
+# Send the request
+curl -X POST "$GATEWAY_URL/v1/images/edits" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d "{
+    \"model\": \"dall-e-2\",
+    \"image\": \"data:image/png;base64,$IMAGE_B64\",
+    \"prompt\": \"Add a small red circle in the center\",
+    \"n\": 1,
+    \"size\": \"256x256\",
+    \"response_format\": \"url\"
+  }"
+
+echo ""


### PR DESCRIPTION
**Description**

This PR adds support for the OpenAI /v1/images/edits endpoint across the Envoy AI Gateway. The implementation closely follows the pattern established by the image generation endpoint (merged in #1280).

Resolves #1746.

**Changes**

**API Schema** (internal/apischema/openai/image_edit.go)
- Added ImageEditRequest with all fields from the OpenAI API reference: image, prompt, model, mask, n, size, response_format, user.
- Added ImageEditResponse and ImageEditResponseData matching the images object schema.

**Translator** (internal/translator/imageedit_openai_openai.go)
- Implemented OpenAI-to-OpenAI translator for image edits:
  - Request body transformation with model override support.
  - Path header routing to /v1/images/edits.
  - Response body parsing and response model attribution (using request model since the images API omits it in responses).
  - Error handling via the existing convertErrorOpenAIToOpenAIError helper.
- Added OpenAIImageEditTranslator type alias in translator.go.

**Tracing** (internal/tracing/openinference/openai/image_edit.go)
- Added ImageEditRecorder following OpenInference semantic conventions.
- Records request/response attributes with proper input/output redaction support.
- Wired up ImageEditTracer, ImageEditSpan, and NoopImageEditTracer in the tracing API and implementation.

**Metrics** (internal/metrics/genai.go)
- Added GenAIOperationImageEdit operation type for observability.

**Endpoint Registration** (internal/endpointspec/endpointspec.go)
- Added ImageEditEndpointSpec with ParseBody and GetTranslator methods.

**ExtProc** (cmd/extproc/mainlib/main.go)
- Registered /v1/images/edits processor with its metrics factory, tracer, and endpoint spec.

**Tests**

- Unit tests for the translator covering:
  - Path header routing
  - Model override behavior
  - Response body parsing with model attribution
  - Error response handling
- All existing tests continue to pass.

**AI Disclosure**

AI tooling (GitHub Copilot) was used to assist with scaffolding this implementation. I fully understand the code, reviewed every change, and take ownership of this PR.

**Related Issues/PRs (if applicable)**

Resolves #1746
Related PR: #1280

**Special notes for reviewers (if applicable)**

OpenAI API reference for the image edit endpoint:
1: https://platform.openai.com/docs/api-reference/images/createEdit