### PR TITLE
test: disable context7 tests due to certificate issues

### DIFF
--- a/examples/mcp/mcp_example.yaml
+++ b/examples/mcp/mcp_example.yaml
@@ -28,10 +28,18 @@ spec:
         apiKey:
           secretRef:
             name: github-access-token
-    - name: context7
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/mcp"
+    # TODO(nacx): Context7 started giving errors due to its certificate:
+    # time=2026-02-20T12:14:12.555+01:00 level=ERROR msg="failed to create MCP session" component=mcp-proxy backend=context7
+    # error="MCP initialize request failed with status code 503 and body=upstream connect error or disconnect/reset before headers.
+    # reset reason: remote connection failure, transport failure reason: TLS_error:|268435563:SSL routines:OPENSSL_internal:BAD_ECC_CERT:TLS_error_end"
+    #
+    # Until those are resolved or figure out, we're just adding kiwi to verify that we can connect to a public MCP server and call a tool.
+    # context7 can be enabled back when the certificate issue is sorted out.
+    #
+    # - name: context7
+    #   kind: Backend
+    #   group: gateway.envoyproxy.io
+    #   path: "/mcp"
     - name: kiwi
       kind: Backend
       group: gateway.envoyproxy.io
@@ -103,30 +111,33 @@ spec:
     wellKnownCACertificates: "System"
     hostname: mcp.kiwi.com
 ---
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: context7
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: mcp.context7.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: context7-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: context7
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: mcp.context7.com
+# apiVersion: gateway.envoyproxy.io/v1alpha1
+# kind: Backend
+# metadata:
+#   name: context7
+#   namespace: default
+# spec:
+#   endpoints:
+#     - fqdn:
+#         hostname: mcp.context7.com
+#         port: 443
+# ---
+# apiVersion: gateway.networking.k8s.io/v1alpha3
+# kind: BackendTLSPolicy
+# metadata:
+#   name: context7-tls
+#   namespace: default
+# spec:
+#   targetRefs:
+#     - group: "gateway.envoyproxy.io"
+#       kind: Backend
+#       name: context7
+#   validation:
+#     wellKnownCACertificates: "System"
+#     hostname: mcp.context7.com
+#     subjectAltNames:
+#       - type: Hostname
+#         hostname: "*.context7.com"
 ---
 ###################################################################################
 ############################### Gateway Definitions ###############################

--- a/examples/mcp/mcp_oauth_example.yaml
+++ b/examples/mcp/mcp_oauth_example.yaml
@@ -17,10 +17,6 @@ spec:
       kind: Gateway
       group: gateway.networking.k8s.io
   backendRefs:
-    - name: context7
-      kind: Backend
-      group: gateway.envoyproxy.io
-      path: "/mcp"
     - name: kiwi
       kind: Backend
       group: gateway.envoyproxy.io
@@ -100,31 +96,6 @@ spec:
   validation:
     wellKnownCACertificates: "System"
     hostname: mcp.kiwi.com
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: context7
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: mcp.context7.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: context7-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: context7
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: mcp.context7.com
 ---
 ###################################################################################
 ############################### Gateway Definitions ###############################

--- a/examples/mcp/mcp_oauth_keycloak.yaml
+++ b/examples/mcp/mcp_oauth_keycloak.yaml
@@ -73,31 +73,6 @@ spec:
     wellKnownCACertificates: "System"
     hostname: mcp.kiwi.com
 ---
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: context7
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: mcp.context7.com
-        port: 443
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: context7-tls
-  namespace: default
-spec:
-  targetRefs:
-    - group: "gateway.envoyproxy.io"
-      kind: Backend
-      name: context7
-  validation:
-    wellKnownCACertificates: "System"
-    hostname: mcp.context7.com
----
 ###################################################################################
 ############################### Gateway Definitions ###############################
 ###################################################################################

--- a/tests/data-plane-mcp/publicmcp_test.go
+++ b/tests/data-plane-mcp/publicmcp_test.go
@@ -29,7 +29,15 @@ func TestPublicMCPServers(t *testing.T) {
 			{
 				Name: "test-route",
 				Backends: []filterapi.MCPBackend{
-					{Name: "context7"},
+					// TODO(nacx): Context7 started giving errors due to its certificate:
+					// time=2026-02-20T12:14:12.555+01:00 level=ERROR msg="failed to create MCP session" component=mcp-proxy backend=context7
+					// error="MCP initialize request failed with status code 503 and body=upstream connect error or disconnect/reset before headers.
+					// reset reason: remote connection failure, transport failure reason: TLS_error:|268435563:SSL routines:OPENSSL_internal:BAD_ECC_CERT:TLS_error_end"
+					//
+					// Until those are resolved or figure out, we're just adding kiwi to verify that we can connect to a public MCP server and call a tool.
+					// context7 can be enabled back when the certificate issue is sorted out.
+					//
+					// {Name: "context7"},
 					{Name: "kiwi"},
 				},
 			},
@@ -78,8 +86,8 @@ func TestPublicMCPServers(t *testing.T) {
 		}
 
 		exps := []string{
-			"context7__resolve-library-id",
-			"context7__query-docs",
+			// "context7__resolve-library-id",
+			// "context7__query-docs",
 			"kiwi__search-flight",
 			"kiwi__feedback-to-devs",
 		}
@@ -107,20 +115,20 @@ func TestPublicMCPServers(t *testing.T) {
 			params   map[string]any
 		}
 		tests := []callToolTest{
-			{
-				toolName: "context7__resolve-library-id",
-				params: map[string]any{
-					"libraryName": "envoyproxy/ai-gateway",
-					"query":       "how can I route to an LLM bakend",
-				},
-			},
-			{
-				toolName: "context7__query-docs",
-				params: map[string]any{
-					"libraryId": "/envoyproxy/ai-gateway",
-					"query":     "how can I route to an LLM bakend",
-				},
-			},
+			// {
+			// 	toolName: "context7__resolve-library-id",
+			// 	params: map[string]any{
+			// 		"libraryName": "envoyproxy/ai-gateway",
+			// 		"query":       "how can I route to an LLM bakend",
+			// 	},
+			// },
+			// {
+			// 	toolName: "context7__query-docs",
+			// 	params: map[string]any{
+			// 		"libraryId": "/envoyproxy/ai-gateway",
+			// 		"query":     "how can I route to an LLM bakend",
+			// 	},
+			// },
 			{
 				toolName: "kiwi__search-flight",
 				params: map[string]any{

--- a/tests/e2e-aigw/examples_mcp_test.go
+++ b/tests/e2e-aigw/examples_mcp_test.go
@@ -27,8 +27,16 @@ var (
 	// Adjust these as services update, as they can be added, removed or renamed
 
 	allNonGithubTools = []string{
-		"context7__query-docs",
-		"context7__resolve-library-id",
+		// TODO(nacx): Context7 started giving errors due to its certificate:
+		// time=2026-02-20T12:14:12.555+01:00 level=ERROR msg="failed to create MCP session" component=mcp-proxy backend=context7
+		// error="MCP initialize request failed with status code 503 and body=upstream connect error or disconnect/reset before headers.
+		// reset reason: remote connection failure, transport failure reason: TLS_error:|268435563:SSL routines:OPENSSL_internal:BAD_ECC_CERT:TLS_error_end"
+		//
+		// Until those are resolved or figure out, we're just adding kiwi to verify that we can connect to a public MCP server and call a tool.
+		// context7 can be enabled back when the certificate issue is sorted out.
+		//
+		// "context7__query-docs",
+		// "context7__resolve-library-id",
 		"kiwi__feedback-to-devs",
 		"kiwi__search-flight",
 	}
@@ -74,20 +82,20 @@ func TestMCP_standalone(t *testing.T) {
 			params   map[string]any
 		}
 		tests := []callToolTest{
-			{
-				toolName: "context7__resolve-library-id",
-				params: map[string]any{
-					"libraryName": "envoyproxy/ai-gateway",
-					"query":       "how can I route to an LLM bakend",
-				},
-			},
-			{
-				toolName: "context7__query-docs",
-				params: map[string]any{
-					"libraryId": "/envoyproxy/ai-gateway",
-					"query":     "how can I route to an LLM bakend",
-				},
-			},
+			// {
+			// 	toolName: "context7__resolve-library-id",
+			// 	params: map[string]any{
+			// 		"libraryName": "envoyproxy/ai-gateway",
+			// 		"query":       "how can I route to an LLM bakend",
+			// 	},
+			// },
+			// {
+			// 	toolName: "context7__query-docs",
+			// 	params: map[string]any{
+			// 		"libraryId": "/envoyproxy/ai-gateway",
+			// 		"query":     "how can I route to an LLM bakend",
+			// 	},
+			// },
 			{
 				toolName: "kiwi__search-flight",
 				params: map[string]any{


### PR DESCRIPTION
**Description**

Recently, there have been issues in the tests caused by the certificate of the `context7` MCP server:

```
time=2026-02-20T12:14:12.555+01:00 level=ERROR msg="failed to create MCP session" component=mcp-proxy backend=context7
error="MCP initialize request failed with status code 503 and body=upstream connect error or disconnect/reset before headers.
reset reason: remote connection failure, transport failure reason: TLS_error:|268435563:SSL routines:OPENSSL_internal:BAD_ECC_CERT:TLS_error_end"
```

This is blocking pull requests, so this PR disables temporary context7 from the tests while the certificate issue is sorted out.

Note that other public servers work fine (kiwi, GitHub), and are already tested, so we shouldn't be losing feature test coverage by not explicitly testing context7.
We still need to understand why it started to fail now or if things need to be configured differently for context7, but I think it is OK to disable for now to avoid blocking PRs.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
