### PR TITLE
fix: fix completion_tokens usage for gcp vertex

### DIFF
--- a/internal/translator/openai_gcpvertexai.go
+++ b/internal/translator/openai_gcpvertexai.go
@@ -181,12 +181,11 @@ func (o *openAIToGCPVertexAITranslatorV1ChatCompletion) ResponseBody(_ map[strin
 	}
 
 	// Update token usage if available.
-	if gcpResp.UsageMetadata != nil {
-		tokenUsage.SetInputTokens(uint32(gcpResp.UsageMetadata.PromptTokenCount))              //nolint:gosec
-		tokenUsage.SetOutputTokens(uint32(gcpResp.UsageMetadata.CandidatesTokenCount))         //nolint:gosec
-		tokenUsage.SetTotalTokens(uint32(gcpResp.UsageMetadata.TotalTokenCount))               //nolint:gosec
-		tokenUsage.SetCachedInputTokens(uint32(gcpResp.UsageMetadata.CachedContentTokenCount)) //nolint:gosec
-		// Gemini does not return cache creation input tokens; Skipping setCacheCreationInputTokens.
+	tokenUsage.SetInputTokens(uint32(openAIResp.Usage.PromptTokens))      //nolint:gosec
+	tokenUsage.SetOutputTokens(uint32(openAIResp.Usage.CompletionTokens)) //nolint:gosec
+	tokenUsage.SetTotalTokens(uint32(openAIResp.Usage.TotalTokens))       //nolint:gosec
+	if openAIResp.Usage.PromptTokensDetails != nil {
+		tokenUsage.SetCachedInputTokens(uint32(openAIResp.Usage.PromptTokensDetails.CachedTokens)) //nolint:gosec
 	}
 
 	if span != nil {

--- a/internal/translator/openai_gcpvertexai_test.go
+++ b/internal/translator/openai_gcpvertexai_test.go
@@ -881,7 +881,7 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
 				"usageMetadata": {
 					"promptTokenCount": 10,
 					"candidatesTokenCount": 15,
-					"totalTokenCount": 25,
+					"totalTokenCount": 35,
                     "cachedContentTokenCount": 10,
                     "thoughtsTokenCount": 10
 				}
@@ -910,10 +910,10 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
         "prompt_tokens_details": {
             "cached_tokens": 10
         },
-        "total_tokens": 25
+        "total_tokens": 35
     }
 }`),
-			wantTokenUsage: tokenUsageFrom(10, 10, -1, 15, 25),
+			wantTokenUsage: tokenUsageFrom(10, 10, -1, 25, 35),
 		},
 		{
 			name: "response with safety ratings",
@@ -1005,7 +1005,7 @@ func TestOpenAIToGCPVertexAITranslatorV1ChatCompletion_ResponseBody(t *testing.T
 			wantError:      false,
 			wantHeaderMut:  []internalapi.Header{{contentLengthHeaderName, "28"}},
 			wantBodyMut:    []byte(`{"object":"chat.completion"}`),
-			wantTokenUsage: tokenUsageFrom(-1, -1, -1, -1, -1),
+			wantTokenUsage: tokenUsageFrom(0, -1, -1, 0, 0),
 		},
 		{
 			name: "single stream chunk response",
@@ -1180,7 +1180,7 @@ data: [DONE]
 				"usageMetadata": {
 					"promptTokenCount": 10,
 					"candidatesTokenCount": 15,
-					"totalTokenCount": 25,
+					"totalTokenCount": 35,
                     "cachedContentTokenCount": 10,
                     "thoughtsTokenCount": 10
 				}
@@ -1210,11 +1210,11 @@ data: [DONE]
         "prompt_tokens_details": {
             "cached_tokens": 10
         },
-        "total_tokens": 25
+        "total_tokens": 35
     }
 }`),
 
-			wantTokenUsage: tokenUsageFrom(10, 10, -1, 15, 25), // Does not support Cache Creation.
+			wantTokenUsage: tokenUsageFrom(10, 10, -1, 25, 35), // Does not support Cache Creation.
 		},
 		{
 			name: "stream chunks with thought summary",


### PR DESCRIPTION
**Description**
The token usage report https://github.com/envoyproxy/ai-gateway/blob/c2bacbf8e2fb36d31469981f5e5b8dcd57c33e21/internal/translator/openai_gcpvertexai.go#L186 is not consistent with usage response returned: https://github.com/envoyproxy/ai-gateway/blob/c2bacbf8e2fb36d31469981f5e5b8dcd57c33e21/internal/translator/gemini_helper.go#L967, by @sukumargaonkar  so just need to make them consistent.

