### PR TITLE
feat: add eager_input_stream support for Anthropic

### DIFF
--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -971,13 +971,6 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 		if input, ok := usage.InputTokens(); ok {
 			p.tokenUsage.SetInputTokens(input)
 		}
-		if cached, ok := usage.CachedInputTokens(); ok {
-			p.tokenUsage.SetCachedInputTokens(cached)
-		}
-		if cacheCreation, ok := usage.CacheCreationInputTokens(); ok {
-			p.tokenUsage.SetCacheCreationInputTokens(cacheCreation)
-		}
-
 		// reset the toolIndex for each message
 		p.toolIndex = -1
 		return nil, nil


### PR DESCRIPTION
**Description**

- Adds a new `eager_input_streaming` field to ChatCompletionRequest that, when true, opts the request into Anthropic's fine-grained tool streaming so tool input parameters stream incrementally instead of being buffered until complete.
- API behavior: sets EagerInputStreaming=true on every translated Anthropic ToolParam when enabled


PS: Re-purpose the PR due to accidentally force-push  
