### PR TITLE
fix: anthropic to openai api translator tools fix

### DIFF
--- a/internal/apischema/anthropic/anthropic.go
+++ b/internal/apischema/anthropic/anthropic.go
@@ -1113,10 +1113,11 @@ const (
 
 func (t *ToolUnion) UnmarshalJSON(data []byte) error {
 	typ := gjson.GetBytes(data, "type")
-	if !typ.Exists() {
-		return errors.New("missing type field in tool")
+	typStr := toolTypeCustom
+	if typ.Exists() && typ.String() != "" {
+		typStr = typ.String()
 	}
-	switch typ.String() {
+	switch typStr {
 	case toolTypeCustom:
 		var tool Tool
 		if err := json.Unmarshal(data, &tool); err != nil {

--- a/internal/apischema/anthropic/anthropic_test.go
+++ b/internal/apischema/anthropic/anthropic_test.go
@@ -735,9 +735,20 @@ func TestToolUnion_UnmarshalJSON(t *testing.T) {
 			want:    ToolUnion{WebSearchTool: &WebSearchTool{Type: "web_search_20250305", Name: "web_search"}},
 		},
 		{
-			name:    "missing type",
-			jsonStr: `{"name":"my_tool"}`,
-			wantErr: true,
+			name:    "missing type defaults to custom",
+			jsonStr: `{"name":"my_tool","description":"A tool","input_schema":{"type":"object"}}`,
+			want: ToolUnion{Tool: &Tool{
+				Name: "my_tool", Description: "A tool",
+				InputSchema: ToolInputSchema{Type: "object"},
+			}},
+		},
+		{
+			name:    "empty type defaults to custom",
+			jsonStr: `{"type":"","name":"my_tool","input_schema":{"type":"object"}}`,
+			want: ToolUnion{Tool: &Tool{
+				Type: "", Name: "my_tool",
+				InputSchema: ToolInputSchema{Type: "object"},
+			}},
 		},
 		{
 			name:    "unknown type ignored",

--- a/internal/translator/anthropic_openai_test.go
+++ b/internal/translator/anthropic_openai_test.go
@@ -726,6 +726,154 @@ func TestAnthropicToOpenAITranslator_ResponseBody_SpanRecording(t *testing.T) {
 	})
 }
 
+func TestAnthropicMessagesToOpenAI_ToolConversation(t *testing.T) {
+	t.Run("tool_use in assistant message becomes tool_calls", func(t *testing.T) {
+		body := &anthropic.MessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 100,
+			Messages: []anthropic.MessageParam{
+				{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "write hello to file"}},
+				{
+					Role: anthropic.MessageRoleAssistant,
+					Content: anthropic.MessageContent{
+						Array: []anthropic.ContentBlockParam{
+							{ToolUse: &anthropic.ToolUseBlockParam{
+								Type: "tool_use", ID: "tool-1", Name: "Write",
+								Input: map[string]any{"file_path": "test.txt", "content": "hello"},
+							}},
+						},
+					},
+				},
+				{
+					Role: anthropic.MessageRoleUser,
+					Content: anthropic.MessageContent{
+						Array: []anthropic.ContentBlockParam{
+							{ToolResult: &anthropic.ToolResultBlockParam{
+								Type: "tool_result", ToolUseID: "tool-1",
+								Content: &anthropic.ToolResultContent{Text: "File written successfully"},
+							}},
+						},
+					},
+				},
+			},
+		}
+		msgs := anthropicMessagesToOpenAI(body)
+		// system (none), user, assistant with tool_calls, tool result
+		require.Len(t, msgs, 3)
+
+		// First message: user
+		require.NotNil(t, msgs[0].OfUser)
+		assert.Equal(t, "write hello to file", msgs[0].OfUser.Content.Value)
+
+		// Second message: assistant with tool_calls
+		require.NotNil(t, msgs[1].OfAssistant)
+		require.Len(t, msgs[1].OfAssistant.ToolCalls, 1)
+		assert.Equal(t, "Write", msgs[1].OfAssistant.ToolCalls[0].Function.Name)
+		assert.Equal(t, "tool-1", *msgs[1].OfAssistant.ToolCalls[0].ID)
+		assert.Contains(t, msgs[1].OfAssistant.ToolCalls[0].Function.Arguments, `"file_path"`)
+
+		// Third message: tool result
+		require.NotNil(t, msgs[2].OfTool)
+		assert.Equal(t, "tool-1", msgs[2].OfTool.ToolCallID)
+		assert.Equal(t, "File written successfully", msgs[2].OfTool.Content.Value)
+	})
+
+	t.Run("tool_result with error preserves error text", func(t *testing.T) {
+		body := &anthropic.MessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 100,
+			Messages: []anthropic.MessageParam{
+				{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "do something"}},
+				{
+					Role: anthropic.MessageRoleAssistant,
+					Content: anthropic.MessageContent{
+						Array: []anthropic.ContentBlockParam{
+							{ToolUse: &anthropic.ToolUseBlockParam{
+								Type: "tool_use", ID: "tool-2", Name: "Bash",
+								Input: map[string]any{"command": "ls"},
+							}},
+						},
+					},
+				},
+				{
+					Role: anthropic.MessageRoleUser,
+					Content: anthropic.MessageContent{
+						Array: []anthropic.ContentBlockParam{
+							{ToolResult: &anthropic.ToolResultBlockParam{
+								Type: "tool_result", ToolUseID: "tool-2",
+								Content: &anthropic.ToolResultContent{Text: "permission denied"},
+								IsError: true,
+							}},
+							{Text: &anthropic.TextBlockParam{Type: "text", Text: "try again"}},
+						},
+					},
+				},
+			},
+		}
+		msgs := anthropicMessagesToOpenAI(body)
+		// user, assistant, tool result, user text
+		require.Len(t, msgs, 4)
+
+		require.NotNil(t, msgs[2].OfTool)
+		assert.Equal(t, "tool-2", msgs[2].OfTool.ToolCallID)
+		assert.Equal(t, "permission denied", msgs[2].OfTool.Content.Value)
+
+		require.NotNil(t, msgs[3].OfUser)
+		assert.Equal(t, "try again", msgs[3].OfUser.Content.Value)
+	})
+
+	t.Run("assistant message with text and tool_use", func(t *testing.T) {
+		body := &anthropic.MessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 100,
+			Messages: []anthropic.MessageParam{
+				{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "help"}},
+				{
+					Role: anthropic.MessageRoleAssistant,
+					Content: anthropic.MessageContent{
+						Array: []anthropic.ContentBlockParam{
+							{Text: &anthropic.TextBlockParam{Type: "text", Text: "I'll write that for you."}},
+							{ToolUse: &anthropic.ToolUseBlockParam{
+								Type: "tool_use", ID: "tool-3", Name: "Write",
+								Input: map[string]any{"file_path": "out.txt", "content": "data"},
+							}},
+						},
+					},
+				},
+			},
+		}
+		msgs := anthropicMessagesToOpenAI(body)
+		require.Len(t, msgs, 2)
+
+		assistantMsg := msgs[1].OfAssistant
+		require.NotNil(t, assistantMsg)
+		assert.Equal(t, "I'll write that for you.", assistantMsg.Content.Value)
+		require.Len(t, assistantMsg.ToolCalls, 1)
+		assert.Equal(t, "Write", assistantMsg.ToolCalls[0].Function.Name)
+	})
+
+	t.Run("plain text messages still work", func(t *testing.T) {
+		body := &anthropic.MessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 100,
+			System:    &anthropic.SystemPrompt{Text: "You are helpful."},
+			Messages: []anthropic.MessageParam{
+				{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "hi"}},
+				{Role: anthropic.MessageRoleAssistant, Content: anthropic.MessageContent{Text: "hello!"}},
+				{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "bye"}},
+			},
+		}
+		msgs := anthropicMessagesToOpenAI(body)
+		// system + 3 messages
+		require.Len(t, msgs, 4)
+		require.NotNil(t, msgs[0].OfSystem)
+		require.NotNil(t, msgs[1].OfUser)
+		require.NotNil(t, msgs[2].OfAssistant)
+		assert.Equal(t, "hello!", msgs[2].OfAssistant.Content.Value)
+		require.NotNil(t, msgs[3].OfUser)
+	})
+}
+
 // responseBodyStreaming should return an error when streamState is nil.
 func TestAnthropicToOpenAITranslator_ResponseBody_StreamStateNilGuard(t *testing.T) {
 	tr := NewAnthropicToChatCompletionOpenAITranslator("v1", "").(*anthropicToOpenAIV1ChatCompletionTranslator)

--- a/internal/translator/openai_helper.go
+++ b/internal/translator/openai_helper.go
@@ -57,6 +57,8 @@ func buildOpenAIChatCompletionRequest(body *anthropic.MessagesRequest, modelName
 }
 
 // anthropicMessagesToOpenAI converts Anthropic messages (including the system prompt) to OpenAI message format.
+// It preserves tool_use blocks in assistant messages as OpenAI tool_calls, and converts
+// tool_result blocks in user messages into separate OpenAI tool-role messages.
 func anthropicMessagesToOpenAI(body *anthropic.MessagesRequest) []openai.ChatCompletionMessageParamUnion {
 	var messages []openai.ChatCompletionMessageParamUnion
 
@@ -76,23 +78,103 @@ func anthropicMessagesToOpenAI(body *anthropic.MessagesRequest) []openai.ChatCom
 	for _, msg := range body.Messages {
 		switch msg.Role {
 		case anthropic.MessageRoleUser:
-			messages = append(messages, openai.ChatCompletionMessageParamUnion{
-				OfUser: &openai.ChatCompletionUserMessageParam{
-					Content: openai.StringOrUserRoleContentUnion{Value: anthropicContentToText(msg.Content)},
-					Role:    openai.ChatMessageRoleUser,
-				},
-			})
+			messages = appendAnthropicUserMessage(messages, msg)
 		case anthropic.MessageRoleAssistant:
-			messages = append(messages, openai.ChatCompletionMessageParamUnion{
-				OfAssistant: &openai.ChatCompletionAssistantMessageParam{
-					Content: openai.StringOrAssistantRoleContentUnion{Value: anthropicContentToText(msg.Content)},
-					Role:    openai.ChatMessageRoleAssistant,
-				},
-			})
+			messages = appendAnthropicAssistantMessage(messages, msg)
 		}
 	}
 
 	return messages
+}
+
+// appendAnthropicAssistantMessage converts an Anthropic assistant message to OpenAI format.
+// It extracts tool_use blocks as OpenAI tool_calls on the assistant message, and preserves
+// any text content alongside them.
+func appendAnthropicAssistantMessage(messages []openai.ChatCompletionMessageParamUnion, msg anthropic.MessageParam) []openai.ChatCompletionMessageParamUnion {
+	text := anthropicContentToText(msg.Content)
+	var toolCalls []openai.ChatCompletionMessageToolCallParam
+
+	for _, block := range msg.Content.Array {
+		if block.ToolUse == nil {
+			continue
+		}
+		args, _ := json.Marshal(block.ToolUse.Input)
+		if args == nil {
+			args = []byte("{}")
+		}
+		id := block.ToolUse.ID
+		toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
+			ID:   &id,
+			Type: openai.ChatCompletionMessageToolCallTypeFunction,
+			Function: openai.ChatCompletionMessageToolCallFunctionParam{
+				Name:      block.ToolUse.Name,
+				Arguments: string(args),
+			},
+		})
+	}
+
+	assistantMsg := &openai.ChatCompletionAssistantMessageParam{
+		Role: openai.ChatMessageRoleAssistant,
+	}
+	if text != "" {
+		assistantMsg.Content = openai.StringOrAssistantRoleContentUnion{Value: text}
+	}
+	if len(toolCalls) > 0 {
+		assistantMsg.ToolCalls = toolCalls
+	}
+	return append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: assistantMsg})
+}
+
+// appendAnthropicUserMessage converts an Anthropic user message to OpenAI format.
+// It splits tool_result blocks into separate OpenAI tool-role messages and keeps
+// text content as a user message.
+func appendAnthropicUserMessage(messages []openai.ChatCompletionMessageParamUnion, msg anthropic.MessageParam) []openai.ChatCompletionMessageParamUnion {
+	// Emit tool-role messages for each tool_result block first, since OpenAI
+	// expects tool results to immediately follow the assistant message that
+	// generated the tool calls.
+	for _, block := range msg.Content.Array {
+		if block.ToolResult == nil {
+			continue
+		}
+		content := toolResultToText(block.ToolResult)
+		messages = append(messages, openai.ChatCompletionMessageParamUnion{
+			OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: block.ToolResult.ToolUseID,
+				Content:    openai.ContentUnion{Value: content},
+			},
+		})
+	}
+
+	// Emit user text if there is any non-tool-result content.
+	text := anthropicContentToText(msg.Content)
+	if text != "" {
+		messages = append(messages, openai.ChatCompletionMessageParamUnion{
+			OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.StringOrUserRoleContentUnion{Value: text},
+				Role:    openai.ChatMessageRoleUser,
+			},
+		})
+	}
+
+	return messages
+}
+
+// toolResultToText extracts text from a ToolResultBlockParam.
+func toolResultToText(tr *anthropic.ToolResultBlockParam) string {
+	if tr.Content == nil {
+		return ""
+	}
+	if tr.Content.Text != "" {
+		return tr.Content.Text
+	}
+	var sb strings.Builder
+	for _, item := range tr.Content.Array {
+		if item.Text != nil {
+			sb.WriteString(item.Text.Text)
+		}
+	}
+	return sb.String()
 }
 
 // anthropicSystemPromptToText extracts a plain string from an Anthropic system prompt,


### PR DESCRIPTION
**Description**

This PR fixes Messages API handling for tool types and tool conversations. 

1. In the Anthropic schema, tools with a missing or empty type are now treated as custom tools instead of returning an error. Clients like Claude Code, do not always send type. 

2. For Anthropic→OpenAI translation, assistant tool_use blocks are mapped to OpenAI tool_calls, and user tool_result blocks are emitted as separate tool-role messages so multi-turn tool conversations round-trip correctly when the backend is OpenAI.


<details>
<summary>Sample anthropic messages tool conversation</summary>

```{
  "model": "claude-3-5-sonnet-20241022",
  "max_tokens": 1024,
  "messages": [
    { "role": "user", "content": "Write 'hello' to test.txt" },
    {
      "role": "assistant",
      "content": [
        {
          "type": "tool_use",
          "id": "toolu_1",
          "name": "write_file",
          "input": { "path": "test.txt", "content": "hello" }
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "type": "tool_result",
          "tool_use_id": "toolu_1",
          "content": "Wrote 5 bytes to test.txt."
        }
      ]
    }
  ]
}
```
</details>
<details>
<summary>Sample openai chat completions tool conversation</summary>

```[
  { "role": "user", "content": "Write 'hello' to test.txt" },
  {
    "role": "assistant",
    "tool_calls": [
      {
        "id": "toolu_1",
        "type": "function",
        "function": {
          "name": "write_file",
          "arguments": "{\"path\":\"test.txt\",\"content\":\"hello\"}"
        }
      }
    ]
  },
  {
    "role": "tool",
    "tool_call_id": "toolu_1",
    "content": "Wrote 5 bytes to test.txt."
  }
]
```