### PR TITLE
fix: logger panic when debug is enabled in extproc

### DIFF
--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -143,8 +143,7 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 	var internalReqID string
 	var originalReqID string
 	var logger *slog.Logger
-	// Seed the context with the server-level logger as a fallback so that loggerFromContext never
-	// returns nil in processMsg.
+	// Seed the context with the server-level logger as a fallback so that loggerFromContext never returns nil in processMsg.
 	ctx = context.WithValue(ctx, loggerContextKey, s.logger)
 	defer func() {
 		if !isUpstreamFilter {


### PR DESCRIPTION
**Description**

Fix a nil-pointer panic in AI Gateway extproc when a request is rejected before reaching the router ext_proc RequestHeaders phase. 

When Envoy sends only response-phase callbacks (e.g., ext_authz failure), loggerFromContext(ctx) could return nil, and debug logging in processMsg panicked. 
https://github.com/envoyproxy/ai-gateway/blob/8b88b90b7d7dc070c4ea042fddf27682224f71c3/internal/extproc/server.go#L320