### PR TITLE
fix: quote endpoint prefix to render as a string

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
               {{- $endpointPrefixes = append $endpointPrefixes (printf "anthropic:%s" $anthropic) -}}
             {{- end -}}
             {{- if $endpointPrefixes }}
-            - --endpointPrefixes={{ join "," $endpointPrefixes }}
+            - "--endpointPrefixes={{ join "," $endpointPrefixes }}"
             {{- end }}
             {{- if .Values.extProc.extraEnvVars }}
             - --extProcExtraEnvVars={{ include "ai-gateway-helm.extProc.envVarsString" . }}


### PR DESCRIPTION
**Description**

- When provider prefixes are configured as empty (for example `cohere: ""`), the generated value becomes `--endpointPrefixes=cohere:` and without YAML quoting this can be interpreted incorrectly in manifest generation.

- Quoting the whole argument preserves it as a single string and prevents parsing/manifest errors for empty-prefix configurations.
