### PR TITLE
docs: Enable Kapa.ai MCP integration in docs widget

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -40,6 +40,8 @@ const config: Config = {
       "data-answer-cta-button-text": "Need more help? Ask a human!",
       "data-modal-disclaimer": "This AI assistant can help you find information about **Envoy AI Gateway**, **Envoy Gateway** and **Proxy**. Please verify important information from our official documentation. If you need more help you can always [ask a human](https://github.com/envoyproxy/ai-gateway/discussions/new?category=q-a).",
       "data-modal-override-open-id": "custom-ask-ai-button",
+      "data-mcp-enabled": "true",
+      "data-mcp-server-url": "https://envoy-gateway.mcp.kapa.ai",
       "data-user-analytics-fingerprint-enabled": "true",
       "data-modal-full-screen": "true",
       "data-modal-z-index": "2000",


### PR DESCRIPTION
**Description**

This commit enables the Kapa.ai MCP (Model Context Protocol) install menu in the documentation site widget by adding two parameters to the widget script in `docusaurus.config.ts`:

- `data-mcp-enabled="true"`
- `data-mcp-server-url="https://envoy-gateway.mcp.kapa.ai"`

This surfaces a dropdown in the widget header that lets users connect to the Envoy AI Gateway knowledge base from Cursor, VS Code, Claude, and ChatGPT. Users visiting the docs site will see an MCP install option with one-click install for Cursor and VS Code, plus copy-to-clipboard for Claude Desktop and ChatGPT.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A
