### PR TITLE
fix: allow x-ai-eg-model to be overridden via headerMutation

### DIFF
--- a/internal/headermutator/header_mutator.go
+++ b/internal/headermutator/header_mutator.go
@@ -112,11 +112,20 @@ func (h *HeaderMutator) Mutate(headers map[string]string, onRetry bool) (sets []
 // This should be safe since these headers are managed by Envoy AI Gateway itself, not expected to be
 // modified by users via header mutation API.
 //
+// Exception: the model name header (x-ai-eg-model by default) is a user-facing header that
+// represents the effective model for a request. It can be legitimately overridden via headerMutation
+// to control what model name is forwarded to the backend.
+//
 // Also, skip Envoy pseudo-headers beginning with ':', such as ":method", ":path", etc.
 // This is important because these headers are not only sensitive to our implementation detail as well as
 // it can cause unexpected behavior if they are modified unexpectedly. User shouldn't need to
 // modify these headers via header mutation API.
 func shouldIgnoreHeader(key string) bool {
+	// Allow the model name header to be overridden via headerMutation.
+	// This is a documented user-facing header used for routing and backend model selection.
+	if strings.EqualFold(key, internalapi.ModelNameHeaderKeyDefault) {
+		return false
+	}
 	return strings.HasPrefix(key, ":") ||
 		strings.HasPrefix(key, internalapi.EnvoyAIGatewayHeaderPrefix) ||
 		strings.EqualFold(key, internalapi.EnvoyOriginalPathHeader)

--- a/internal/headermutator/header_mutator_test.go
+++ b/internal/headermutator/header_mutator_test.go
@@ -39,6 +39,49 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 		require.Equal(t, "value", headers["other"])
 	})
 
+	t.Run("allow model name header to be overridden via headerMutation", func(t *testing.T) {
+		// Regression test for https://github.com/envoyproxy/ai-gateway/issues/1872.
+		// x-ai-eg-model is a user-facing header and must be settable via headerMutation.
+		headers := map[string]string{
+			internalapi.ModelNameHeaderKeyDefault: "original-model",
+			"other":                               "value",
+		}
+		mutations := &filterapi.HTTPHeaderMutation{
+			Set: []filterapi.HTTPHeader{
+				{Name: internalapi.ModelNameHeaderKeyDefault, Value: "overridden-model"},
+			},
+		}
+		mutator := NewHeaderMutator(mutations, nil)
+		sets, removes := mutator.Mutate(headers, false)
+
+		require.Empty(t, removes)
+		require.Len(t, sets, 1)
+		require.Equal(t, internalapi.ModelNameHeaderKeyDefault, sets[0][0])
+		require.Equal(t, "overridden-model", sets[0][1])
+		// The local headers map should reflect the override.
+		require.Equal(t, "overridden-model", headers[internalapi.ModelNameHeaderKeyDefault])
+		require.Equal(t, "value", headers["other"])
+	})
+
+	t.Run("other x-ai-eg-* headers are still ignored", func(t *testing.T) {
+		// All x-ai-eg-* headers other than x-ai-eg-model must remain protected.
+		headers := map[string]string{
+			"other": "value",
+		}
+		mutations := &filterapi.HTTPHeaderMutation{
+			Set: []filterapi.HTTPHeader{
+				{Name: internalapi.EnvoyAIGatewayHeaderPrefix + "internal-secret", Value: "hacked"},
+			},
+		}
+		mutator := NewHeaderMutator(mutations, nil)
+		sets, removes := mutator.Mutate(headers, false)
+
+		require.Empty(t, removes)
+		require.Empty(t, sets)
+		_, ok := headers[internalapi.EnvoyAIGatewayHeaderPrefix+"internal-secret"]
+		require.False(t, ok)
+	})
+
 	t.Run("restore original headers on retry", func(t *testing.T) {
 		originalHeaders := map[string]string{
 			"authorization":    "secret",


### PR DESCRIPTION
Fixes #1872

**Description**

`shouldIgnoreHeader` was silently dropping all `x-ai-eg-*` headers from
`headerMutation.set`, including the user-facing `x-ai-eg-model` header.
This made it impossible to override the model name forwarded to the backend
via `headerMutation`, even though `x-ai-eg-model` is a documented routing
header that users are expected to control.

This commit adds an explicit exception for `ModelNameHeaderKeyDefault`
(`x-ai-eg-model`) in `shouldIgnoreHeader`, allowing it to be set via
`headerMutation` while keeping all other internal `x-ai-eg-*` headers protected.

**Related Issues/PRs (if applicable)**

Fixes #1872

**Special notes for reviewers (if applicable)**

Only `ModelNameHeaderKeyDefault` (`x-ai-eg-model`) is exempted from the
ignore list. All other `x-ai-eg-*` headers remain blocked. A regression
test and a guard test are included to cover both behaviors.

> Note: I identified this bug by reading through the codebase and traced it
> to `shouldIgnoreHeader` in `header_mutator.go`. I used Claude (AI) as a
> coding assistant during implementation. I fully understand and own all
> changes submitted in this PR.