### PR TITLE
fix: quick fixes on claude thinking

### DIFF
--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -576,15 +576,18 @@ func getThinkingConfigParamUnion(tu *openai.ThinkingUnion) *anthropic.ThinkingCo
 
 	result := &anthropic.ThinkingConfigParamUnion{}
 
-	if tu.OfEnabled != nil {
+	switch {
+	case tu.OfEnabled != nil:
 		result.OfEnabled = &anthropic.ThinkingConfigEnabledParam{
 			BudgetTokens: tu.OfEnabled.BudgetTokens,
 			Type:         constant.Enabled(tu.OfEnabled.Type),
 		}
-	} else if tu.OfDisabled != nil {
+	case tu.OfDisabled != nil:
 		result.OfDisabled = &anthropic.ThinkingConfigDisabledParam{
 			Type: constant.Disabled(tu.OfDisabled.Type),
 		}
+	case tu.OfAdaptive != nil:
+		result.OfAdaptive = &anthropic.ThinkingConfigAdaptiveParam{}
 	}
 
 	return result
@@ -597,6 +600,17 @@ func outputConfigAvailable(model internalapi.RequestModel) bool {
 	modelLower := strings.ToLower(model)
 	return strings.Contains(modelLower, "4-5") ||
 		strings.Contains(modelLower, "4-6")
+}
+
+// effortAvailable checks if the model supports the output_config.effort parameter.
+// The effort parameter is supported by Claude Opus 4.6, Claude Sonnet 4.6, and Claude Opus 4.5.
+// See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#adaptive-thinking
+func effortAvailable(model internalapi.RequestModel) bool {
+	modelLower := strings.ToLower(model)
+	if strings.Contains(modelLower, "4-6") {
+		return true
+	}
+	return strings.Contains(modelLower, "4-5") && strings.Contains(modelLower, "opus")
 }
 
 // mapReasoningEffortToOutputConfigEffort converts OpenAI reasoning effort levels to Anthropic output config effort levels.
@@ -673,7 +687,7 @@ func buildAnthropicParams(openAIReq *openai.ChatCompletionRequest, apiSchema str
 	}
 
 	// Map OpenAI reasoning_effort to Anthropic output_config.effort.
-	if openAIReq.ReasoningEffort != "" && outputConfigAvailable(openAIReq.Model) {
+	if openAIReq.ReasoningEffort != "" && effortAvailable(openAIReq.Model) {
 		effort, effortErr := mapReasoningEffortToOutputConfigEffort(openAIReq.ReasoningEffort)
 		if effortErr != nil {
 			return nil, effortErr

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -691,7 +691,7 @@ func buildAnthropicParams(openAIReq *openai.ChatCompletionRequest, apiSchema str
 
 	// 5. Handle structured outputs (ResponseFormat -> OutputConfig).
 	// See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
-	// Currently, GCP Vertex AI does not support output_config.
+	// Currently, GCP Vertex AI does not support structured output.
 	// Use modelNameOverride for feature checks when available, as it is more
 	// reliable than the user-provided model name which may be arbitrarily set.
 	featureCheckModel := openAIReq.Model

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -607,8 +607,6 @@ func modelContainsAny(model internalapi.RequestModel, identifiers []string) bool
 }
 
 // outputConfigModels lists model identifiers that support structured outputs (OutputConfig).
-// The model checked here is the original gateway-facing model name from the user's request,
-// not the upstream provider's model name (which is applied separately via modelNameOverride).
 // Structured outputs are available on Claude Opus 4.6, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Opus 4.5, and Claude Haiku 4.5.
 // See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
 var outputConfigModels = []string{
@@ -624,10 +622,8 @@ func outputConfigAvailable(model internalapi.RequestModel) bool {
 }
 
 // effortModels lists model identifiers that support the output_config.effort parameter.
-// The model checked here is the original gateway-facing model name from the user's request,
-// not the upstream provider's model name (which is applied separately via modelNameOverride).
 // The effort parameter is supported by Claude Opus 4.6, Claude Sonnet 4.6, and Claude Opus 4.5.
-// See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#adaptive-thinking
+// See: https://platform.claude.com/docs/en/build-with-claude/effort
 var effortModels = []string{
 	"opus-4-5",   // Claude Opus 4.5
 	"opus-4-6",   // Claude Opus 4.6
@@ -662,7 +658,7 @@ func mapReasoningEffortToOutputConfigEffort(reasonEffort openaisdk.ReasoningEffo
 // buildAnthropicParams is a helper function that translates an OpenAI request
 // into the parameter struct required by the Anthropic SDK.
 // The apiSchema parameter indicates the backend API schema (e.g., "AWSAnthropic", "GCPAnthropic").
-func buildAnthropicParams(openAIReq *openai.ChatCompletionRequest, apiSchema string) (params *anthropic.MessageNewParams, err error) {
+func buildAnthropicParams(openAIReq *openai.ChatCompletionRequest, apiSchema string, modelNameOverride internalapi.ModelNameOverride) (params *anthropic.MessageNewParams, err error) {
 	// 1. Handle simple parameters.
 	// max_tokens is required by the Anthropic API but optional in the OpenAI API.
 	// If not set, pass 0 and let the Anthropic API reject the request.
@@ -696,8 +692,14 @@ func buildAnthropicParams(openAIReq *openai.ChatCompletionRequest, apiSchema str
 	// 5. Handle structured outputs (ResponseFormat -> OutputConfig).
 	// See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
 	// Currently, GCP Vertex AI does not support output_config.
+	// Use modelNameOverride for feature checks when available, as it is more
+	// reliable than the user-provided model name which may be arbitrarily set.
+	featureCheckModel := openAIReq.Model
+	if modelNameOverride != "" {
+		featureCheckModel = modelNameOverride
+	}
 	isGCPBackend := strings.HasPrefix(apiSchema, "GCP")
-	if !isGCPBackend && openAIReq.ResponseFormat != nil && openAIReq.ResponseFormat.OfJSONSchema != nil && outputConfigAvailable(openAIReq.Model) {
+	if !isGCPBackend && openAIReq.ResponseFormat != nil && openAIReq.ResponseFormat.OfJSONSchema != nil && outputConfigAvailable(featureCheckModel) {
 		// Convert OpenAI JSON schema to Anthropic OutputConfig format
 		var schemaMap map[string]any
 		if err = json.Unmarshal(openAIReq.ResponseFormat.OfJSONSchema.JSONSchema.Schema, &schemaMap); err != nil {
@@ -712,7 +714,7 @@ func buildAnthropicParams(openAIReq *openai.ChatCompletionRequest, apiSchema str
 	}
 
 	// Map OpenAI reasoning_effort to Anthropic output_config.effort.
-	if openAIReq.ReasoningEffort != "" && effortAvailable(openAIReq.Model) {
+	if openAIReq.ReasoningEffort != "" && effortAvailable(featureCheckModel) {
 		effort, effortErr := mapReasoningEffortToOutputConfigEffort(openAIReq.ReasoningEffort)
 		if effortErr != nil {
 			return nil, effortErr

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -587,30 +587,55 @@ func getThinkingConfigParamUnion(tu *openai.ThinkingUnion) *anthropic.ThinkingCo
 			Type: constant.Disabled(tu.OfDisabled.Type),
 		}
 	case tu.OfAdaptive != nil:
-		result.OfAdaptive = &anthropic.ThinkingConfigAdaptiveParam{}
+		result.OfAdaptive = &anthropic.ThinkingConfigAdaptiveParam{
+			Type: constant.Adaptive(tu.OfAdaptive.Type),
+		}
 	}
 
 	return result
 }
 
-// outputConfigAvailable checks if the model supports structured outputs (OutputConfig).
-// Structured outputs are available on Claude Opus 4.6, Claude Sonnet 4.5, Claude Opus 4.5, and Claude Haiku 4.5.
-// See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
-func outputConfigAvailable(model internalapi.RequestModel) bool {
+// modelContainsAny checks if the model string contains any of the given identifiers (case-insensitive).
+func modelContainsAny(model internalapi.RequestModel, identifiers []string) bool {
 	modelLower := strings.ToLower(model)
-	return strings.Contains(modelLower, "4-5") ||
-		strings.Contains(modelLower, "4-6")
+	for _, id := range identifiers {
+		if strings.Contains(modelLower, id) {
+			return true
+		}
+	}
+	return false
 }
 
-// effortAvailable checks if the model supports the output_config.effort parameter.
+// outputConfigModels lists model identifiers that support structured outputs (OutputConfig).
+// The model checked here is the original gateway-facing model name from the user's request,
+// not the upstream provider's model name (which is applied separately via modelNameOverride).
+// Structured outputs are available on Claude Opus 4.6, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Opus 4.5, and Claude Haiku 4.5.
+// See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+var outputConfigModels = []string{
+	"opus-4-5",   // Claude Opus 4.5
+	"sonnet-4-5", // Claude Sonnet 4.5
+	"haiku-4-5",  // Claude Haiku 4.5
+	"opus-4-6",   // Claude Opus 4.6
+	"sonnet-4-6", // Claude Sonnet 4.6
+}
+
+func outputConfigAvailable(model internalapi.RequestModel) bool {
+	return modelContainsAny(model, outputConfigModels)
+}
+
+// effortModels lists model identifiers that support the output_config.effort parameter.
+// The model checked here is the original gateway-facing model name from the user's request,
+// not the upstream provider's model name (which is applied separately via modelNameOverride).
 // The effort parameter is supported by Claude Opus 4.6, Claude Sonnet 4.6, and Claude Opus 4.5.
 // See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#adaptive-thinking
+var effortModels = []string{
+	"opus-4-5",   // Claude Opus 4.5
+	"opus-4-6",   // Claude Opus 4.6
+	"sonnet-4-6", // Claude Sonnet 4.6
+}
+
 func effortAvailable(model internalapi.RequestModel) bool {
-	modelLower := strings.ToLower(model)
-	if strings.Contains(modelLower, "4-6") {
-		return true
-	}
-	return strings.Contains(modelLower, "4-5") && strings.Contains(modelLower, "opus")
+	return modelContainsAny(model, effortModels)
 }
 
 // mapReasoningEffortToOutputConfigEffort converts OpenAI reasoning effort levels to Anthropic output config effort levels.

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -907,7 +907,7 @@ func TestBuildAnthropicParamsWithStructuredOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			params, err := buildAnthropicParams(tt.request, "AWSAnthropic")
+			params, err := buildAnthropicParams(tt.request, "AWSAnthropic", "")
 
 			if tt.expectErr {
 				require.Error(t, err)
@@ -926,6 +926,34 @@ func TestBuildAnthropicParamsWithStructuredOutput(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("structured output enabled via modelNameOverride when request model is custom", func(t *testing.T) {
+		request := &openai.ChatCompletionRequest{
+			Model:               "my-custom-model", // User-defined name that doesn't match outputConfigModels.
+			MaxCompletionTokens: ptr.To(int64(1024)),
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{OfUser: &openai.ChatCompletionUserMessageParam{
+					Role:    "user",
+					Content: openai.StringOrUserRoleContentUnion{Value: "test"},
+				}},
+			},
+			ResponseFormat: &openai.ChatCompletionResponseFormatUnion{
+				OfJSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+					Type: "json_schema",
+					JSONSchema: openai.ChatCompletionResponseFormatJSONSchemaJSONSchema{
+						Name:   "test_schema",
+						Schema: []byte(`{"type": "object", "properties": {"name": {"type": "string"}}}`),
+					},
+				},
+			},
+		}
+		// The modelNameOverride contains a recognized model identifier.
+		params, err := buildAnthropicParams(request, "AWSAnthropic", "us.anthropic.claude-sonnet-4-5-20250514-v1:0")
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		require.NotNil(t, params.OutputConfig.Format.Schema)
+		require.Equal(t, constant.JSONSchema("json_schema"), params.OutputConfig.Format.Type)
+	})
 }
 
 func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
@@ -1042,7 +1070,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			params, err := buildAnthropicParams(tt.request, "AWSAnthropic")
+			params, err := buildAnthropicParams(tt.request, "AWSAnthropic", "")
 			require.NoError(t, err)
 			require.NotNil(t, params)
 			require.Equal(t, tt.expectedEffort, params.OutputConfig.Effort)
@@ -1061,9 +1089,47 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 				}},
 			},
 		}
-		_, err := buildAnthropicParams(request, "AWSAnthropic")
+		_, err := buildAnthropicParams(request, "AWSAnthropic", "")
 		require.Error(t, err)
 		require.ErrorIs(t, err, internalapi.ErrInvalidRequestBody)
 		require.Contains(t, err.Error(), "unsupported reasoning effort level")
+	})
+
+	t.Run("reasoning_effort enabled via modelNameOverride when request model is custom", func(t *testing.T) {
+		request := &openai.ChatCompletionRequest{
+			Model:               "my-custom-model", // User-defined name that doesn't match effort models.
+			MaxCompletionTokens: ptr.To(int64(1024)),
+			ReasoningEffort:     openaisdk.ReasoningEffortHigh,
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{OfUser: &openai.ChatCompletionUserMessageParam{
+					Role:    "user",
+					Content: openai.StringOrUserRoleContentUnion{Value: "test"},
+				}},
+			},
+		}
+		// The modelNameOverride contains a recognized model identifier.
+		params, err := buildAnthropicParams(request, "AWSAnthropic", "us.anthropic.claude-opus-4-5-20250514-v1:0")
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		require.Equal(t, anthropic.OutputConfigEffortHigh, params.OutputConfig.Effort)
+	})
+
+	t.Run("reasoning_effort skipped when modelNameOverride is unsupported model", func(t *testing.T) {
+		request := &openai.ChatCompletionRequest{
+			Model:               "claude-opus-4-5-20250514", // Request model matches, but override doesn't.
+			MaxCompletionTokens: ptr.To(int64(1024)),
+			ReasoningEffort:     openaisdk.ReasoningEffortHigh,
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{OfUser: &openai.ChatCompletionUserMessageParam{
+					Role:    "user",
+					Content: openai.StringOrUserRoleContentUnion{Value: "test"},
+				}},
+			},
+		}
+		// The modelNameOverride points to an unsupported model.
+		params, err := buildAnthropicParams(request, "AWSAnthropic", "us.anthropic.claude-3-sonnet-20240229-v1:0")
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		require.Equal(t, anthropic.OutputConfigEffort(""), params.OutputConfig.Effort)
 	})
 }

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -753,6 +753,67 @@ func TestOutputConfigAvailable(t *testing.T) {
 	}
 }
 
+func TestEffortAvailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected bool
+	}{
+		{
+			name:     "claude-opus-4-6-20250514 supported",
+			model:    "claude-opus-4-6-20250514",
+			expected: true,
+		},
+		{
+			name:     "claude-sonnet-4-6-20250514 supported",
+			model:    "claude-sonnet-4-6-20250514",
+			expected: true,
+		},
+		{
+			name:     "claude-opus-4-5-20250514 supported",
+			model:    "claude-opus-4-5-20250514",
+			expected: true,
+		},
+		{
+			name:     "anthropic.claude-4-5-opus-v1 supported",
+			model:    "anthropic.claude-4-5-opus-v1",
+			expected: true,
+		},
+		{
+			name:     "claude-sonnet-4-5-20250514 not supported",
+			model:    "claude-sonnet-4-5-20250514",
+			expected: false,
+		},
+		{
+			name:     "anthropic.claude-4-5-sonnet-v1 not supported",
+			model:    "anthropic.claude-4-5-sonnet-v1",
+			expected: false,
+		},
+		{
+			name:     "claude-haiku-4-5-20250514 not supported",
+			model:    "claude-haiku-4-5-20250514",
+			expected: false,
+		},
+		{
+			name:     "claude-3-sonnet not supported",
+			model:    "claude-3-sonnet",
+			expected: false,
+		},
+		{
+			name:     "empty model not supported",
+			model:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := effortAvailable(tt.model)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestBuildAnthropicParamsWithStructuredOutput(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -886,7 +947,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 		{
 			name: "reasoning_effort low on supported model",
 			request: &openai.ChatCompletionRequest{
-				Model:               "claude-sonnet-4-5-20250514",
+				Model:               "claude-opus-4-5-20250514",
 				MaxCompletionTokens: ptr.To(int64(1024)),
 				ReasoningEffort:     openaisdk.ReasoningEffortLow,
 				Messages: []openai.ChatCompletionMessageParamUnion{
@@ -901,7 +962,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 		{
 			name: "reasoning_effort medium on supported model",
 			request: &openai.ChatCompletionRequest{
-				Model:               "claude-sonnet-4-5-20250514",
+				Model:               "claude-opus-4-5-20250514",
 				MaxCompletionTokens: ptr.To(int64(1024)),
 				ReasoningEffort:     openaisdk.ReasoningEffortMedium,
 				Messages: []openai.ChatCompletionMessageParamUnion{
@@ -916,7 +977,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 		{
 			name: "reasoning_effort high on supported model",
 			request: &openai.ChatCompletionRequest{
-				Model:               "claude-sonnet-4-5-20250514",
+				Model:               "claude-opus-4-5-20250514",
 				MaxCompletionTokens: ptr.To(int64(1024)),
 				ReasoningEffort:     openaisdk.ReasoningEffortHigh,
 				Messages: []openai.ChatCompletionMessageParamUnion{
@@ -931,7 +992,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 		{
 			name: "reasoning_effort xhigh on supported model",
 			request: &openai.ChatCompletionRequest{
-				Model:               "claude-sonnet-4-5-20250514",
+				Model:               "claude-opus-4-5-20250514",
 				MaxCompletionTokens: ptr.To(int64(1024)),
 				ReasoningEffort:     openaisdk.ReasoningEffortXhigh,
 				Messages: []openai.ChatCompletionMessageParamUnion{
@@ -944,7 +1005,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 			expectedEffort: anthropic.OutputConfigEffortMax,
 		},
 		{
-			name: "reasoning_effort skipped on unsupported model",
+			name: "reasoning_effort skipped on unsupported model claude-3-sonnet",
 			request: &openai.ChatCompletionRequest{
 				Model:               "claude-3-sonnet",
 				MaxCompletionTokens: ptr.To(int64(1024)),
@@ -959,9 +1020,24 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 			expectedEffort: "",
 		},
 		{
-			name: "no reasoning_effort set",
+			name: "reasoning_effort skipped on unsupported model claude-sonnet-4-5",
 			request: &openai.ChatCompletionRequest{
 				Model:               "claude-sonnet-4-5-20250514",
+				MaxCompletionTokens: ptr.To(int64(1024)),
+				ReasoningEffort:     openaisdk.ReasoningEffortHigh,
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{OfUser: &openai.ChatCompletionUserMessageParam{
+						Role:    "user",
+						Content: openai.StringOrUserRoleContentUnion{Value: "test"},
+					}},
+				},
+			},
+			expectedEffort: "",
+		},
+		{
+			name: "no reasoning_effort set",
+			request: &openai.ChatCompletionRequest{
+				Model:               "claude-opus-4-5-20250514",
 				MaxCompletionTokens: ptr.To(int64(1024)),
 				Messages: []openai.ChatCompletionMessageParamUnion{
 					{OfUser: &openai.ChatCompletionUserMessageParam{
@@ -985,7 +1061,7 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 
 	t.Run("unsupported reasoning_effort returns error", func(t *testing.T) {
 		request := &openai.ChatCompletionRequest{
-			Model:               "claude-sonnet-4-5-20250514",
+			Model:               "claude-opus-4-5-20250514",
 			MaxCompletionTokens: ptr.To(int64(1024)),
 			ReasoningEffort:     "invalid",
 			Messages: []openai.ChatCompletionMessageParamUnion{

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -719,8 +719,8 @@ func TestOutputConfigAvailable(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "anthropic.claude-4-5-sonnet-v1 supported",
-			model:    "anthropic.claude-4-5-sonnet-v1",
+			name:     "claude-sonnet-4-6-20250514 supported",
+			model:    "claude-sonnet-4-6-20250514",
 			expected: true,
 		},
 		{
@@ -775,18 +775,8 @@ func TestEffortAvailable(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "anthropic.claude-4-5-opus-v1 supported",
-			model:    "anthropic.claude-4-5-opus-v1",
-			expected: true,
-		},
-		{
 			name:     "claude-sonnet-4-5-20250514 not supported",
 			model:    "claude-sonnet-4-5-20250514",
-			expected: false,
-		},
-		{
-			name:     "anthropic.claude-4-5-sonnet-v1 not supported",
-			model:    "anthropic.claude-4-5-sonnet-v1",
 			expected: false,
 		},
 		{

--- a/internal/translator/openai_awsanthropic.go
+++ b/internal/translator/openai_awsanthropic.go
@@ -70,7 +70,7 @@ func (o *openAIToAWSAnthropicTranslatorV1ChatCompletion) RequestBody(_ []byte, o
 		o.streamParser = newAnthropicStreamParser(o.requestModel)
 	}
 
-	params, err := buildAnthropicParams(openAIReq, "AWSAnthropic")
+	params, err := buildAnthropicParams(openAIReq, "AWSAnthropic", o.modelNameOverride)
 	if err != nil {
 		return
 	}

--- a/internal/translator/openai_gcpanthropic.go
+++ b/internal/translator/openai_gcpanthropic.go
@@ -56,7 +56,7 @@ type openAIToGCPAnthropicTranslatorV1ChatCompletion struct {
 func (o *openAIToGCPAnthropicTranslatorV1ChatCompletion) RequestBody(_ []byte, openAIReq *openai.ChatCompletionRequest, _ bool) (
 	newHeaders []internalapi.Header, newBody []byte, err error,
 ) {
-	params, err := buildAnthropicParams(openAIReq, "GCPAnthropic")
+	params, err := buildAnthropicParams(openAIReq, "GCPAnthropic", o.modelNameOverride)
 	if err != nil {
 		return
 	}

--- a/internal/translator/openai_gcpanthropic_test.go
+++ b/internal/translator/openai_gcpanthropic_test.go
@@ -233,7 +233,7 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_RequestBody(t *testing.T
 				OfStringArray: []string{"stop1", "stop2"},
 			},
 		}
-		messageParam, err := buildAnthropicParams(openaiRequest, "GCPAnthropic")
+		messageParam, err := buildAnthropicParams(openaiRequest, "GCPAnthropic", "")
 		require.NoError(t, err)
 		require.Equal(t, int64(100), messageParam.MaxTokens)
 		require.Equal(t, "0.1", messageParam.TopP.String())
@@ -252,7 +252,7 @@ func TestOpenAIToGCPAnthropicTranslatorV1ChatCompletion_RequestBody(t *testing.T
 				OfString: openaigo.Opt[string]("stop1"),
 			},
 		}
-		messageParam, err := buildAnthropicParams(openaiRequest, "GCPAnthropic")
+		messageParam, err := buildAnthropicParams(openaiRequest, "GCPAnthropic", "")
 		require.NoError(t, err)
 		require.Equal(t, int64(100), messageParam.MaxTokens)
 		require.Equal(t, "0.1", messageParam.TopP.String())


### PR DESCRIPTION
**Description**
  - Add missing OfAdaptive thinking config handling: `getThinkingConfigParamUnion` only handled `OfEnabled` and `OfDisabled`, silently dropping `{"type": "adaptive"}` thinking configs.
  https://github.com/envoyproxy/ai-gateway/pull/1842


- Fix `reasoning_effort` model support: The `reasoning_effort` → `output_config.effort` mapping was incorrectly using             
  `outputConfigAvailable`, which includes models that don't support the effort parameter (e.g., Claude Sonnet 4.5, Claude Haiku  4.5). Added a new effortAvailable function to use a list as suggested by @aabchoo so that correctly limits effort support to Claude Opus 4.6, Claude Sonnet 4.6, and Claude Opus 4.5. 

Referece: https://platform.claude.com/docs/en/build-with-claude/effort
https://github.com/envoyproxy/ai-gateway/pull/1892

