### PR TITLE
feat: add hostnames field to AIGatewayRoute spec

### DIFF
--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -64,6 +64,17 @@ type AIGatewayRouteSpec struct {
 	// +optional
 	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
 
+	// Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+	// used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+	// When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+	//
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+	// for the details of the Hostnames field in the Gateway API.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxItems=16
+	Hostnames []gwapiv1.Hostname `json:"hostnames,omitempty"`
+
 	// Rules is the list of AIGatewayRouteRule that this AIGatewayRoute will match the traffic to.
 	// Each rule is a subset of the HTTPRoute in the Gateway API (https://gateway-api.sigs.k8s.io/api-types/httproute/).
 	//

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -201,6 +201,11 @@ func (in *AIGatewayRouteSpec) DeepCopyInto(out *AIGatewayRouteSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Hostnames != nil {
+		in, out := &in.Hostnames, &out.Hostnames
+		*out = make([]v1.Hostname, len(*in))
+		copy(*out, *in)
+	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules
 		*out = make([]AIGatewayRouteRule, len(*in))

--- a/api/v1beta1/ai_gateway_route.go
+++ b/api/v1beta1/ai_gateway_route.go
@@ -64,6 +64,17 @@ type AIGatewayRouteSpec struct {
 	// +optional
 	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
 
+	// Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+	// used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+	// When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+	//
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+	// for the details of the Hostnames field in the Gateway API.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxItems=16
+	Hostnames []gwapiv1.Hostname `json:"hostnames,omitempty"`
+
 	// Rules is the list of AIGatewayRouteRule that this AIGatewayRoute will match the traffic to.
 	// Each rule is a subset of the HTTPRoute in the Gateway API (https://gateway-api.sigs.k8s.io/api-types/httproute/).
 	//

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -201,6 +201,11 @@ func (in *AIGatewayRouteSpec) DeepCopyInto(out *AIGatewayRouteSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Hostnames != nil {
+		in, out := &in.Hostnames, &out.Hostnames
+		*out = make([]v1.Hostname, len(*in))
+		copy(*out, *in)
+	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules
 		*out = make([]AIGatewayRouteRule, len(*in))

--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -355,6 +355,7 @@ func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv
 	dst.Annotations[httpRouteAnnotationForAIGatewayGeneratedIndication] = "true"
 
 	dst.Spec.ParentRefs = aiGatewayRoute.Spec.ParentRefs
+	dst.Spec.Hostnames = aiGatewayRoute.Spec.Hostnames
 	return nil
 }
 

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -219,6 +219,7 @@ func Test_newHTTPRoute(t *testing.T) {
 							Group: ptr.To(gwapiv1a2.Group("gateway.networking.k8s.io")),
 						},
 					},
+					Hostnames: []gwapiv1.Hostname{"ai-llm.example.com", "ai-api.example.com"},
 					Rules: []aigv1b1.AIGatewayRouteRule{
 						{
 							BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple", Weight: ptr.To[int32](100)}},
@@ -340,6 +341,8 @@ func Test_newHTTPRoute(t *testing.T) {
 				},
 			}
 			require.Equal(t, expRules, httpRoute.Spec.Rules)
+
+			require.Equal(t, []gwapiv1.Hostname{"ai-llm.example.com", "ai-api.example.com"}, httpRoute.Spec.Hostnames)
 		})
 	}
 }

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -68,6 +68,36 @@ spec:
           spec:
             description: Spec defines the details of the AIGatewayRoute.
             properties:
+              hostnames:
+                description: |-
+                  Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+                  used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+                  When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+
+                  See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+                  for the details of the Hostnames field in the Gateway API.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
               llmRequestCosts:
                 description: "LLMRequestCosts specifies how to capture the cost of
                   the LLM-related request, notably the token usage.\nThe AI Gateway
@@ -913,6 +943,36 @@ spec:
           spec:
             description: Spec defines the details of the AIGatewayRoute.
             properties:
+              hostnames:
+                description: |-
+                  Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+                  used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+                  When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+
+                  See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+                  for the details of the Hostnames field in the Gateway API.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
               llmRequestCosts:
                 description: "LLMRequestCosts specifies how to capture the cost of
                   the LLM-related request, notably the token usage.\nThe AI Gateway

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -760,6 +760,11 @@ AIGatewayRouteSpec details the AIGatewayRoute configuration.
   required="false"
   description="ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.<br />Currently, each reference's Kind must be Gateway."
 /><ApiField
+  name="hostnames"
+  type="Hostname array"
+  required="false"
+  description="Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute<br />used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.<br />When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.<br />See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec<br />for the details of the Hostnames field in the Gateway API."
+/><ApiField
   name="rules"
   type="[AIGatewayRouteRule](#aigatewayrouterule) array"
   required="true"
@@ -3034,6 +3039,11 @@ AIGatewayRouteSpec details the AIGatewayRoute configuration.
   type="[ParentReference](https://gateway-api.sigs.k8s.io/reference/spec/?h=httproutetimeouts#parentreference) array"
   required="false"
   description="ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.<br />Currently, each reference's Kind must be Gateway."
+/><ApiField
+  name="hostnames"
+  type="Hostname array"
+  required="false"
+  description="Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute<br />used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.<br />When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.<br />See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec<br />for the details of the Hostnames field in the Gateway API."
 /><ApiField
   name="rules"
   type="[AIGatewayRouteRule](#aigatewayrouterule) array"


### PR DESCRIPTION
**Description**

Add `Hostnames` field to `AIGatewayRouteSpec` for hostname-based filtering on the generated HTTPRoute. This is consistent with Gateway API's `HTTPRouteSpec.Hostnames` and follows the same pass-through pattern used for `ParentRefs`.

**Related Issues/PRs (if applicable)**
Close #1965


This PR was developed with assistance from a generative AI agent. I reviewed the generated output, understand the changes, and take full responsibility for the submitted code.