### PR TITLE
fix: strip structured-output headers and body for gcp on message api path.

### DIFF
--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -598,6 +598,11 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) SetBackend(c
 	}
 	rp.upstreamFilter = u // Only assign after translator is confirmed valid
 
+	// Pass request headers to the translator if it supports it.
+	if headerAware, ok := u.translator.(translator.RequestHeadersAware); ok {
+		headerAware.SetRequestHeaders(u.requestHeaders)
+	}
+
 	switch redactor := u.translator.(type) {
 	case translator.ResponseRedactor:
 		redactor.SetRedactionConfig(u.parent.debugLogEnabled, u.parent.enableRedaction, u.logger)

--- a/internal/translator/anthropic_gcpanthropic.go
+++ b/internal/translator/anthropic_gcpanthropic.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
 	anthropicschema "github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
@@ -72,7 +73,14 @@ func (a *anthropicToGCPAnthropicTranslator) RequestBody(raw []byte, req *anthrop
 	// Strip output_config.format from the body since GCP Vertex AI does not support structured outputs.
 	// Requests with output_config.format will be rejected by Vertex with "Extra inputs are not permitted".
 	// We only strip the format field, preserving other output_config fields like effort.
-	newBody, _ = sjson.DeleteBytesOptions(newBody, "output_config.format", sjsonOptionsInPlace)
+	if gjson.GetBytes(newBody, "output_config.format").Exists() {
+		newBody, _ = sjson.DeleteBytesOptions(newBody, "output_config.format", sjsonOptionsInPlace)
+		// If output_config is now empty (format was the only field), remove the entire key
+		// to avoid leaving an empty object that GCP may also reject.
+		if oc := gjson.GetBytes(newBody, "output_config"); oc.Exists() && len(oc.Map()) == 0 {
+			newBody, _ = sjson.DeleteBytesOptions(newBody, "output_config", sjsonOptionsInPlace)
+		}
+	}
 
 	// Determine the GCP path based on whether streaming is requested.
 	specifier := "rawPredict"
@@ -92,26 +100,23 @@ func (a *anthropicToGCPAnthropicTranslator) RequestBody(raw []byte, req *anthrop
 	return
 }
 
-// filteredAnthropicBetaHeader returns a new anthropic-beta header with the
-// "structured-outputs-2025-12-15" value removed, or nil if no change is needed.
+// filteredAnthropicBetaHeader returns the anthropic-beta header with the
+// "structured-outputs-2025-12-15" value removed. If no anthropic-beta header
+// exists in the request, returns nil.
 // The anthropic-beta header is a comma-separated list of beta feature names.
 func (a *anthropicToGCPAnthropicTranslator) filteredAnthropicBetaHeader() *internalapi.Header {
 	betaValue, ok := a.requestHeaders[anthropicBetaHeaderName]
-	if !ok || betaValue == "" {
+	if !ok {
 		return nil
 	}
 	betas := strings.Split(betaValue, ",")
 	filtered := make([]string, 0, len(betas))
-	changed := false
 	for _, b := range betas {
-		if strings.TrimSpace(b) == structuredOutputsBetaValue {
-			changed = true
+		trimmed := strings.TrimSpace(b)
+		if trimmed == "" || trimmed == structuredOutputsBetaValue {
 			continue
 		}
-		filtered = append(filtered, b)
-	}
-	if !changed {
-		return nil
+		filtered = append(filtered, trimmed)
 	}
 	h := internalapi.Header{anthropicBetaHeaderName, strings.Join(filtered, ",")}
 	return &h

--- a/internal/translator/anthropic_gcpanthropic.go
+++ b/internal/translator/anthropic_gcpanthropic.go
@@ -9,11 +9,17 @@ import (
 	"cmp"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/tidwall/sjson"
 
 	anthropicschema "github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+)
+
+const (
+	anthropicBetaHeaderName    = "anthropic-beta"
+	structuredOutputsBetaValue = "structured-outputs-2025-12-15"
 )
 
 // NewAnthropicToGCPAnthropicTranslator creates a translator for Anthropic to GCP Anthropic format.
@@ -30,6 +36,14 @@ type anthropicToGCPAnthropicTranslator struct {
 	apiVersion        string
 	modelNameOverride internalapi.ModelNameOverride
 	requestModel      internalapi.RequestModel
+	requestHeaders    map[string]string
+}
+
+// SetRequestHeaders stores the request headers for use during translation.
+// This allows the translator to modify headers like anthropic-beta that are
+// not part of the request body.
+func (a *anthropicToGCPAnthropicTranslator) SetRequestHeaders(headers map[string]string) {
+	a.requestHeaders = headers
 }
 
 // RequestBody implements [AnthropicMessagesTranslator.RequestBody] for Anthropic to GCP Anthropic translation.
@@ -55,6 +69,11 @@ func (a *anthropicToGCPAnthropicTranslator) RequestBody(raw []byte, req *anthrop
 		// It is safe to use sjsonOptionsInPlace here since we have already created a new mutatedBody above.
 		sjsonOptionsInPlace)
 
+	// Strip output_config.format from the body since GCP Vertex AI does not support structured outputs.
+	// Requests with output_config.format will be rejected by Vertex with "Extra inputs are not permitted".
+	// We only strip the format field, preserving other output_config fields like effort.
+	newBody, _ = sjson.DeleteBytesOptions(newBody, "output_config.format", sjsonOptionsInPlace)
+
 	// Determine the GCP path based on whether streaming is requested.
 	specifier := "rawPredict"
 	if req.Stream {
@@ -63,5 +82,37 @@ func (a *anthropicToGCPAnthropicTranslator) RequestBody(raw []byte, req *anthrop
 
 	path := buildGCPModelPathSuffix(gcpModelPublisherAnthropic, a.requestModel, specifier)
 	newHeaders = []internalapi.Header{{pathHeaderName, path}, {contentLengthHeaderName, strconv.Itoa(len(newBody))}}
+
+	// Strip the structured-outputs beta value from the anthropic-beta header since
+	// GCP Vertex AI does not support it and rejects requests containing this beta.
+	if betaHeader := a.filteredAnthropicBetaHeader(); betaHeader != nil {
+		newHeaders = append(newHeaders, *betaHeader)
+	}
+
 	return
+}
+
+// filteredAnthropicBetaHeader returns a new anthropic-beta header with the
+// "structured-outputs-2025-12-15" value removed, or nil if no change is needed.
+// The anthropic-beta header is a comma-separated list of beta feature names.
+func (a *anthropicToGCPAnthropicTranslator) filteredAnthropicBetaHeader() *internalapi.Header {
+	betaValue, ok := a.requestHeaders[anthropicBetaHeaderName]
+	if !ok || betaValue == "" {
+		return nil
+	}
+	betas := strings.Split(betaValue, ",")
+	filtered := make([]string, 0, len(betas))
+	changed := false
+	for _, b := range betas {
+		if strings.TrimSpace(b) == structuredOutputsBetaValue {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	if !changed {
+		return nil
+	}
+	h := internalapi.Header{anthropicBetaHeaderName, strings.Join(filtered, ",")}
+	return &h
 }

--- a/internal/translator/anthropic_gcpanthropic_test.go
+++ b/internal/translator/anthropic_gcpanthropic_test.go
@@ -408,6 +408,160 @@ func TestAnthropicToGCPAnthropicTranslator_RequestBody_FieldPassthrough(t *testi
 	require.Equal(t, "2023-06-01", modifiedReq["anthropic_version"])
 }
 
+func TestAnthropicToGCPAnthropicTranslator_RequestBody_StripsOutputConfigFormat(t *testing.T) {
+	tests := []struct {
+		name                string
+		rawBody             string
+		expectFormatRemoved bool
+		expectEffortKept    bool
+	}{
+		{
+			name:                "strips output_config.format from body",
+			rawBody:             `{"model":"claude-3-haiku-20240307","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"output_config":{"format":{"type":"json_schema","schema":{"type":"object"}}}}`,
+			expectFormatRemoved: true,
+		},
+		{
+			name:                "preserves output_config.effort when stripping format",
+			rawBody:             `{"model":"claude-3-haiku-20240307","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"output_config":{"effort":"high","format":{"type":"json_schema","schema":{"type":"object"}}}}`,
+			expectFormatRemoved: true,
+			expectEffortKept:    true,
+		},
+		{
+			name:                "no output_config is fine",
+			rawBody:             `{"model":"claude-3-haiku-20240307","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`,
+			expectFormatRemoved: false,
+		},
+		{
+			name:                "output_config without format is preserved",
+			rawBody:             `{"model":"claude-3-haiku-20240307","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"output_config":{"effort":"high"}}`,
+			expectFormatRemoved: false,
+			expectEffortKept:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translator := NewAnthropicToGCPAnthropicTranslator("2023-06-01", "")
+
+			parsedReq := &anthropic.MessagesRequest{
+				Model: "claude-3-haiku-20240307",
+				Messages: []anthropic.MessageParam{
+					{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "hi"}},
+				},
+				MaxTokens: 100,
+			}
+
+			_, bodyMutation, err := translator.RequestBody([]byte(tt.rawBody), parsedReq, false)
+			require.NoError(t, err)
+
+			var modifiedReq map[string]any
+			err = json.Unmarshal(bodyMutation, &modifiedReq)
+			require.NoError(t, err)
+
+			outputConfig, hasOutputConfig := modifiedReq["output_config"]
+			if tt.expectFormatRemoved || tt.expectEffortKept {
+				if tt.expectEffortKept {
+					require.True(t, hasOutputConfig, "output_config should be present")
+					oc := outputConfig.(map[string]any)
+					_, hasFormat := oc["format"]
+					assert.False(t, hasFormat, "output_config.format should be removed")
+					assert.Equal(t, "high", oc["effort"], "output_config.effort should be preserved")
+				} else if tt.expectFormatRemoved {
+					if hasOutputConfig {
+						oc := outputConfig.(map[string]any)
+						_, hasFormat := oc["format"]
+						assert.False(t, hasFormat, "output_config.format should be removed")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAnthropicToGCPAnthropicTranslator_RequestBody_StripsStructuredOutputsBeta(t *testing.T) {
+	tests := []struct {
+		name              string
+		requestHeaders    map[string]string
+		expectBetaHeader  bool
+		expectedBetaValue string
+	}{
+		{
+			name:             "no anthropic-beta header",
+			requestHeaders:   map[string]string{},
+			expectBetaHeader: false,
+		},
+		{
+			name:             "empty anthropic-beta header",
+			requestHeaders:   map[string]string{"anthropic-beta": ""},
+			expectBetaHeader: false,
+		},
+		{
+			name:              "only structured-outputs beta is stripped",
+			requestHeaders:    map[string]string{"anthropic-beta": "structured-outputs-2025-12-15"},
+			expectBetaHeader:  true,
+			expectedBetaValue: "",
+		},
+		{
+			name:              "structured-outputs stripped, other betas preserved",
+			requestHeaders:    map[string]string{"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15,structured-outputs-2025-12-15"},
+			expectBetaHeader:  true,
+			expectedBetaValue: "max-tokens-3-5-sonnet-2024-07-15",
+		},
+		{
+			name:              "structured-outputs in middle stripped, others preserved",
+			requestHeaders:    map[string]string{"anthropic-beta": "beta-a,structured-outputs-2025-12-15,beta-b"},
+			expectBetaHeader:  true,
+			expectedBetaValue: "beta-a,beta-b",
+		},
+		{
+			name:             "unrelated beta not stripped",
+			requestHeaders:   map[string]string{"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15"},
+			expectBetaHeader: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translator := NewAnthropicToGCPAnthropicTranslator("2023-06-01", "")
+
+			translator.(RequestHeadersAware).SetRequestHeaders(tt.requestHeaders)
+
+			parsedReq := &anthropic.MessagesRequest{
+				Model: "claude-3-haiku-20240307",
+				Messages: []anthropic.MessageParam{
+					{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "hi"}},
+				},
+				MaxTokens: 100,
+			}
+
+			headers, _, err := translator.RequestBody([]byte(`{"model":"claude-3-haiku-20240307","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`), parsedReq, false)
+			require.NoError(t, err)
+
+			var foundBeta bool
+			var betaValue string
+			for _, h := range headers {
+				if h.Key() == anthropicBetaHeaderName {
+					foundBeta = true
+					betaValue = h.Value()
+				}
+			}
+
+			if tt.expectBetaHeader {
+				assert.True(t, foundBeta, "expected anthropic-beta header in response")
+				assert.Equal(t, tt.expectedBetaValue, betaValue)
+			} else {
+				assert.False(t, foundBeta, "did not expect anthropic-beta header in response")
+			}
+		})
+	}
+}
+
+func TestAnthropicToGCPAnthropicTranslator_ImplementsRequestHeadersAware(t *testing.T) {
+	translator := NewAnthropicToGCPAnthropicTranslator("2023-06-01", "")
+	_, ok := translator.(RequestHeadersAware)
+	assert.True(t, ok, "anthropicToGCPAnthropicTranslator should implement RequestHeadersAware")
+}
+
 func TestAnthropicToGCPAnthropicTranslator_ResponseHeaders(t *testing.T) {
 	translator := NewAnthropicToGCPAnthropicTranslator("2023-06-01", "")
 

--- a/internal/translator/anthropic_gcpanthropic_test.go
+++ b/internal/translator/anthropic_gcpanthropic_test.go
@@ -480,43 +480,39 @@ func TestAnthropicToGCPAnthropicTranslator_RequestBody_StripsOutputConfigFormat(
 
 func TestAnthropicToGCPAnthropicTranslator_RequestBody_StripsStructuredOutputsBeta(t *testing.T) {
 	tests := []struct {
-		name              string
-		requestHeaders    map[string]string
-		expectBetaHeader  bool
-		expectedBetaValue string
+		name               string
+		requestHeaders     map[string]string
+		expectBetaInOutput bool   // whether anthropic-beta should appear in returned headers
+		expectedBetaValue  string // expected value if present
 	}{
 		{
-			name:             "no anthropic-beta header",
-			requestHeaders:   map[string]string{},
-			expectBetaHeader: false,
+			name:               "no anthropic-beta header in request",
+			requestHeaders:     map[string]string{},
+			expectBetaInOutput: false,
 		},
 		{
-			name:             "empty anthropic-beta header",
-			requestHeaders:   map[string]string{"anthropic-beta": ""},
-			expectBetaHeader: false,
+			name:               "only structured-outputs beta is stripped, result is empty",
+			requestHeaders:     map[string]string{"anthropic-beta": "structured-outputs-2025-12-15"},
+			expectBetaInOutput: true,
+			expectedBetaValue:  "",
 		},
 		{
-			name:              "only structured-outputs beta is stripped",
-			requestHeaders:    map[string]string{"anthropic-beta": "structured-outputs-2025-12-15"},
-			expectBetaHeader:  true,
-			expectedBetaValue: "",
+			name:               "structured-outputs stripped, other betas preserved",
+			requestHeaders:     map[string]string{"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15,structured-outputs-2025-12-15"},
+			expectBetaInOutput: true,
+			expectedBetaValue:  "max-tokens-3-5-sonnet-2024-07-15",
 		},
 		{
-			name:              "structured-outputs stripped, other betas preserved",
-			requestHeaders:    map[string]string{"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15,structured-outputs-2025-12-15"},
-			expectBetaHeader:  true,
-			expectedBetaValue: "max-tokens-3-5-sonnet-2024-07-15",
+			name:               "structured-outputs in middle stripped, others preserved",
+			requestHeaders:     map[string]string{"anthropic-beta": "beta-a,structured-outputs-2025-12-15,beta-b"},
+			expectBetaInOutput: true,
+			expectedBetaValue:  "beta-a,beta-b",
 		},
 		{
-			name:              "structured-outputs in middle stripped, others preserved",
-			requestHeaders:    map[string]string{"anthropic-beta": "beta-a,structured-outputs-2025-12-15,beta-b"},
-			expectBetaHeader:  true,
-			expectedBetaValue: "beta-a,beta-b",
-		},
-		{
-			name:             "unrelated beta not stripped",
-			requestHeaders:   map[string]string{"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15"},
-			expectBetaHeader: false,
+			name:               "unrelated beta passes through unchanged",
+			requestHeaders:     map[string]string{"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15"},
+			expectBetaInOutput: true,
+			expectedBetaValue:  "max-tokens-3-5-sonnet-2024-07-15",
 		},
 	}
 
@@ -546,11 +542,11 @@ func TestAnthropicToGCPAnthropicTranslator_RequestBody_StripsStructuredOutputsBe
 				}
 			}
 
-			if tt.expectBetaHeader {
-				assert.True(t, foundBeta, "expected anthropic-beta header in response")
+			if tt.expectBetaInOutput {
+				require.True(t, foundBeta, "expected anthropic-beta in returned headers")
 				assert.Equal(t, tt.expectedBetaValue, betaValue)
 			} else {
-				assert.False(t, foundBeta, "did not expect anthropic-beta header in response")
+				assert.False(t, foundBeta, "no anthropic-beta in request, so none in output")
 			}
 		})
 	}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -86,6 +86,13 @@ type ResponseRedactor interface {
 	RedactBody(resp *openai.ChatCompletionResponse) *openai.ChatCompletionResponse
 }
 
+// RequestHeadersAware is an optional interface that translators can implement
+// to receive request headers before translation. This allows translators to
+// modify headers (e.g., stripping unsupported beta values) during translation.
+type RequestHeadersAware interface {
+	SetRequestHeaders(headers map[string]string)
+}
+
 // AnthropicResponseRedactor is an optional interface that Anthropic translators
 // can implement to support response body redaction for debug logging.
 type AnthropicResponseRedactor interface {


### PR DESCRIPTION
**Description**

When we use claude code with ai-gateway, it would treat ai-gateway as first-party provider, and would send requests with structured output. However, gcp does not support this now it would return 
1) "Unexpected value(s) `structured-outputs-2025-12-15` for the `anthropic-beta` header.
2) "output_config: Extra inputs are not permitted" for the request body.

Thus, it might be better for us to remove the headers and the filed related with structured output for message api on gcp.

verified tests:
```
Test 1: Beta header stripping                                                                                                            
                                                                                                                                         
  curl -s -X POST http://localhost:8080/anthropic/v1/messages \                                                                            
    -H "Content-Type: application/json" \                                                                                                  
    -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: structured-outputs-2025-12-15" \
    -d '{"model": "claude-sonnet-4", "max_tokens": 50, "messages": [{"role": "user", "content": "say hi in one word"}]}'
  Result: ✅ Success (200 OK with response)

  ---
  Test 2: Body stripping (output_config.format)

  curl -s -X POST http://localhost:8080/anthropic/v1/messages \
    -H "Content-Type: application/json" \
    -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: structured-outputs-2025-12-15" \
    -d '{"model": "claude-sonnet-4", "max_tokens": 50, "messages": [{"role": "user", "content": "say hi in one word"}],
  "output_config": {"format": {"type": "json_schema", "json_schema": {"name": "test", "schema": {"type": "object"}}}}}'
  Result: ✅ Success (200 OK with response)

  ---
  Test 3: Multiple beta values (verify other betas preserved)

  curl -s -X POST http://localhost:8080/anthropic/v1/messages \
    -H "Content-Type: application/json" \
    -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: max-tokens-3-5-sonnet-2024-07-15,structured-outputs-2025-12-15" \
    -d '{"model": "claude-sonnet-4", "max_tokens": 50, "messages": [{"role": "user", "content": "say hi"}]}'
  Result: ✅ GCP rejected with "Unexpected value(s) max-tokens-3-5-sonnet-2024-07-15" — proving that max-tokens was preserved and
  structured-outputs was stripped

  ---
  Test 4: Both beta header AND body together

  curl -s -X POST http://localhost:8080/anthropic/v1/messages \
    -H "Content-Type: application/json" \
    -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: structured-outputs-2025-12-15" \
    -d '{"model": "claude-sonnet-4", "max_tokens": 50, "messages": [{"role": "user", "content": "say hi"}], "output_config": {"format":
   {"type": "json_schema", "json_schema": {"name": "test", "schema": {"type": "object"}}}}}'
  Result: ✅ Success (200 OK with response)
````

