### PR TITLE
build: upgrade to Go 1.26.2 to fix CVEs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG VARIANT=static
 ARG COMMAND_NAME
 
 # Base image configuration
-ARG GOLANG_BASE_IMAGE=golang:1.25
+ARG GOLANG_BASE_IMAGE=golang:1.26
 ARG RUNTIME_BASE_IMAGE=gcr.io/distroless/${VARIANT}-debian12:nonroot
 
 # Pre-download Envoy for aigw using func-e. This reduces latency and avoids

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
 
   # chat-completion is a simple curl-based test client for sending requests to aigw.
   chat-completion:
-    image: golang:1.25
+    image: golang:1.26
     container_name: chat-completion
     profiles: ["test"]
     env_file:
@@ -87,7 +87,7 @@ services:
 
   # completion is a simple curl-based test client for sending completion requests to aigw.
   completion:
-    image: golang:1.25
+    image: golang:1.26
     container_name: completion
     profiles: ["test"]
     env_file:
@@ -111,7 +111,7 @@ services:
 
   # embeddings is a simple curl-based test client for sending embeddings requests to aigw.
   embeddings:
-    image: golang:1.25
+    image: golang:1.26
     container_name: embeddings
     profiles: ["test"]
     env_file:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/envoyproxy/ai-gateway
 
 // Explicitly specify the Go patch version to be able to purge the CI cache correctly.
-go 1.25.8
+go 1.26.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/tests/data-plane/vcr/docker-compose-otel.yaml
+++ b/tests/data-plane/vcr/docker-compose-otel.yaml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   extproc-build:
-    image: golang:1.25
+    image: golang:1.26
     container_name: extproc-build
     working_dir: /workspace
     volumes:

--- a/tests/data-plane/vcr/docker-compose.yaml
+++ b/tests/data-plane/vcr/docker-compose.yaml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   extproc-build:
-    image: golang:1.25
+    image: golang:1.26
     container_name: extproc-build
     working_dir: /workspace
     volumes:
@@ -66,7 +66,7 @@ services:
     command: ["envoy", "-c", "/etc/envoy/envoy.yaml", "--log-level", "debug"]
 
   openai-client:
-    image: golang:1.25
+    image: golang:1.26
     container_name: openai-client
     profiles: ["test"]
     env_file:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ai-gateway/tools
 
-go 1.25.8
+go 1.26.2
 
 tool (
 	github.com/apache/skywalking-eyes/cmd/license-eye


### PR DESCRIPTION
**Description**

Go 1.25.9 and 1.26.2 fix several low CVEs and one high one. This PR upgrades to Go 1.26.2.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

N/A