### PR TITLE
feat: add response model metadata

### DIFF
--- a/examples/access-log/basic.yaml
+++ b/examples/access-log/basic.yaml
@@ -51,7 +51,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/examples/aigw/ollama.yaml
+++ b/examples/aigw/ollama.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/examples/mcp/openai-github.yaml
+++ b/examples/mcp/openai-github.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/config.yaml.tmpl
+++ b/internal/autoconfig/config.yaml.tmpl
@@ -6,7 +6,7 @@
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/anthropic.yaml
+++ b/internal/autoconfig/testdata/anthropic.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/azure-openai-with-org-and-project.yaml
+++ b/internal/autoconfig/testdata/azure-openai-with-org-and-project.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/azure-openai.yaml
+++ b/internal/autoconfig/testdata/azure-openai.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/debug.yaml
+++ b/internal/autoconfig/testdata/debug.yaml
@@ -59,7 +59,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/kiwi.yaml
+++ b/internal/autoconfig/testdata/kiwi.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/llamastack.yaml
+++ b/internal/autoconfig/testdata/llamastack.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-github.yaml
+++ b/internal/autoconfig/testdata/openai-github.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-ip.yaml
+++ b/internal/autoconfig/testdata/openai-ip.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-otel-ip.yaml
+++ b/internal/autoconfig/testdata/openai-otel-ip.yaml
@@ -58,7 +58,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-otel.yaml
+++ b/internal/autoconfig/testdata/openai-otel.yaml
@@ -65,7 +65,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-with-org-and-project.yaml
+++ b/internal/autoconfig/testdata/openai-with-org-and-project.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-with-org.yaml
+++ b/internal/autoconfig/testdata/openai-with-org.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai-with-project.yaml
+++ b/internal/autoconfig/testdata/openai-with-project.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openai.yaml
+++ b/internal/autoconfig/testdata/openai.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/openrouter.yaml
+++ b/internal/autoconfig/testdata/openrouter.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/autoconfig/testdata/tars.yaml
+++ b/internal/autoconfig/testdata/tars.yaml
@@ -55,7 +55,7 @@ spec:
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
               # header-mapped attributes via OTEL_*_REQUEST_HEADER_ATTRIBUTES.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
-              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"

--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -528,7 +528,7 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) ProcessRespo
 	}
 
 	if body.EndOfStream && len(u.parent.config.RequestCosts) > 0 {
-		metadata, err := buildDynamicMetadata(u.parent.config, &u.costs, u.requestHeaders, u.backendName)
+		metadata, err := buildDynamicMetadata(u.parent.config, &u.costs, u.requestHeaders, u.backendName, responseModel)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build dynamic metadata: %w", err)
 		}
@@ -703,7 +703,7 @@ func mergeDynamicMetadata(base, extra *structpb.Struct) *structpb.Struct {
 // This function is called by the upstream filter only at the end of the stream (body.EndOfStream=true)
 // when the response is successfully completed. It is not called for failed requests or partial responses.
 // The metadata includes token usage costs and model information for downstream processing.
-func buildDynamicMetadata(config *filterapi.RuntimeConfig, costs *metrics.TokenUsage, requestHeaders map[string]string, backendName string) (*structpb.Struct, error) {
+func buildDynamicMetadata(config *filterapi.RuntimeConfig, costs *metrics.TokenUsage, requestHeaders map[string]string, backendName string, responseModel string) (*structpb.Struct, error) {
 	metadata := make(map[string]*structpb.Value, len(config.RequestCosts)+2)
 	for i := range config.RequestCosts {
 		rc := &config.RequestCosts[i]
@@ -756,6 +756,11 @@ func buildDynamicMetadata(config *filterapi.RuntimeConfig, costs *metrics.TokenU
 
 	if backendName != "" {
 		metadata["backend_name"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: backendName}}
+	}
+
+	// responseModel is the actual model that served the request.
+	if responseModel != "" {
+		metadata["response_model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: responseModel}}
 	}
 
 	if len(metadata) == 0 {

--- a/internal/extproc/processor_impl_test.go
+++ b/internal/extproc/processor_impl_test.go
@@ -271,6 +271,7 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 		mt := &mockTranslator{
 			t: t, expResponseBody: inBody,
 			retHeaderMutation: []internalapi.Header{{"foo", "bar"}},
+			retResponseModel:  internalapi.ResponseModel("some_model"),
 		}
 		mt.retUsedToken.SetOutputTokens(123)
 		mt.retUsedToken.SetInputTokens(1)
@@ -335,6 +336,7 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 			GetStructValue().Fields["cel_uint"].GetNumberValue())
 		require.Equal(t, "ai_gateway_llm", md.Fields[internalapi.AIGatewayFilterMetadataNamespace].GetStructValue().Fields["model_name_override"].GetStringValue())
 		require.Equal(t, "some_backend", md.Fields[internalapi.AIGatewayFilterMetadataNamespace].GetStructValue().Fields["backend_name"].GetStringValue())
+		require.Equal(t, "some_model", md.Fields[internalapi.AIGatewayFilterMetadataNamespace].GetStructValue().Fields["response_model"].GetStringValue())
 	})
 
 	// Verify we record failure for non-2xx responses and do it exactly once (defer suppressed).

--- a/site/docs/capabilities/observability/accesslogs.md
+++ b/site/docs/capabilities/observability/accesslogs.md
@@ -68,6 +68,7 @@ spec:
               # AI specific fields. The properties in the dynamic metadata expressions must match the ones
               # defined in the AIGatewayRoute llmRequestCosts field.
               gen_ai.request.model: "%REQ(X-AI-EG-MODEL)%"
+              gen_ai.response.model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
               gen_ai.request.model_override: "%DYNAMIC_METADATA(io.envoy.ai_gateway:model_name_override)%"
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.total_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"


### PR DESCRIPTION
**Description**

This PR adds the response model from the upstream response to the dynamic metadata. This gives the proxy access to the actual model serving the request, unaffected by mode name overrides or other backend routing changes.


**Related Issues/PRs (if applicable)**

Close #2044
