### PR TITLE
fix: prevent panic in extractSubject for malformed bearer Authorization header

### DIFF
--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -1228,6 +1228,9 @@ func extractSubject(r *http.Request) string {
 	if !strings.EqualFold(parts[0], "bearer") {
 		return ""
 	}
+	if len(parts) < 2 {
+		return ""
+	}
 
 	var claims jwt.RegisteredClaims
 	_, _, _ = jwt.NewParser().ParseUnverified(parts[1], &claims)

--- a/internal/mcpproxy/handlers_test.go
+++ b/internal/mcpproxy/handlers_test.go
@@ -1263,6 +1263,13 @@ func TestExtractSubject(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, extractSubject(req))
 	})
+
+	t.Run("bearer with no token", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/mcp", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "bearer")
+		require.Empty(t, extractSubject(req))
+	})
 }
 
 func TestExtractForwardHeaders(t *testing.T) {


### PR DESCRIPTION
**Description**

## Summary

This PR fixes a potential index out of bounds panic in `extractSubject` when the `Authorization` header contains a `bearer` scheme without a token. It adds a defensive length check and a corresponding test case in `handlers_test.go`.

---

## Fix

```go
// BEFORE
parts := strings.SplitN(authzHeader, " ", 2)
if !strings.EqualFold(parts[0], "bearer") {
    return ""
}
_, _, _ = jwt.NewParser().ParseUnverified(parts[1], &claims)


// AFTER
parts := strings.SplitN(authzHeader, " ", 2)
if !strings.EqualFold(parts[0], "bearer") {
    return ""
}
if len(parts) < 2 {
    return ""
}
_, _, _ = jwt.NewParser().ParseUnverified(parts[1], &claims)
```

---

## Verification

All unit tests pass locally with `go test ./internal/mcpproxy/...`, including the newly added case for `Authorization: bearer`. The change was also validated by confirming that malformed headers are handled gracefully without causing a panic.
