### PR TITLE
feat: add Lua filter to afterExtProcFilterPrefixes

### DIFF
--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -797,6 +797,7 @@ outer:
 var afterExtProcFilterPrefixes = []string{
 	egv1a1.EnvoyFilterExtProc.String(),
 	egv1a1.EnvoyFilterWasm.String(),
+	egv1a1.EnvoyFilterLua.String(),
 	egv1a1.EnvoyFilterRBAC.String(),
 	egv1a1.EnvoyFilterLocalRateLimit.String(),
 	egv1a1.EnvoyFilterRateLimit.String(),

--- a/internal/extensionserver/post_translate_modify_test.go
+++ b/internal/extensionserver/post_translate_modify_test.go
@@ -77,6 +77,16 @@ func TestInsertAIGatewayExtProcFilter(t *testing.T) {
 			expectedFilterCount: 4,
 		},
 		{
+			name: "insert before lua filter",
+			existingFilters: []*httpconnectionmanagerv3.HttpFilter{
+				{Name: "envoy.filters.http.fault"},
+				{Name: "envoy.filters.http.lua"},
+				{Name: "envoy.filters.http.router"},
+			},
+			expectedPosition:    1,
+			expectedFilterCount: 4,
+		},
+		{
 			name: "insert before rbac filter",
 			existingFilters: []*httpconnectionmanagerv3.HttpFilter{
 				{Name: "envoy.filters.http.fault"},


### PR DESCRIPTION
**Description**

Allow Lua filters configured via `EnvoyExtensionPolicy` to run after the AI Gateway ext_proc filter, consistent with how Wasm filters are already handled.

The `afterExtProcFilterPrefixes` slice controls which filters AIGW's ext_proc is inserted before. Wasm was already in this list, but Lua was missing, so Lua filters would end up running before AIGW's ext_proc rather than after it. This prevented users from using Lua scripts to act on AIGW metadata (e.g. the `x-ai-eg-model` header set by ext_proc).

This PR adds `EnvoyFilterLua` to `afterExtProcFilterPrefixes` in the same position as `EnvoyFilterWasm`, and adds a corresponding test case.

Note: This code was written with AI assistance (Claude Code).

**Related Issues/PRs (if applicable)**

Fixes #1469

**Special notes for reviewers (if applicable)**

The fix follows the exact same pattern used for `EnvoyFilterWasm` (line 799). `EnvoyFilterLua` is defined in the `egv1a1` package (`envoy.filters.http.lua`) so no new dependencies are introduced.