### PR TITLE
fix: remove hardcoded runAsUser/runAsGroup from extproc security context

### DIFF
--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -428,9 +428,7 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 			Drop: []corev1.Capability{"ALL"},
 		},
 		Privileged:   ptr.To(false),
-		RunAsGroup:   ptr.To(int64(65532)),
 		RunAsNonRoot: ptr.To(true),
-		RunAsUser:    ptr.To(int64(65532)),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -431,9 +431,7 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 			Drop: []corev1.Capability{"ALL"},
 		},
 		Privileged:   ptr.To(false),
-		RunAsGroup:   ptr.To(int64(65532)),
 		RunAsNonRoot: ptr.To(true),
-		RunAsUser:    ptr.To(int64(65532)),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/internal/controller/gateway_mutator_test.go
+++ b/internal/controller/gateway_mutator_test.go
@@ -97,6 +97,18 @@ func TestGatewayMutator_mutatePod(t *testing.T) {
 			},
 		},
 		{
+			name: "default security context does not set RunAsUser or RunAsGroup",
+			extprocTest: func(t *testing.T, container corev1.Container) {
+				require.NotNil(t, container.SecurityContext)
+				require.Nil(t, container.SecurityContext.RunAsUser,
+					"RunAsUser must not be hardcoded so platforms like OpenShift can assign their own UID")
+				require.Nil(t, container.SecurityContext.RunAsGroup,
+					"RunAsGroup must not be hardcoded so platforms like OpenShift can assign their own GID")
+				require.Equal(t, ptr.To(true), container.SecurityContext.RunAsNonRoot)
+				require.Equal(t, ptr.To(false), container.SecurityContext.AllowPrivilegeEscalation)
+			},
+		},
+		{
 			name:    "basic extproc container with MCPRoute",
 			needMCP: true,
 			extprocTest: func(t *testing.T, container corev1.Container) {


### PR DESCRIPTION
**Description**

The extproc container's default `SecurityContext` hardcoded `runAsUser: 65532`
and `runAsGroup: 65532`. On OpenShift clusters using the default `restricted-v2`
SCC, pod UIDs must fall within a namespace-allocated range (e.g.
`1001540000–1001549999`), so any hardcoded UID outside that range causes the
pod to be rejected with:

```
unable to validate against any security context constraint:
  provider restricted-v2: .initContainers[0].runAsUser: Invalid value: 65532:
  must be in the ranges: [1001540000, 1001549999]
```

`RunAsNonRoot: true` and `AllowPrivilegeEscalation: false` are sufficient to
enforce safe execution without pinning a specific UID — the platform assigns
one from its allocated range automatically.

Users who need a fixed UID can still set `kubernetesExtProc.SecurityContext`
explicitly in their `GatewayConfig`, which continues to take full precedence
(unchanged behaviour).

**Related Issues/PRs (if applicable)**

Fixes #2046

**Special notes for reviewers (if applicable)**

The existing override path (`kubernetesExtProc.SecurityContext != nil`) is
untouched. Only the hardcoded default values are removed.

> Note: I used Claude (AI) as a coding assistant. I fully understand and own
> all changes in this PR.