### PR TITLE
fix: ensure InferencePool metadata is assigned when metadata is nil

### DIFF
--- a/internal/extensionserver/inferencepool.go
+++ b/internal/extensionserver/inferencepool.go
@@ -133,17 +133,17 @@ func getInferencePoolByMetadata(meta *corev3.Metadata) *gwaiev1.InferencePool {
 // encoded as a string in the format: "namespace/name/serviceName/port".
 func buildEPPMetadataForCluster(cluster *clusterv3.Cluster, inferencePool *gwaiev1.InferencePool) {
 	// Initialize cluster metadata structure if not present.
-	buildEPPMetadata(cluster.Metadata, inferencePool)
+	cluster.Metadata = buildEPPMetadata(cluster.Metadata, inferencePool)
 }
 
 // buildMetadataForInferencePool adds InferencePool metadata to the route for reference by other components.
 func buildEPPMetadataForRoute(route *routev3.Route, inferencePool *gwaiev1.InferencePool) {
 	// Initialize route metadata structure if not present.
-	buildEPPMetadata(route.Metadata, inferencePool)
+	route.Metadata = buildEPPMetadata(route.Metadata, inferencePool)
 }
 
 // buildEPPMetadata adds InferencePool metadata to the given metadata structure.
-func buildEPPMetadata(metadata *corev3.Metadata, inferencePool *gwaiev1.InferencePool) {
+func buildEPPMetadata(metadata *corev3.Metadata, inferencePool *gwaiev1.InferencePool) *corev3.Metadata {
 	// Initialize cluster metadata structure if not present.
 	if metadata == nil {
 		metadata = &corev3.Metadata{}
@@ -179,6 +179,7 @@ func buildEPPMetadata(metadata *corev3.Metadata, inferencePool *gwaiev1.Inferenc
 			allowModeOverride,
 		),
 	)
+	return metadata
 }
 
 // buildClustersForInferencePoolEndpointPickers builds and returns a "STRICT_DNS" cluster

--- a/internal/extensionserver/inferencepool_test.go
+++ b/internal/extensionserver/inferencepool_test.go
@@ -7,7 +7,8 @@ package extensionserver
 
 import (
 	"testing"
-
+     
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
@@ -151,4 +152,22 @@ func TestBuildHTTPFilterForInferencePool_Defaults(t *testing.T) {
 	assert.Equal(t, extprocv3.ProcessingMode_FULL_DUPLEX_STREAMED, filter.ProcessingMode.RequestBodyMode)
 	assert.Equal(t, extprocv3.ProcessingMode_FULL_DUPLEX_STREAMED, filter.ProcessingMode.ResponseBodyMode)
 	assert.False(t, filter.AllowModeOverride)
+}
+
+func TestBuildEPPMetadataForCluster_NilMetadata(t *testing.T) {
+    cluster := &clusterv3.Cluster{
+        Metadata: nil,
+    }
+
+    pool := &gwaiev1.InferencePool{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      "test-pool",
+            Namespace: "default",
+        },
+    }
+
+    buildEPPMetadataForCluster(cluster, pool)
+
+    assert.NotNil(t, cluster.Metadata)
+    assert.NotNil(t, cluster.Metadata.FilterMetadata)
 }

--- a/internal/extensionserver/inferencepool_test.go
+++ b/internal/extensionserver/inferencepool_test.go
@@ -7,7 +7,7 @@ package extensionserver
 
 import (
 	"testing"
-     
+
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
@@ -155,19 +155,19 @@ func TestBuildHTTPFilterForInferencePool_Defaults(t *testing.T) {
 }
 
 func TestBuildEPPMetadataForCluster_NilMetadata(t *testing.T) {
-    cluster := &clusterv3.Cluster{
-        Metadata: nil,
-    }
+	cluster := &clusterv3.Cluster{
+		Metadata: nil,
+	}
 
-    pool := &gwaiev1.InferencePool{
-        ObjectMeta: metav1.ObjectMeta{
-            Name:      "test-pool",
-            Namespace: "default",
-        },
-    }
+	pool := &gwaiev1.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pool",
+			Namespace: "default",
+		},
+	}
 
-    buildEPPMetadataForCluster(cluster, pool)
+	buildEPPMetadataForCluster(cluster, pool)
 
-    assert.NotNil(t, cluster.Metadata)
-    assert.NotNil(t, cluster.Metadata.FilterMetadata)
+	assert.NotNil(t, cluster.Metadata)
+	assert.NotNil(t, cluster.Metadata.FilterMetadata)
 }


### PR DESCRIPTION
**Description**

## Summary

This PR fixes an issue where InferencePool metadata was not getting saved when the initial metadata was nil.
`buildEPPMetadata` was creating metadata, but since it wasn’t returned, the caller never stored it.

This change makes `buildEPPMetadata` return the metadata and ensures it is assigned back by the caller.

---

## Use Case

Clusters and routes created without existing metadata (which is the default case) were missing InferencePool metadata.

While debugging this, I found that `buildEPPMetadata` initializes metadata when it is nil, but the updated value wasn’t being returned. Because of that, the metadata was never actually set on the cluster/route.

As a result, the InferencePool reference was getting dropped and later code could not read it.

---

## Reproduction (Concrete Code Path)

This happens in the following flow:

1. A cluster/route is created with `Metadata = nil`
2. `buildEPPMetadataForCluster` / `buildEPPMetadataForRoute` is called
3. This calls `buildEPPMetadata(metadata, inferencePool)`
4. Inside it, metadata gets initialized and updated

Before this change:

* The updated metadata was not returned
* So the caller never assigned it back
* `Metadata` stayed nil

Because of this:

* `getInferencePoolByMetadata` could not find the InferencePool
* Downstream logic skipped processing

---

## Fix

### Before

```go
func buildEPPMetadata(metadata *corev3.Metadata, inferencePool *gwaiev1.InferencePool) {
    if metadata == nil {
        metadata = &corev3.Metadata{}
    }
}
```

### After

```go
func buildEPPMetadata(metadata *corev3.Metadata, inferencePool *gwaiev1.InferencePool) *corev3.Metadata {
    if metadata == nil {
        metadata = &corev3.Metadata{}
    }
    return metadata
}
```

Callers now assign it back:

```go
cluster.Metadata = buildEPPMetadata(cluster.Metadata, inferencePool)
route.Metadata = buildEPPMetadata(route.Metadata, inferencePool)
```

---

## Verification

All unit tests pass locally using `go test ./internal/extensionserver/...` . The change was verified by ensuring no regressions in existing behavior and that metadata initialization no longer gets dropped when initially nil.