### PR TITLE
fix: add Envoy route for Bedrock Titan embeddings in dataplane tests

### DIFF
--- a/tests/data-plane/envoy.yaml
+++ b/tests/data-plane/envoy.yaml
@@ -112,6 +112,15 @@ static_resources:
                             headers:
                               - name: x-ai-eg-model
                                 string_match:
+                                  exact: amazon.titan-embed-text-v2:0
+                          route:
+                            auto_host_rewrite: true
+                            cluster: aws_bedrock
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: x-ai-eg-model
+                                string_match:
                                   exact: o1
                           route:
                             auto_host_rewrite: true


### PR DESCRIPTION
**Description**

`TestWithRealProviders` exercises `POST /v1/embeddings` with model `amazon.titan-embed-text-v2:0` against the aws-bedrock backend. The data-plane test Envoy config routes by exact `x-ai-eg-model` match to a cluster. That model had no matching route, so requests never reached Bedrock and the client saw HTTP 404 until the test timed out—breaking the embeddings health check and anything that depends on that job (e.g. release CI).

Add an Envoy route mapping amazon.titan-embed-text-v2:0 → aws_bedrock, consistent with other models already listed in tests/data-plane/envoy.yaml.

This change is test harness only (tests/data-plane/envoy.yaml); it does not alter production gateway routing.

Related Issues/PRs
#1969 