### PR TITLE
fix: avoid ownership of fields for updates

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -19,7 +19,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -27,7 +26,6 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -43,7 +41,6 @@ import (
 
 	aigv1a1 "github.com/envoyproxy/ai-gateway/api/v1alpha1"
 	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
-	aigwjson "github.com/envoyproxy/ai-gateway/internal/json"
 )
 
 func init() {
@@ -546,29 +543,10 @@ func newConditions(conditionType, message string) []metav1.Condition {
 }
 
 // aiGatewayControllerFinalizer is the name of the finalizer added to various AI Gateway resources.
-const (
-	aiGatewayControllerFinalizer  = "aigateway.envoyproxy.io/finalizer"
-	aiGatewayControllerFieldOwner = "aigateway-controller"
-)
-
-func patchFinalizersWithServerSideApply(ctx context.Context, c client.Client, o client.Object) error {
-	gvk, err := apiutil.GVKForObject(o, Scheme)
-	if err != nil {
-		return fmt.Errorf("failed to determine gvk for finalizer patch: %w", err)
-	}
-
-	o.GetObjectKind().SetGroupVersionKind(gvk)
-	o.SetManagedFields(nil)
-	data, err := aigwjson.Marshal(o)
-	if err != nil {
-		return fmt.Errorf("failed to marshal finalizer apply patch: %w", err)
-	}
-	return c.Patch(ctx, o, client.RawPatch(types.ApplyPatchType, data), client.ForceOwnership,
-		client.FieldOwner(aiGatewayControllerFieldOwner))
-}
+const aiGatewayControllerFinalizer = "aigateway.envoyproxy.io/finalizer"
 
 // handleFinalizer checks if the object has a deletion timestamp. If it does, it removes the finalizer and
-// calls the onDeletionFn if provided. Otherwise, it adds the finalizer to the object and patches it
+// calls the onDeletionFn if provided. Otherwise, it adds the finalizer to the object and updates it
 // so that the finalizer is persisted.
 //
 // onDeletionFn can be nil, in which case it will not be called. The function can return an error but should not
@@ -583,7 +561,7 @@ func handleFinalizer[objType client.Object](
 	if o.GetDeletionTimestamp().IsZero() {
 		if !ctrlutil.ContainsFinalizer(o, aiGatewayControllerFinalizer) {
 			ctrlutil.AddFinalizer(o, aiGatewayControllerFinalizer)
-			if err := patchFinalizersWithServerSideApply(ctx, client, o); err != nil {
+			if err := client.Update(ctx, o); err != nil {
 				// This shouldn't happen in normal operation, but if it does, we log the error.
 				logger.Error(err, "Failed to add finalizer to object",
 					"namespace", o.GetNamespace(), "name", o.GetName())
@@ -600,7 +578,7 @@ func handleFinalizer[objType client.Object](
 					"namespace", o.GetNamespace(), "name", o.GetName())
 			}
 		}
-		if err := patchFinalizersWithServerSideApply(ctx, client, o); err != nil {
+		if err := client.Update(ctx, o); err != nil {
 			// This shouldn't happen in normal operation, but if it does, we log the error.
 			logger.Error(err, "Failed to remove finalizer from object",
 				"namespace", o.GetNamespace(), "name", o.GetName())

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -517,7 +517,7 @@ func Test_handleFinalizer(t *testing.T) {
 		name               string
 		hasFinalizer       bool
 		hasDeletionTS      bool
-		clientPatchError   bool
+		clientUpdateError  bool
 		onDeletionFnError  bool
 		expectedOnDelete   bool
 		expectedFinalizers []string
@@ -531,10 +531,10 @@ func Test_handleFinalizer(t *testing.T) {
 			expectedFinalizers: []string{aiGatewayControllerFinalizer},
 		},
 		{
-			name:               "add finalizer to new object with patch error",
+			name:               "add finalizer to new object witt update error",
 			hasFinalizer:       false,
 			hasDeletionTS:      false,
-			clientPatchError:   true,
+			clientUpdateError:  true,
 			expectedOnDelete:   false,
 			expectedFinalizers: []string{aiGatewayControllerFinalizer},
 		},
@@ -563,10 +563,10 @@ func Test_handleFinalizer(t *testing.T) {
 			expectCallback:     true,
 		},
 		{
-			name:               "object being deleted, client patch error",
+			name:               "object being deleted, client update error",
 			hasFinalizer:       true,
 			hasDeletionTS:      true,
-			clientPatchError:   true,
+			clientUpdateError:  true,
 			expectedOnDelete:   true,
 			expectedFinalizers: []string{},
 			expectCallback:     true,
@@ -599,7 +599,7 @@ func Test_handleFinalizer(t *testing.T) {
 				}
 			}
 			onDelete := handleFinalizer(context.Background(),
-				&mockClient{patchErr: tc.clientPatchError}, logr.Discard(), obj, onDeletionFn)
+				&mockClient{updateErr: tc.clientUpdateError}, logr.Discard(), obj, onDeletionFn)
 			require.Equal(t, tc.expectedOnDelete, onDelete)
 			require.Equal(t, tc.expectedFinalizers, obj.Finalizers)
 			require.Equal(t, tc.expectCallback, callbackExecuted)
@@ -607,16 +607,16 @@ func Test_handleFinalizer(t *testing.T) {
 	}
 }
 
-// mockClients implements client.Client with a custom Patch method for testing purposes.
+// mockClients implements client.Client with a custom Update method for testing purposes.
 type mockClient struct {
 	client.Client
-	patchErr bool
+	updateErr bool
 }
 
-// Patch implements the client.Client interface for the mock client.
-func (m *mockClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
-	if m.patchErr {
-		return fmt.Errorf("mock patch error")
+// Updates implements the client.Client interface for the mock client.
+func (m *mockClient) Update(context.Context, client.Object, ...client.UpdateOption) error {
+	if m.updateErr {
+		return fmt.Errorf("mock update error")
 	}
 	return nil
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -531,7 +531,7 @@ func Test_handleFinalizer(t *testing.T) {
 			expectedFinalizers: []string{aiGatewayControllerFinalizer},
 		},
 		{
-			name:               "add finalizer to new object witt update error",
+			name:               "add finalizer to new object with update error",
 			hasFinalizer:       false,
 			hasDeletionTS:      false,
 			clientUpdateError:  true,


### PR DESCRIPTION
**Description**
PR #1930 introduced patchFinalizersWithServerSideApply which uses client.ForceOwnership with field owner aigateway-controller. While intended only to manage the finalizers field, the SSA call marshals the entire object, causing the controller to claim ownership of every field on the resource — including labels managed by Helm (helm.sh/chart, app.kubernetes.io/managed-by, etc.).

This breaks Helm-managed deployments. When users install AI Gateway resources (e.g. AIServiceBackend) via a Helm chart, subsequent helm upgrade operations fail with:


```
Apply failed with 1 conflict: conflict with "aigateway-controller":
.metadata.labels.helm.sh/chart
```

This commit restores the previous behavior using client.Update() to persist finalizers. 


**Related Issues/PRs (if applicable)**
reverts #1930 

**Special notes for reviewers (if applicable)**
The client.Update() is used for simplicity as I am not sure of a solid use case for forcing ownerships on resources hence preferring simplicity, that said if we have a use I am happy to explore options where ownership is claimed only for finalizers and not for the entire object.
