### PR TITLE
ci: declare contents:write on Release workflow's release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write # gh release create requires releases:write
+      contents: write # gh release create requires contents:write
     steps:
       - name: Set HELM_CHART_VERSION and TAG envs
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
     needs: [docker_push]
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release create requires releases:write
     steps:
       - name: Set HELM_CHART_VERSION and TAG envs
         run: |


### PR DESCRIPTION
**Description**

The `Release` workflow runs on tag push and has two jobs:

- `docker_push` -- calls the reusable `./.github/workflows/docker_build_job.yaml` workflow
- `release` -- runs `gh release create` (twice, branched on `-rc` suffix) to attach helm tarballs + the aigw binaries to the GitHub release

The `gh release create` API call needs `contents: write`. Right now there's no `permissions:` block on either the workflow or the `release` job, so the token gets whatever the repo default grants.

This patch adds `permissions: contents: write` at the `release` job (not at workflow scope) for two reasons:

1. `docker_push` is a reusable-workflow caller. Per GitHub docs on reusable workflows [1], a caller-level `permissions:` block intersects with the callee's grants. Keeping the new block on the `release` job leaves the callee's existing permissions story unchanged.
2. The `docker_push` callee already authenticates to DockerHub via `DOCKERHUB_PASSWORD` and `DOCKERHUB_USERNAME` (external secrets), so it doesn't need the workflow `GITHUB_TOKEN` for the push path.

Style matches the per-job permission blocks already used by `codeql.yaml` (`actions: read, contents: read, security-events: write`) and the workflow-level block in `build_and_test.yaml` (`contents: read, packages: write, id-token: write`).

No behavioural change. The release workflow continues to use `${{ secrets.GITHUB_TOKEN }}` for the two `gh release create` calls, just with the scope spelled out.

1: https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-and-permissions