### PR TITLE
fix: preserve inferencepool metadata on extension hooks

### DIFF
--- a/internal/extensionserver/extensionserver_test.go
+++ b/internal/extensionserver/extensionserver_test.go
@@ -1355,6 +1355,7 @@ func TestPostClusterModify(t *testing.T) {
 		require.NotNil(t, cluster.LbConfig)
 		require.Nil(t, cluster.LoadBalancingPolicy)
 		require.Nil(t, cluster.EdsClusterConfig)
+		require.NotNil(t, getInferencePoolByMetadata(cluster.Metadata))
 	})
 }
 
@@ -1419,6 +1420,7 @@ func TestPostRouteModify(t *testing.T) {
 		// Verify route was modified.
 		require.Equal(t, wrapperspb.Bool(false), route.GetRoute().GetAutoHostRewrite())
 		require.NotNil(t, route.TypedPerFilterConfig)
+		require.NotNil(t, getInferencePoolByMetadata(route.Metadata))
 	})
 
 	t.Run("with InferencePool extension and DirectResponse route action", func(t *testing.T) {

--- a/internal/extensionserver/inferencepool.go
+++ b/internal/extensionserver/inferencepool.go
@@ -130,24 +130,26 @@ func getInferencePoolByMetadata(meta *corev3.Metadata) *gwaiev1.InferencePool {
 }
 
 // buildMetadataForInferencePool adds InferencePool metadata to the cluster for reference by other components.
-// encoded as a string in the format: "namespace/name/serviceName/port".
+// encoded as a string in the format: "namespace/name/serviceName/port/bodyMode/allowModeOverride".
 func buildEPPMetadataForCluster(cluster *clusterv3.Cluster, inferencePool *gwaiev1.InferencePool) {
 	// Initialize cluster metadata structure if not present.
+	if cluster.Metadata == nil {
+		cluster.Metadata = &corev3.Metadata{}
+	}
 	buildEPPMetadata(cluster.Metadata, inferencePool)
 }
 
 // buildMetadataForInferencePool adds InferencePool metadata to the route for reference by other components.
 func buildEPPMetadataForRoute(route *routev3.Route, inferencePool *gwaiev1.InferencePool) {
 	// Initialize route metadata structure if not present.
+	if route.Metadata == nil {
+		route.Metadata = &corev3.Metadata{}
+	}
 	buildEPPMetadata(route.Metadata, inferencePool)
 }
 
 // buildEPPMetadata adds InferencePool metadata to the given metadata structure.
 func buildEPPMetadata(metadata *corev3.Metadata, inferencePool *gwaiev1.InferencePool) {
-	// Initialize cluster metadata structure if not present.
-	if metadata == nil {
-		metadata = &corev3.Metadata{}
-	}
 	if metadata.FilterMetadata == nil {
 		metadata.FilterMetadata = make(map[string]*structpb.Struct)
 	}


### PR DESCRIPTION
**Description**

PostClusterModify and PostRouteModify dropped InferencePool metadata when Envoy Gateway sent a cluster or route with nil Metadata. The helper allocated metadata, but only in a local pointer, so later InferencePool handling could not read it. Small fix, real footgun.

Repro:
1. Revert this patch, or apply only the added assertions.
2. Run `go test ./internal/extensionserver -run 'TestPost(Cluster|Route)Modify/with_InferencePool' -count=1`.
3. Both hook tests fail because getInferencePoolByMetadata returns nil.

This is reachable for normal InferencePool backendRefs; Metadata is optional in the Envoy proto and the repo example uses AIGatewayRoute to InferencePool. No cloud quota or provider API ceiling blocks this path.

Verification:
`go test ./internal/extensionserver -run 'TestPost(Cluster|Route)Modify/with_InferencePool' -count=1`
`go test ./internal/extensionserver`
`make test`
`make precommit`

**Related Issues/PRs (if applicable)**

Related PR: #2071

**Special notes for reviewers (if applicable)**

AI-assisted patch prep; I reviewed the code and own the change.