### PR TITLE
fix: guard nil Output in AWS Bedrock response translator to prevent ext-proc panic

### DIFF
--- a/internal/translator/openai_awsbedrock.go
+++ b/internal/translator/openai_awsbedrock.go
@@ -735,6 +735,17 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(_ map[string
 	if err = json.NewDecoder(body).Decode(&bedrockResp); err != nil {
 		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("failed to unmarshal body: %w", err)
 	}
+	// Bedrock can return HTTP 200 with a body that has no "output" field
+	// (e.g. Coral framework errors like UnknownOperationException, guardrail
+	// interventions, or empty/null responses). Guard the dereference so we
+	// surface a real error to the caller instead of panicking with a nil
+	// pointer dereference on bedrockResp.Output.Message below.
+	if bedrockResp.Output == nil {
+		return nil, nil, metrics.TokenUsage{}, responseModel, fmt.Errorf(
+			"bedrock response missing 'output' (stopReason=%q)",
+			ptr.Deref(bedrockResp.StopReason, ""),
+		)
+	}
 	openAIResp := &openai.ChatCompletionResponse{
 		// We use request model as response model since bedrock does not return the modelName in the response.
 		Model:   o.requestModel,


### PR DESCRIPTION
**Description**

When the upstream AWS Bedrock Converse response is decoded with no `output` field, the chat-completion translator dereferenced `bedrockResp.Output.Message.Role` and crashed the ext-proc with a nil pointer panic, taking down the gateway pod for the duration of the panic-loop.

This can happen on HTTP 200 responses in several real-world scenarios that the existing `ResponseError` path does not cover (it only runs on non-2xx):
- AWS Coral framework routing errors such as `UnknownOperationException` returned with HTTP 200 (e.g. when the upstream cluster is pointed at `bedrock.<region>.amazonaws.com` instead of `bedrock-runtime.<region>.amazonaws.com`).
- Guardrail / content-filter interventions where Bedrock omits `output.message`.
- Empty / `null` response bodies from misbehaving intermediaries.

This change adds a defensive nil-check on `bedrockResp.Output` immediately after the JSON decode and returns a descriptive error (including the Bedrock `stopReason` for diagnostics) instead of panicking.

**Related Issues/PRs (if applicable)**
N/A

**Special notes for reviewers (if applicable)**