### PR TITLE
feat: support hostname in aigateway route

### DIFF
--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -64,6 +64,13 @@ type AIGatewayRouteSpec struct {
 	// +optional
 	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
 
+	// Hostnames defines a set of hostnames that should be matched against the HTTP Host header
+	// before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxItems=16
+	Hostnames []gwapiv1.Hostname `json:"hostnames,omitempty"`
+
 	// Rules is the list of AIGatewayRouteRule that this AIGatewayRoute will match the traffic to.
 	// Each rule is a subset of the HTTPRoute in the Gateway API (https://gateway-api.sigs.k8s.io/api-types/httproute/).
 	//

--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -64,8 +64,11 @@ type AIGatewayRouteSpec struct {
 	// +optional
 	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
 
-	// Hostnames defines a set of hostnames that should be matched against the HTTP Host header
-	// before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+	// Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+	// used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+	// When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+	// for the details of the Hostnames field in the Gateway API.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -201,6 +201,11 @@ func (in *AIGatewayRouteSpec) DeepCopyInto(out *AIGatewayRouteSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Hostnames != nil {
+		in, out := &in.Hostnames, &out.Hostnames
+		*out = make([]v1.Hostname, len(*in))
+		copy(*out, *in)
+	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules
 		*out = make([]AIGatewayRouteRule, len(*in))

--- a/api/v1beta1/ai_gateway_route.go
+++ b/api/v1beta1/ai_gateway_route.go
@@ -64,6 +64,13 @@ type AIGatewayRouteSpec struct {
 	// +optional
 	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
 
+	// Hostnames defines a set of hostnames that should be matched against the HTTP Host header
+	// before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxItems=16
+	Hostnames []gwapiv1.Hostname `json:"hostnames,omitempty"`
+
 	// Rules is the list of AIGatewayRouteRule that this AIGatewayRoute will match the traffic to.
 	// Each rule is a subset of the HTTPRoute in the Gateway API (https://gateway-api.sigs.k8s.io/api-types/httproute/).
 	//

--- a/api/v1beta1/ai_gateway_route.go
+++ b/api/v1beta1/ai_gateway_route.go
@@ -64,8 +64,11 @@ type AIGatewayRouteSpec struct {
 	// +optional
 	ParentRefs []gwapiv1.ParentReference `json:"parentRefs,omitempty"`
 
-	// Hostnames defines a set of hostnames that should be matched against the HTTP Host header
-	// before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+	// Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+	// used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+	// When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+	// for the details of the Hostnames field in the Gateway API.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -201,6 +201,11 @@ func (in *AIGatewayRouteSpec) DeepCopyInto(out *AIGatewayRouteSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Hostnames != nil {
+		in, out := &in.Hostnames, &out.Hostnames
+		*out = make([]v1.Hostname, len(*in))
+		copy(*out, *in)
+	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules
 		*out = make([]AIGatewayRouteRule, len(*in))

--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -355,6 +355,8 @@ func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv
 	dst.Annotations[httpRouteAnnotationForAIGatewayGeneratedIndication] = "true"
 
 	dst.Spec.ParentRefs = aiGatewayRoute.Spec.ParentRefs
+
+	dst.Spec.Hostnames = append(dst.Spec.Hostnames, aiGatewayRoute.Spec.Hostnames...)
 	return nil
 }
 

--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -356,7 +356,7 @@ func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv
 
 	dst.Spec.ParentRefs = aiGatewayRoute.Spec.ParentRefs
 
-	dst.Spec.Hostnames = append(dst.Spec.Hostnames, aiGatewayRoute.Spec.Hostnames...)
+	dst.Spec.Hostnames = aiGatewayRoute.Spec.Hostnames
 	return nil
 }
 

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -558,24 +558,23 @@ func Test_newHTTPRoute_LabelAndAnnotationPropagation(t *testing.T) {
 func Test_newHTTPRoute_Hostnames_NotSet(t *testing.T) {
 	c := requireNewFakeClientWithIndexes(t)
 
-	// Minimal backend to satisfy newHTTPRoute validation.
-	backend := &aigv1a1.AIServiceBackend{
+	backend := &aigv1b1.AIServiceBackend{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-backend", Namespace: "test-ns"},
-		Spec: aigv1a1.AIServiceBackendSpec{
+		Spec: aigv1b1.AIServiceBackendSpec{
 			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend", Namespace: ptr.To(gwapiv1.Namespace("test-ns"))},
 		},
 	}
 	require.NoError(t, c.Create(context.Background(), backend))
 
-	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
+	aiGatewayRoute := &aigv1b1.AIGatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
 		},
-		Spec: aigv1a1.AIGatewayRouteSpec{
-			Rules: []aigv1a1.AIGatewayRouteRule{
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			Rules: []aigv1b1.AIGatewayRouteRule{
 				{
-					BackendRefs: []aigv1a1.AIGatewayRouteRuleBackendRef{
+					BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{
 						{Name: "test-backend", Weight: ptr.To[int32](100)},
 					},
 				},
@@ -594,32 +593,30 @@ func Test_newHTTPRoute_Hostnames_NotSet(t *testing.T) {
 	err := controller.newHTTPRoute(context.Background(), httpRoute, aiGatewayRoute)
 	require.NoError(t, err)
 
-	// Without spec.hostnames, Hostnames should remain empty.
 	require.Empty(t, httpRoute.Spec.Hostnames)
 }
 
 func Test_newHTTPRoute_Hostnames_Set(t *testing.T) {
 	c := requireNewFakeClientWithIndexes(t)
 
-	// Minimal backend to satisfy newHTTPRoute validation.
-	backend := &aigv1a1.AIServiceBackend{
+	backend := &aigv1b1.AIServiceBackend{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-backend", Namespace: "test-ns"},
-		Spec: aigv1a1.AIServiceBackendSpec{
+		Spec: aigv1b1.AIServiceBackendSpec{
 			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend", Namespace: ptr.To(gwapiv1.Namespace("test-ns"))},
 		},
 	}
 	require.NoError(t, c.Create(context.Background(), backend))
 
-	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
+	aiGatewayRoute := &aigv1b1.AIGatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
 		},
-		Spec: aigv1a1.AIGatewayRouteSpec{
+		Spec: aigv1b1.AIGatewayRouteSpec{
 			Hostnames: []gwapiv1.Hostname{"api.example.com", "*.example.net", "sub.example.com"},
-			Rules: []aigv1a1.AIGatewayRouteRule{
+			Rules: []aigv1b1.AIGatewayRouteRule{
 				{
-					BackendRefs: []aigv1a1.AIGatewayRouteRuleBackendRef{
+					BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{
 						{Name: "test-backend", Weight: ptr.To[int32](100)},
 					},
 				},

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -555,6 +555,93 @@ func Test_newHTTPRoute_LabelAndAnnotationPropagation(t *testing.T) {
 	require.Equal(t, "ann-value-2", httpRoute.Annotations["custom-annotation-2"])
 }
 
+func Test_newHTTPRoute_Hostnames_NotSet(t *testing.T) {
+	c := requireNewFakeClientWithIndexes(t)
+
+	// Minimal backend to satisfy newHTTPRoute validation.
+	backend := &aigv1a1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-backend", Namespace: "test-ns"},
+		Spec: aigv1a1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend", Namespace: ptr.To(gwapiv1.Namespace("test-ns"))},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), backend))
+
+	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+		Spec: aigv1a1.AIGatewayRouteSpec{
+			Rules: []aigv1a1.AIGatewayRouteRule{
+				{
+					BackendRefs: []aigv1a1.AIGatewayRouteRuleBackendRef{
+						{Name: "test-backend", Weight: ptr.To[int32](100)},
+					},
+				},
+			},
+		},
+	}
+
+	controller := &AIGatewayRouteController{client: c}
+	httpRoute := &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+	}
+
+	err := controller.newHTTPRoute(context.Background(), httpRoute, aiGatewayRoute)
+	require.NoError(t, err)
+
+	// Without spec.hostnames, Hostnames should remain empty.
+	require.Empty(t, httpRoute.Spec.Hostnames)
+}
+
+func Test_newHTTPRoute_Hostnames_Set(t *testing.T) {
+	c := requireNewFakeClientWithIndexes(t)
+
+	// Minimal backend to satisfy newHTTPRoute validation.
+	backend := &aigv1a1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-backend", Namespace: "test-ns"},
+		Spec: aigv1a1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend", Namespace: ptr.To(gwapiv1.Namespace("test-ns"))},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), backend))
+
+	aiGatewayRoute := &aigv1a1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+		Spec: aigv1a1.AIGatewayRouteSpec{
+			Hostnames: []gwapiv1.Hostname{"api.example.com", "*.example.net", "sub.example.com"},
+			Rules: []aigv1a1.AIGatewayRouteRule{
+				{
+					BackendRefs: []aigv1a1.AIGatewayRouteRuleBackendRef{
+						{Name: "test-backend", Weight: ptr.To[int32](100)},
+					},
+				},
+			},
+		},
+	}
+
+	controller := &AIGatewayRouteController{client: c, logger: logr.Discard()}
+	httpRoute := &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-ns",
+		},
+	}
+
+	err := controller.newHTTPRoute(context.Background(), httpRoute, aiGatewayRoute)
+	require.NoError(t, err)
+
+	expected := []gwapiv1.Hostname{"api.example.com", "*.example.net", "sub.example.com"}
+	require.Equal(t, expected, httpRoute.Spec.Hostnames)
+}
+
 func TestAIGatewayRouteController_syncGateways_NamespaceDetermination(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	eventCh := internaltesting.NewControllerEventChan[*gwapiv1.Gateway]()

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -367,6 +367,11 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		ec.GlobalLLMRequestCosts = append(ec.GlobalLLMRequestCosts, fc)
 	}
 
+	// Models contributed by routes with no Spec.Hostnames. We only promote these to
+	// ec.UnscopedModels (and merge them into ec.ModelsByHost) when at least one route
+	// IS hostname-scoped; otherwise the existing ec.Models list already covers them.
+	var unscopedModels []filterapi.Model
+
 	for i := range aiGatewayRoutes {
 		aiGatewayRoute := &aiGatewayRoutes[i]
 		if !aiGatewayRoute.GetDeletionTimestamp().IsZero() {
@@ -405,7 +410,9 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 						}
 					} else {
 						// Routes without hostnames are "unscoped": they apply to every host.
-						ec.UnscopedModels = append(ec.UnscopedModels, model)
+						// Tracked in unscopedModels for now; only promoted to ec.UnscopedModels
+						// after the loop if at least one scoped route is also present.
+						unscopedModels = append(unscopedModels, model)
 					}
 				}
 			}
@@ -496,13 +503,15 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		}
 	}
 
-	// Merge unscoped models into every per-host list so that a request matching a hostname-scoped route
-	// still sees the models from routes that didn't declare hostnames. Without this, a Gateway that mixes
-	// scoped and unscoped AIGatewayRoutes would silently hide the unscoped models from /v1/models on the
-	// scoped hosts. The unscoped fallback for unmatched hosts is handled by filterapi.RuntimeConfig.UnscopedModels.
-	if len(ec.ModelsByHost) > 0 && len(ec.UnscopedModels) > 0 {
+	// If at least one route is hostname-scoped, promote the unscoped models to ec.UnscopedModels
+	// so the runtime can fall back to them on unmatched hosts, and merge them into every per-host
+	// list so a host-matched request still sees the models from routes that didn't declare hostnames.
+	// When no route uses hostname scoping, ec.Models is the sole source of truth and we skip both
+	// steps to avoid serializing a redundant UnscopedModels duplicate of Models.
+	if len(ec.ModelsByHost) > 0 && len(unscopedModels) > 0 {
+		ec.UnscopedModels = unscopedModels
 		for hn := range ec.ModelsByHost {
-			ec.ModelsByHost[hn] = append(ec.ModelsByHost[hn], ec.UnscopedModels...)
+			ec.ModelsByHost[hn] = append(ec.ModelsByHost[hn], unscopedModels...)
 		}
 	}
 

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -403,6 +403,9 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 						for _, hn := range hostnames {
 							ec.ModelsByHost[string(hn)] = append(ec.ModelsByHost[string(hn)], model)
 						}
+					} else {
+						// Routes without hostnames are "unscoped": they apply to every host.
+						ec.UnscopedModels = append(ec.UnscopedModels, model)
 					}
 				}
 			}
@@ -490,6 +493,16 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 			for _, fc := range dedup {
 				ec.LLMRequestCosts = append(ec.LLMRequestCosts, fc)
 			}
+		}
+	}
+
+	// Merge unscoped models into every per-host list so that a request matching a hostname-scoped route
+	// still sees the models from routes that didn't declare hostnames. Without this, a Gateway that mixes
+	// scoped and unscoped AIGatewayRoutes would silently hide the unscoped models from /v1/models on the
+	// scoped hosts. The unscoped fallback for unmatched hosts is handled by filterapi.RuntimeConfig.UnscopedModels.
+	if len(ec.ModelsByHost) > 0 && len(ec.UnscopedModels) > 0 {
+		for hn := range ec.ModelsByHost {
+			ec.ModelsByHost[hn] = append(ec.ModelsByHost[hn], ec.UnscopedModels...)
 		}
 	}
 

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -375,6 +375,7 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		}
 		hasEffectiveRoute = true
 		routeName := fmt.Sprintf("%s/%s", aiGatewayRoute.Namespace, aiGatewayRoute.Name)
+		hostnames := aiGatewayRoute.Spec.Hostnames
 		spec := aiGatewayRoute.Spec
 		routeBackendNamesSet := map[string]struct{}{}
 		routeBackendNames := []string{}
@@ -389,11 +390,20 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 					if (h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact) || string(h.Name) != internalapi.ModelNameHeaderKeyDefault {
 						continue
 					}
-					ec.Models = append(ec.Models, filterapi.Model{
+					model := filterapi.Model{
 						Name:      h.Value,
 						CreatedAt: ptr.Deref[metav1.Time](rule.ModelsCreatedAt, aiGatewayRoute.CreationTimestamp).UTC(),
 						OwnedBy:   ptr.Deref(rule.ModelsOwnedBy, defaultOwnedBy),
-					})
+					}
+					ec.Models = append(ec.Models, model)
+					if len(hostnames) > 0 {
+						if ec.ModelsByHost == nil {
+							ec.ModelsByHost = make(map[string][]filterapi.Model)
+						}
+						for _, hn := range hostnames {
+							ec.ModelsByHost[string(hn)] = append(ec.ModelsByHost[string(hn)], model)
+						}
+					}
 				}
 			}
 			for backendRefIndex := range rule.BackendRefs {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -417,6 +417,62 @@ func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *t
 	require.ElementsMatch(t, []string{"scoped-model", "unscoped-model"}, gotHostModels)
 }
 
+// TestGatewayController_reconcileFilterConfigSecret_AllUnscopedRoutesLeaveUnscopedModelsEmpty
+// regression-locks the gate added to avoid duplicating Models into UnscopedModels when no route is
+// hostname-scoped. Without the gate, every existing golden YAML that didn't expect an
+// `unscopedModels:` field would break (as Test_translate did when this gate was missing).
+func TestGatewayController_reconcileFilterConfigSecret_AllUnscopedRoutesLeaveUnscopedModelsEmpty(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
+	c := NewGatewayController(fakeClient, kube, ctrl.Log,
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	const gwNamespace = "ns"
+	routes := []aigv1b1.AIGatewayRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "route-only-unscoped", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				// No Hostnames — and no other route adds Hostnames either.
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "lone-model"},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: gwNamespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+		},
+	}))
+
+	const someNamespace = "some-namespace"
+	configName := FilterConfigSecretPerGatewayName("gw-unscoped-only", gwNamespace)
+	effective, err := c.reconcileFilterConfigSecret(t.Context(), configName, someNamespace, routes, nil, "foouuid", nil)
+	require.NoError(t, err)
+	require.True(t, effective)
+
+	secret, err := kube.CoreV1().Secrets(someNamespace).Get(t.Context(), configName, metav1.GetOptions{})
+	require.NoError(t, err)
+	var fc filterapi.Config
+	require.NoError(t, yaml.Unmarshal([]byte(secret.StringData[FilterConfigKeyInSecret]), &fc))
+
+	require.Len(t, fc.Models, 1)
+	require.Equal(t, "lone-model", fc.Models[0].Name)
+	// Critical: with no scoped routes, ModelsByHost must be empty AND UnscopedModels must stay nil
+	// so it's omitted from the marshalled YAML (omitempty).
+	require.Empty(t, fc.ModelsByHost)
+	require.Nil(t, fc.UnscopedModels)
+}
+
 // TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostAggregation verifies that
 // routes sharing the same metadataKey each get their own filter-config row (scoped by routeName).
 func TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostAggregation(t *testing.T) {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -319,6 +319,104 @@ func TestGatewayController_reconcileFilterConfigSecret(t *testing.T) {
 	}
 }
 
+// TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels verifies that mixing routes
+// with and without Spec.Hostnames produces a filter config where:
+//   - each per-host list contains the host's own models AND every unscoped model (so the unscoped
+//     route's models remain visible on host-matched /v1/models requests), and
+//   - UnscopedModels is populated separately so unmatched hosts can fall back to it without leaking
+//     host-scoped models.
+func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
+	c := NewGatewayController(fakeClient, kube, ctrl.Log,
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	const gwNamespace = "ns"
+	routes := []aigv1b1.AIGatewayRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "scoped-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Hostnames: []gwapiv1.Hostname{"api.example.com"},
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "scoped-model"},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "unscoped-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				// No Hostnames -> "unscoped": its models apply to every host.
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "orange"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "unscoped-model"},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, b := range []*aigv1b1.AIServiceBackend{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: gwNamespace},
+			Spec: aigv1b1.AIServiceBackendSpec{
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: gwNamespace},
+			Spec: aigv1b1.AIServiceBackendSpec{
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+			},
+		},
+	} {
+		require.NoError(t, fakeClient.Create(t.Context(), b))
+	}
+
+	const someNamespace = "some-namespace"
+	configName := FilterConfigSecretPerGatewayName("gw-hostname", gwNamespace)
+	effective, err := c.reconcileFilterConfigSecret(t.Context(), configName, someNamespace, routes, nil, "foouuid", nil)
+	require.NoError(t, err)
+	require.True(t, effective, "expected filter config to be effective")
+
+	secret, err := kube.CoreV1().Secrets(someNamespace).Get(t.Context(), configName, metav1.GetOptions{})
+	require.NoError(t, err)
+	configStr, ok := secret.StringData[FilterConfigKeyInSecret]
+	require.True(t, ok)
+	var fc filterapi.Config
+	require.NoError(t, yaml.Unmarshal([]byte(configStr), &fc))
+
+	// Global Models list still contains every model (used as fallback when no ModelsByHost is configured).
+	require.ElementsMatch(t,
+		[]string{"scoped-model", "unscoped-model"},
+		[]string{fc.Models[0].Name, fc.Models[1].Name},
+	)
+
+	// UnscopedModels only holds the route-without-hostnames contribution.
+	require.Len(t, fc.UnscopedModels, 1)
+	require.Equal(t, "unscoped-model", fc.UnscopedModels[0].Name)
+
+	// ModelsByHost["api.example.com"] should have BOTH the scoped model and the merged-in unscoped
+	// model — otherwise the unscoped route's models would silently disappear on host-matched requests.
+	require.Contains(t, fc.ModelsByHost, "api.example.com")
+	gotHostModels := make([]string, 0, len(fc.ModelsByHost["api.example.com"]))
+	for _, m := range fc.ModelsByHost["api.example.com"] {
+		gotHostModels = append(gotHostModels, m.Name)
+	}
+	require.ElementsMatch(t, []string{"scoped-model", "unscoped-model"}, gotHostModels)
+}
+
 // TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostAggregation verifies that
 // routes sharing the same metadataKey each get their own filter-config row (scoped by routeName).
 func TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostAggregation(t *testing.T) {

--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -34,23 +35,27 @@ type modelsProcessor struct {
 var _ Processor = (*modelsProcessor)(nil)
 
 // NewModelsProcessor creates a new processor that returns the list of declared models.
-func NewModelsProcessor(config *filterapi.RuntimeConfig, _ map[string]string, logger *slog.Logger, isUpstreamFilter bool, _ bool) (Processor, error) {
+func NewModelsProcessor(config *filterapi.RuntimeConfig, requestHeaders map[string]string, logger *slog.Logger, isUpstreamFilter bool, _ bool) (Processor, error) {
 	if isUpstreamFilter {
 		return passThroughProcessor{}, nil
 	}
-	models := openai.ModelList{
+
+	host := requestHost(requestHeaders)
+	selectedModels := selectModelsForHost(host, config)
+
+	modelList := openai.ModelList{
 		Object: "list",
-		Data:   make([]openai.Model, 0, len(config.DeclaredModels)),
+		Data:   make([]openai.Model, 0, len(selectedModels)),
 	}
-	for _, m := range config.DeclaredModels {
-		models.Data = append(models.Data, openai.Model{
+	for _, m := range selectedModels {
+		modelList.Data = append(modelList.Data, openai.Model{
 			ID:      m.Name,
 			Object:  "model",
 			OwnedBy: m.OwnedBy,
 			Created: openai.JSONUNIXTime(m.CreatedAt),
 		})
 	}
-	return &modelsProcessor{logger: logger, models: models}, nil
+	return &modelsProcessor{logger: logger.With("host", host), models: modelList}, nil
 }
 
 // ProcessRequestHeaders implements [Processor.ProcessRequestHeaders].
@@ -83,4 +88,52 @@ func setHeader(headers *extprocv3.HeaderMutation, key, value string) {
 			RawValue: []byte(value),
 		},
 	})
+}
+
+// requestHost normalizes the host/authority header for matching (lowercases and strips port).
+func requestHost(headers map[string]string) string {
+	host := headers[":authority"]
+	if host == "" {
+		host = headers["host"]
+	}
+	if host == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(host, ':'); idx != -1 {
+		host = host[:idx]
+	}
+	return strings.ToLower(host)
+}
+
+// selectModelsForHost returns the models for the given host, falling back to the global list.
+func selectModelsForHost(host string, cfg *filterapi.RuntimeConfig) []filterapi.Model {
+	if host == "" || len(cfg.ModelsByHost) == 0 {
+		return cfg.DeclaredModels
+	}
+
+	if exact, ok := cfg.ModelsByHost[host]; ok {
+		return exact
+	}
+
+	bestMatchLength := -1
+	var bestMatchModels []filterapi.Model
+	for pattern, models := range cfg.ModelsByHost {
+		if !strings.HasPrefix(pattern, "*.") {
+			continue
+		}
+		suffix := strings.TrimPrefix(pattern, "*.")
+		// Wildcard hostnames only match subdomains with a label boundary.
+		// Example: "*.bentoml.com" matches "api.bentoml.com" but not "bentoml.com" or "evilbentoml.com".
+		if strings.HasSuffix(host, "."+suffix) {
+			if len(suffix) > bestMatchLength {
+				bestMatchLength = len(suffix)
+				bestMatchModels = models
+			}
+		}
+	}
+	if bestMatchModels != nil {
+		return bestMatchModels
+	}
+
+	return []filterapi.Model{}
 }

--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -99,8 +100,8 @@ func requestHost(headers map[string]string) string {
 	if host == "" {
 		return ""
 	}
-	if idx := strings.IndexByte(host, ':'); idx != -1 {
-		host = host[:idx]
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
 	}
 	return strings.ToLower(host)
 }
@@ -135,5 +136,8 @@ func selectModelsForHost(host string, cfg *filterapi.RuntimeConfig) []filterapi.
 		return bestMatchModels
 	}
 
+	// When ModelsByHost is configured, an unmatched host returns an empty list
+	// rather than falling back to DeclaredModels: hostname scoping is opt-in,
+	// and leaking the global model list to unknown hosts would defeat it.
 	return []filterapi.Model{}
 }

--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -123,21 +123,28 @@ func selectModelsForHost(host string, cfg *filterapi.RuntimeConfig) []filterapi.
 			continue
 		}
 		suffix := strings.TrimPrefix(pattern, "*.")
-		// Wildcard hostnames only match subdomains with a label boundary.
-		// Example: "*.bentoml.com" matches "api.bentoml.com" but not "bentoml.com" or "evilbentoml.com".
-		if strings.HasSuffix(host, "."+suffix) {
-			if len(suffix) > bestMatchLength {
-				bestMatchLength = len(suffix)
-				bestMatchModels = models
-			}
+		// Per the Gateway API spec, a wildcard label matches exactly one DNS label, not multiple.
+		// "*.bentoml.com" matches "api.bentoml.com" but NOT "foo.api.bentoml.com", "bentoml.com",
+		// or "evilbentoml.com". Verify both the label boundary and that the prefix is a single label.
+		if !strings.HasSuffix(host, "."+suffix) {
+			continue
+		}
+		prefix := strings.TrimSuffix(host, "."+suffix)
+		if strings.Contains(prefix, ".") {
+			continue
+		}
+		if len(suffix) > bestMatchLength {
+			bestMatchLength = len(suffix)
+			bestMatchModels = models
 		}
 	}
 	if bestMatchModels != nil {
 		return bestMatchModels
 	}
 
-	// When ModelsByHost is configured, an unmatched host returns an empty list
-	// rather than falling back to DeclaredModels: hostname scoping is opt-in,
-	// and leaking the global model list to unknown hosts would defeat it.
-	return []filterapi.Model{}
+	// Unmatched host: fall back to UnscopedModels (models from routes that didn't declare hostnames).
+	// We do NOT fall back to DeclaredModels because hostname scoping is opt-in — leaking host-scoped
+	// models to unknown hosts would defeat the purpose. UnscopedModels is nil when every route is
+	// scoped, which correctly degrades to an empty list.
+	return cfg.UnscopedModels
 }

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -68,3 +68,68 @@ func headers(in []*corev3.HeaderValueOption) map[string]string {
 	}
 	return h
 }
+
+func Test_selectModelsForHost(t *testing.T) {
+	defaultModels := []filterapi.Model{{Name: "default"}}
+	exactModels := []filterapi.Model{{Name: "exact"}}
+	wildcardComModels := []filterapi.Model{{Name: "wildcard-com"}}
+	wildcardBentomlModels := []filterapi.Model{{Name: "wildcard-bentoml"}}
+
+	cfg := &filterapi.RuntimeConfig{
+		DeclaredModels: defaultModels,
+		ModelsByHost: map[string][]filterapi.Model{
+			"api.bentoml.com":   exactModels,
+			"*.com":             wildcardComModels,
+			"*.bentoml.com":     wildcardBentomlModels,
+			"not-a-pattern.com": {{Name: "ignored"}},
+		},
+	}
+
+	tests := []struct {
+		name string
+		host string
+		want []filterapi.Model
+	}{
+		{
+			name: "exact match wins",
+			host: "api.bentoml.com",
+			want: exactModels,
+		},
+		{
+			name: "wildcard match with label boundary",
+			host: "chat.bentoml.com",
+			want: wildcardBentomlModels,
+		},
+		{
+			name: "more specific wildcard wins",
+			host: "foo.bentoml.com",
+			want: wildcardBentomlModels,
+		},
+		{
+			name: "wildcard does not match apex",
+			host: "bentoml.com",
+			want: wildcardComModels,
+		},
+		{
+			name: "wildcard does not match missing boundary",
+			host: "evilbentoml.com",
+			want: wildcardComModels,
+		},
+		{
+			name: "fallback to default when no match",
+			host: "localhost",
+			want: []filterapi.Model{},
+		},
+		{
+			name: "empty host falls back to default",
+			host: "",
+			want: defaultModels,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, selectModelsForHost(tt.host, cfg))
+		})
+	}
+}

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -116,7 +116,7 @@ func Test_selectModelsForHost(t *testing.T) {
 			want: wildcardComModels,
 		},
 		{
-			name: "fallback to default when no match",
+			name: "returns empty list when host has no match",
 			host: "localhost",
 			want: []filterapi.Model{},
 		},

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -69,6 +69,62 @@ func headers(in []*corev3.HeaderValueOption) map[string]string {
 	return h
 }
 
+func Test_requestHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name: "prefers :authority over host",
+			headers: map[string]string{
+				":authority": "Api.Bentoml.COM",
+				"host":       "should-be-ignored.example.com",
+			},
+			want: "api.bentoml.com",
+		},
+		{
+			name:    "falls back to host header when :authority is missing",
+			headers: map[string]string{"host": "API.example.com"},
+			want:    "api.example.com",
+		},
+		{
+			name:    "strips port for IPv4 / hostname authorities",
+			headers: map[string]string{":authority": "api.bentoml.com:8443"},
+			want:    "api.bentoml.com",
+		},
+		{
+			name: "strips port for bracketed IPv6 authority (the case net.SplitHostPort fixes)",
+			// Before the SplitHostPort change, `strings.IndexByte(host, ':')` would have
+			// truncated this to `[2001` and ToLower-ed it — a clearly broken result. Lock
+			// the correct behaviour in.
+			headers: map[string]string{":authority": "[2001:db8::1]:8443"},
+			want:    "2001:db8::1",
+		},
+		{
+			name:    "leaves unbracketed IPv6 alone (SplitHostPort fails, fallback returns the raw value lowercased)",
+			headers: map[string]string{":authority": "2001:db8::1"},
+			want:    "2001:db8::1",
+		},
+		{
+			name:    "returns empty when neither :authority nor host is present",
+			headers: map[string]string{},
+			want:    "",
+		},
+		{
+			name:    "nil headers map",
+			headers: nil,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, requestHost(tt.headers))
+		})
+	}
+}
+
 func Test_selectModelsForHost(t *testing.T) {
 	defaultModels := []filterapi.Model{{Name: "default"}}
 	unscopedModels := []filterapi.Model{{Name: "unscoped"}}

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -71,12 +71,14 @@ func headers(in []*corev3.HeaderValueOption) map[string]string {
 
 func Test_selectModelsForHost(t *testing.T) {
 	defaultModels := []filterapi.Model{{Name: "default"}}
+	unscopedModels := []filterapi.Model{{Name: "unscoped"}}
 	exactModels := []filterapi.Model{{Name: "exact"}}
 	wildcardComModels := []filterapi.Model{{Name: "wildcard-com"}}
 	wildcardBentomlModels := []filterapi.Model{{Name: "wildcard-bentoml"}}
 
 	cfg := &filterapi.RuntimeConfig{
 		DeclaredModels: defaultModels,
+		UnscopedModels: unscopedModels,
 		ModelsByHost: map[string][]filterapi.Model{
 			"api.bentoml.com":   exactModels,
 			"*.com":             wildcardComModels,
@@ -116,12 +118,21 @@ func Test_selectModelsForHost(t *testing.T) {
 			want: wildcardComModels,
 		},
 		{
-			name: "returns empty list when host has no match",
-			host: "localhost",
-			want: []filterapi.Model{},
+			// Per Gateway API spec, "*.bentoml.com" matches exactly one label, so a
+			// multi-label subdomain ("foo.api.bentoml.com") must NOT match it. "*.com"
+			// likewise must not match it. With no wildcard matching, we fall back to
+			// the unscoped models.
+			name: "wildcard does not match multi-label subdomain",
+			host: "foo.api.bentoml.com",
+			want: unscopedModels,
 		},
 		{
-			name: "empty host falls back to default",
+			name: "unmatched host falls back to unscoped models",
+			host: "localhost",
+			want: unscopedModels,
+		},
+		{
+			name: "empty host falls back to declared (all) models",
 			host: "",
 			want: defaultModels,
 		},
@@ -132,4 +143,17 @@ func Test_selectModelsForHost(t *testing.T) {
 			require.Equal(t, tt.want, selectModelsForHost(tt.host, cfg))
 		})
 	}
+
+	t.Run("no unscoped models: unmatched host returns nil", func(t *testing.T) {
+		// When every route is hostname-scoped, UnscopedModels is nil and an unmatched
+		// host returns nil (treated as empty by the /v1/models endpoint). This preserves
+		// the "no leak to unknown hosts" guarantee.
+		scopedOnly := &filterapi.RuntimeConfig{
+			DeclaredModels: defaultModels,
+			ModelsByHost: map[string][]filterapi.Model{
+				"api.bentoml.com": exactModels,
+			},
+		}
+		require.Nil(t, selectModelsForHost("localhost", scopedOnly))
+	})
 }

--- a/internal/filterapi/filterconfig.go
+++ b/internal/filterapi/filterconfig.go
@@ -41,6 +41,9 @@ type Config struct {
 	Backends []Backend `json:"backends,omitempty"`
 	// Models is the list of models that this route is aware of. Used to populate the "/models" endpoint in OpenAI-compatible APIs.
 	Models []Model `json:"models,omitempty"`
+	// ModelsByHost is the list of models keyed by hostname. When present, the extproc "/v1/models" processor will prefer
+	// the hostname-specific list over the global Models slice.
+	ModelsByHost map[string][]Model `json:"modelsByHost,omitempty"`
 	// MCPConfig is the configuration for the MCPRoute implementations.
 	MCPConfig *MCPConfig `json:"mcpConfig,omitempty"`
 }

--- a/internal/filterapi/filterconfig.go
+++ b/internal/filterapi/filterconfig.go
@@ -42,8 +42,13 @@ type Config struct {
 	// Models is the list of models that this route is aware of. Used to populate the "/models" endpoint in OpenAI-compatible APIs.
 	Models []Model `json:"models,omitempty"`
 	// ModelsByHost is the list of models keyed by hostname. When present, the extproc "/v1/models" processor will prefer
-	// the hostname-specific list over the global Models slice.
+	// the hostname-specific list over the global Models slice. Each per-host list also includes UnscopedModels so that
+	// routes without hostname scoping remain visible alongside the host-specific routes.
 	ModelsByHost map[string][]Model `json:"modelsByHost,omitempty"`
+	// UnscopedModels is the list of models contributed by routes that did NOT declare hostnames. When ModelsByHost is
+	// configured, requests to a host that doesn't match any entry fall back to this list (rather than to Models, which
+	// would leak host-scoped models to unknown hosts).
+	UnscopedModels []Model `json:"unscopedModels,omitempty"`
 	// MCPConfig is the configuration for the MCPRoute implementations.
 	MCPConfig *MCPConfig `json:"mcpConfig,omitempty"`
 }

--- a/internal/filterapi/runtime.go
+++ b/internal/filterapi/runtime.go
@@ -37,6 +37,8 @@ type RuntimeConfig struct {
 	RequestCosts []RuntimeRequestCost
 	// DeclaredModels is the list of declared models.
 	DeclaredModels []Model
+	// ModelsByHost maps hostnames to their specific model lists for per-host filtering.
+	ModelsByHost map[string][]Model
 	// Backends is the map of backends by name.
 	Backends map[string]*RuntimeBackend
 }
@@ -123,5 +125,6 @@ func NewRuntimeConfig(ctx context.Context, config *Config, fn NewBackendAuthHand
 		GlobalRequestCosts: globalCosts,
 		RequestCosts:       costs,
 		DeclaredModels:     config.Models,
+		ModelsByHost:       config.ModelsByHost,
 	}, nil
 }

--- a/internal/filterapi/runtime.go
+++ b/internal/filterapi/runtime.go
@@ -37,8 +37,12 @@ type RuntimeConfig struct {
 	RequestCosts []RuntimeRequestCost
 	// DeclaredModels is the list of declared models.
 	DeclaredModels []Model
-	// ModelsByHost maps hostnames to their specific model lists for per-host filtering.
+	// ModelsByHost maps hostnames to their specific model lists for per-host filtering. Each entry already includes
+	// UnscopedModels so that routes without hostname scoping remain visible on host-matched requests.
 	ModelsByHost map[string][]Model
+	// UnscopedModels is the fallback returned for hosts that don't match any ModelsByHost entry. Populated from routes
+	// that did NOT declare hostnames; kept separate from DeclaredModels so we don't leak scoped models to unknown hosts.
+	UnscopedModels []Model
 	// Backends is the map of backends by name.
 	Backends map[string]*RuntimeBackend
 }
@@ -126,5 +130,6 @@ func NewRuntimeConfig(ctx context.Context, config *Config, fn NewBackendAuthHand
 		RequestCosts:       costs,
 		DeclaredModels:     config.Models,
 		ModelsByHost:       config.ModelsByHost,
+		UnscopedModels:     config.UnscopedModels,
 	}, nil
 }

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -68,6 +68,32 @@ spec:
           spec:
             description: Spec defines the details of the AIGatewayRoute.
             properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames that should be matched against the HTTP Host header
+                  before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
               llmRequestCosts:
                 description: "LLMRequestCosts specifies how to capture the cost of
                   the LLM-related request, notably the token usage.\nThe AI Gateway

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -951,6 +951,32 @@ spec:
           spec:
             description: Spec defines the details of the AIGatewayRoute.
             properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames that should be matched against the HTTP Host header
+                  before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
               llmRequestCosts:
                 description: "LLMRequestCosts specifies how to capture the cost of
                   the LLM-related request, notably the token usage.\nThe AI Gateway

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -70,8 +70,11 @@ spec:
             properties:
               hostnames:
                 description: |-
-                  Hostnames defines a set of hostnames that should be matched against the HTTP Host header
-                  before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+                  Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+                  used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+                  When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+                  See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+                  for the details of the Hostnames field in the Gateway API.
                 items:
                   description: |-
                     Hostname is the fully qualified domain name of a network host. This matches
@@ -953,8 +956,11 @@ spec:
             properties:
               hostnames:
                 description: |-
-                  Hostnames defines a set of hostnames that should be matched against the HTTP Host header
-                  before applying rules. This maps directly to HTTPRoute.Spec.Hostnames.
+                  Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute
+                  used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.
+                  When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.
+                  See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec
+                  for the details of the Hostnames field in the Gateway API.
                 items:
                   description: |-
                     Hostname is the fully qualified domain name of a network host. This matches

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -765,6 +765,11 @@ AIGatewayRouteSpec details the AIGatewayRoute configuration.
   required="false"
   description="ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.<br />Currently, each reference's Kind must be Gateway."
 /><ApiField
+  name="hostnames"
+  type="Hostname array"
+  required="false"
+  description="Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute<br />used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.<br />When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.<br />See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec<br />for the details of the Hostnames field in the Gateway API."
+/><ApiField
   name="rules"
   type="[AIGatewayRouteRule](#github-com-envoyproxy-ai-gateway-api-v1alpha1-aigatewayrouterule) array"
   required="true"
@@ -3177,6 +3182,11 @@ AIGatewayRouteSpec details the AIGatewayRoute configuration.
   type="[ParentReference](https://gateway-api.sigs.k8s.io/reference/spec/?h=httproutetimeouts#parentreference) array"
   required="false"
   description="ParentRefs are the names of the Gateway resources this AIGatewayRoute is being attached to.<br />Currently, each reference's Kind must be Gateway."
+/><ApiField
+  name="hostnames"
+  type="Hostname array"
+  required="false"
+  description="Hostnames is a list of hostnames matched against the HTTP Host header to select an AIGatewayRoute<br />used to process the request. This is equivalent to the Hostnames field in the Gateway API HTTPRouteSpec.<br />When specified, the generated HTTPRoute will include these hostnames for hostname-based filtering.<br />See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteSpec<br />for the details of the Hostnames field in the Gateway API."
 /><ApiField
   name="rules"
   type="[AIGatewayRouteRule](#github-com-envoyproxy-ai-gateway-api-v1beta1-aigatewayrouterule) array"


### PR DESCRIPTION
**Description**

Replaces https://github.com/envoyproxy/ai-gateway/pull/1987 (accidentally closed; GitHub UI blocked reopen after a force-rebase, then the API refused too with state cannot be changed). All commits below are the rebased version of that PR with the latest review feedback applied.

cc @johnugeorge @PatilHrushikesh @mtparet @mathetake @nacx — please review here instead of #1987.

Currently, aigetewayroute seems act as cluster level CR, since it did not have a hostname attached to it. It means that we can not specific a group of models under a specific Hostname (say xx.api.aieg.com). And meanwhile, /v1/models will return all the openai models of all aigetewayroute CRs in the cluster.


**Related Issues/PRs (if applicable)**

mentioned in  https://github.com/envoyproxy/ai-gateway/discussions/1646

**Special notes for reviewers (if applicable)**
