### PR TITLE
fix: buffer Responses streaming SSE events

### DIFF
--- a/internal/translator/openai_responses.go
+++ b/internal/translator/openai_responses.go
@@ -44,6 +44,8 @@ type openAIToOpenAITranslatorV1Responses struct {
 	// requestModel serves as fallback for non-compliant OpenAI backends that
 	// don't return model in responses, ensuring metrics/tracing always have a model.
 	requestModel internalapi.RequestModel
+	// buffered stores incomplete SSE bytes across ResponseBody calls.
+	buffered []byte
 }
 
 // RequestBody implements [OpenAIResponsesTranslator.RequestBody].
@@ -102,12 +104,12 @@ func (o *openAIToOpenAITranslatorV1Responses) ResponseBody(_ map[string]string, 
 func (o *openAIToOpenAITranslatorV1Responses) handleStreamingResponse(body io.Reader, span tracingapi.ResponsesSpan) (
 	newHeaders []internalapi.Header, newBody []byte, tokenUsage metrics.TokenUsage, responseModel string, err error,
 ) {
-	// Buffer the incoming SSE data
 	chunks, err := io.ReadAll(body)
 	if err != nil {
 		return nil, nil, tokenUsage, "", fmt.Errorf("failed to read body: %w", err)
 	}
-	tokenUsage = o.extractUsageFromBufferEvent(span, chunks)
+	o.buffered = append(o.buffered, chunks...)
+	tokenUsage = o.extractUsageFromBufferEvent(span)
 	// Use stored streaming response model, fallback to request model for non-compliant backends
 	responseModel = cmp.Or(o.streamingResponseModel, o.requestModel)
 	return
@@ -142,11 +144,16 @@ func (o *openAIToOpenAITranslatorV1Responses) handleNonStreamingResponse(body io
 }
 
 // extractUsageFromBufferEvent extracts the token usage and model from the buffered SSE events.
-// It scans complete lines and returns the latest usage found in response.completed event.
-func (o *openAIToOpenAITranslatorV1Responses) extractUsageFromBufferEvent(span tracingapi.ResponsesSpan, chunks []byte) (tokenUsage metrics.TokenUsage) {
-	// Parse SSE events from the buffered data
-	// SSE format: "data: {json}\n\n"
-	for event := range bytes.SplitSeq(chunks, []byte("\n\n")) {
+// It scans complete SSE events and returns the latest usage found in response.completed event.
+func (o *openAIToOpenAITranslatorV1Responses) extractUsageFromBufferEvent(span tracingapi.ResponsesSpan) (tokenUsage metrics.TokenUsage) {
+	for {
+		// SSE event boundary is a blank line: "data: {json}\n\n".
+		i := bytes.Index(o.buffered, []byte("\n\n"))
+		if i == -1 {
+			return tokenUsage
+		}
+		event := o.buffered[:i]
+		o.buffered = o.buffered[i+2:]
 		for line := range bytes.SplitSeq(event, []byte("\n")) {
 			// Look for lines starting with "data: "
 			if !bytes.HasPrefix(line, sseDataPrefix) {
@@ -188,7 +195,6 @@ func (o *openAIToOpenAITranslatorV1Responses) extractUsageFromBufferEvent(span t
 			}
 		}
 	}
-	return tokenUsage
 }
 
 // ResponseError implements [OpenAIResponsesTranslator.ResponseError].

--- a/internal/translator/openai_responses_test.go
+++ b/internal/translator/openai_responses_test.go
@@ -594,6 +594,112 @@ data: [DONE]
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read body")
 	})
+
+	t.Run("response completed split across response body calls", func(t *testing.T) {
+		translator := NewResponsesOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Responses)
+
+		req := &openai.ResponseRequest{
+			Model:  "gpt-4o",
+			Stream: true,
+			Input: openai.ResponseNewParamsInputUnion{
+				OfString: ptr.To("Hi"),
+			},
+		}
+		original := []byte(`{"model":"gpt-4o","input":"Hi","stream":true}`)
+		_, _, err := translator.RequestBody(original, req, false)
+		require.NoError(t, err)
+
+		firstChunk := []byte(`data: {"type":"response.created","response":{"model":"gpt-4o-2024-11-20"}}
+
+data: {"type":"response.completed","response":{"id":"resp_123","object":"response","created_at":1741476542,"status":"completed","model":"gpt-4o-2024-11-20","output":[],"usage":{"input_tokens":10,`)
+		secondChunk := []byte(`"input_tokens_details":{"cached_tokens":2},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}
+
+data: [DONE]
+
+`)
+
+		_, _, tokenUsage, responseModel, err := translator.ResponseBody(nil, bytes.NewReader(firstChunk), false, nil)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-2024-11-20", responseModel)
+		_, ok := tokenUsage.InputTokens()
+		require.False(t, ok)
+
+		_, _, tokenUsage, responseModel, err = translator.ResponseBody(nil, bytes.NewReader(secondChunk), true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-2024-11-20", responseModel)
+
+		inputTokens, ok := tokenUsage.InputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(10), inputTokens)
+
+		outputTokens, ok := tokenUsage.OutputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(5), outputTokens)
+
+		totalTokens, ok := tokenUsage.TotalTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(15), totalTokens)
+
+		cachedTokens, ok := tokenUsage.CachedInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(2), cachedTokens)
+
+		cacheCreationTokens, ok := tokenUsage.CacheCreationInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(0), cacheCreationTokens)
+
+		reasoningTokens, ok := tokenUsage.ReasoningTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(0), reasoningTokens)
+	})
+
+	t.Run("complete event followed by next response body call", func(t *testing.T) {
+		translator := NewResponsesOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Responses)
+
+		req := &openai.ResponseRequest{
+			Model:  "gpt-4o",
+			Stream: true,
+			Input: openai.ResponseNewParamsInputUnion{
+				OfString: ptr.To("Hi"),
+			},
+		}
+		original := []byte(`{"model":"gpt-4o","input":"Hi","stream":true}`)
+		_, _, err := translator.RequestBody(original, req, false)
+		require.NoError(t, err)
+
+		firstChunk := []byte(`data: {"type":"response.created","response":{"model":"gpt-4o-2024-11-20"}}
+
+`)
+		secondChunk := []byte(`data: {"type":"response.completed","response":{"id":"resp_123","object":"response","created_at":1741476542,"status":"completed","model":"gpt-4o-2024-11-20","output":[],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":2},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}
+
+data: [DONE]
+
+`)
+
+		_, _, tokenUsage, responseModel, err := translator.ResponseBody(nil, bytes.NewReader(firstChunk), false, nil)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-2024-11-20", responseModel)
+		require.Empty(t, translator.buffered)
+		_, ok := tokenUsage.InputTokens()
+		require.False(t, ok)
+
+		_, _, tokenUsage, responseModel, err = translator.ResponseBody(nil, bytes.NewReader(secondChunk), true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-2024-11-20", responseModel)
+		require.Empty(t, translator.buffered)
+
+		inputTokens, ok := tokenUsage.InputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(10), inputTokens)
+
+		outputTokens, ok := tokenUsage.OutputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(5), outputTokens)
+
+		totalTokens, ok := tokenUsage.TotalTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(15), totalTokens)
+	})
 }
 
 func TestResponses_HandleNonStreamingResponse(t *testing.T) {
@@ -711,7 +817,8 @@ data: [DONE]
 
 `)
 
-		tokenUsage := translator.extractUsageFromBufferEvent(nil, chunks)
+		translator.buffered = chunks
+		tokenUsage := translator.extractUsageFromBufferEvent(nil)
 
 		inputTokens, ok := tokenUsage.InputTokens()
 		require.True(t, ok)
@@ -761,7 +868,8 @@ data: [DONE]
 
 `)
 
-		translator.extractUsageFromBufferEvent(nil, chunks)
+		translator.buffered = chunks
+		translator.extractUsageFromBufferEvent(nil)
 		require.Equal(t, "gpt-4o-2024-11-20", translator.streamingResponseModel)
 	})
 
@@ -774,7 +882,8 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":5,"output
 
 `)
 
-		tokenUsage := translator.extractUsageFromBufferEvent(nil, chunks)
+		translator.buffered = chunks
+		tokenUsage := translator.extractUsageFromBufferEvent(nil)
 
 		inputTokens, ok := tokenUsage.InputTokens()
 		require.True(t, ok)
@@ -794,7 +903,8 @@ data: [DONE]
 
 `)
 
-		tokenUsage := translator.extractUsageFromBufferEvent(nil, chunks)
+		translator.buffered = chunks
+		tokenUsage := translator.extractUsageFromBufferEvent(nil)
 
 		_, inputSet := tokenUsage.InputTokens()
 		_, outputSet := tokenUsage.OutputTokens()

--- a/internal/translator/openai_speech.go
+++ b/internal/translator/openai_speech.go
@@ -40,6 +40,8 @@ type openAIToOpenAITranslatorV1Speech struct {
 	stream bool
 	// requestModel stores the model from the request to use in the response.
 	requestModel internalapi.RequestModel
+	// buffered stores incomplete SSE events across streamed response body chunks.
+	buffered []byte
 }
 
 // RequestBody implements [OpenAISpeechTranslator.RequestBody].
@@ -106,7 +108,8 @@ func (o *openAIToOpenAITranslatorV1Speech) handleStreamingResponse(body io.Reade
 
 	// Record SSE chunks to span if tracing is enabled
 	if span != nil {
-		o.recordSSEChunksToSpan(span, chunks)
+		o.buffered = append(o.buffered, chunks...)
+		o.recordSSEChunksToSpan(span)
 	}
 
 	// Use request model as response model (speech synthesis doesn't return a model field)
@@ -137,10 +140,15 @@ func (o *openAIToOpenAITranslatorV1Speech) handleBinaryResponse(body io.Reader, 
 }
 
 // recordSSEChunksToSpan records SSE streaming chunks to the tracing span.
-func (o *openAIToOpenAITranslatorV1Speech) recordSSEChunksToSpan(span tracingapi.SpeechSpan, chunks []byte) {
-	// Parse SSE events from the buffered data
-	// SSE format: "data: {json}\n\n"
-	for event := range bytes.SplitSeq(chunks, []byte("\n\n")) {
+func (o *openAIToOpenAITranslatorV1Speech) recordSSEChunksToSpan(span tracingapi.SpeechSpan) {
+	for {
+		// SSE event boundary is a blank line: "data: {json}\n\n".
+		i := bytes.Index(o.buffered, []byte("\n\n"))
+		if i == -1 {
+			return
+		}
+		event := o.buffered[:i]
+		o.buffered = o.buffered[i+2:]
 		for line := range bytes.SplitSeq(event, []byte("\n")) {
 			// Look for lines starting with "data: "
 			if !bytes.HasPrefix(line, sseDataPrefix) {

--- a/internal/translator/openai_speech_test.go
+++ b/internal/translator/openai_speech_test.go
@@ -210,6 +210,37 @@ func TestOpenAIToOpenAISpeechTranslator_ResponseBody_RecordsSpan_Streaming(t *te
 	require.Len(t, mockSpan.recordedChunks, 1)
 }
 
+func TestOpenAIToOpenAISpeechTranslator_ResponseBody_RecordsSpan_StreamingSplitEvent(t *testing.T) {
+	mockSpan := &mockSpeechSpan{}
+	tr := NewSpeechOpenAIToOpenAITranslator("v1", "gpt-4o-mini-tts").(*openAIToOpenAITranslatorV1Speech)
+
+	// Set up translator state for streaming
+	sseFormat := "sse"
+	req := &openai.SpeechRequest{
+		Model:        "gpt-4o-mini-tts",
+		Input:        "Test",
+		Voice:        "alloy",
+		StreamFormat: &sseFormat,
+	}
+	original, _ := json.Marshal(req)
+	_, _, _ = tr.RequestBody(original, req, false)
+
+	firstChunk := []byte(`data: {"data":"dGVz`)
+	_, _, _, respModel, err := tr.ResponseBody(map[string]string{}, bytes.NewReader(firstChunk), false, mockSpan)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-4o-mini-tts", respModel)
+	require.Empty(t, mockSpan.recordedChunks)
+	require.Equal(t, firstChunk, tr.buffered)
+
+	secondChunk := []byte("dA==\"}\n\n")
+	_, _, _, respModel, err = tr.ResponseBody(map[string]string{}, bytes.NewReader(secondChunk), true, mockSpan)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-4o-mini-tts", respModel)
+	require.Len(t, mockSpan.recordedChunks, 1)
+	require.Equal(t, []byte("test"), mockSpan.recordedChunks[0].Data)
+	require.Empty(t, tr.buffered)
+}
+
 func TestOpenAIToOpenAISpeechTranslator_ResponseError_NonJSON(t *testing.T) {
 	tr := NewSpeechOpenAIToOpenAITranslator("v1", "")
 	headers := map[string]string{contentTypeHeaderName: "text/plain", statusHeaderName: "503"}


### PR DESCRIPTION
**Description**

This commit buffers streaming OpenAI Responses SSE data across ext_proc `ResponseBody` calls.

In `STREAMED` response body mode, ext_proc body chunks may split a single SSE event. The OpenAI Responses passthrough translator previously parsed each chunk independently, so
a split `response.completed` event could be skipped and usage would remain unset.

This change keeps incomplete SSE bytes in the translator and only parses complete `\n\n`-terminated SSE events.

**Related Issues/PRs (if applicable)**

Fixes #2162

**Special notes for reviewers (if applicable)**

Added tests covering a split `response.completed` event across two `ResponseBody` calls, and a chunk boundary that ends exactly after a complete SSE event.

Validation run:

```bash
go test ./internal/translator
go test ./internal/extproc
```