### PR TITLE
fix(openai): parse typeless assistant output messages

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -3747,7 +3747,16 @@ func (r *ResponseInputItemUnionParam) UnmarshalJSON(data []byte) error {
 	// Handle messages without explicit type field (for compatibility with simple message arrays)
 	// This allows arrays like [{"role": "user", "content": "Hello"}] to work without requiring type field
 	if typ.String() == "" {
-		if gjson.GetBytes(data, "role").Exists() && gjson.GetBytes(data, "content").Exists() {
+		role := gjson.GetBytes(data, "role")
+		if role.Exists() && gjson.GetBytes(data, "content").Exists() {
+			if role.String() == "assistant" {
+				// Assistant history may be sent as output_message content without type: "message".
+				var om ResponseOutputMessage
+				if err := json.Unmarshal(data, &om); err == nil {
+					r.OfOutputMessage = &om
+					return nil
+				}
+			}
 			// Treat as EasyInputMessageParam
 			var msg EasyInputMessageParam
 			if err := json.Unmarshal(data, &msg); err != nil {

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -4950,6 +4950,20 @@ func TestResponseInputItemUnionParamUnmarshalJSON(t *testing.T) {
 			input: []byte(`{"role": "user", "content": "Hello"}`),
 		},
 		{
+			name: "unmarshal assistant output_message without type field",
+			expRes: ResponseInputItemUnionParam{
+				OfOutputMessage: &ResponseOutputMessage{
+					Role: "assistant",
+					Content: ResponseOutputMessageContentUnion{
+						OfContentArray: []ResponseOutputMessageContentArrayUnion{
+							{OfOutputText: &ResponseOutputTextParam{Text: "Hi! I'm here and working.", Type: "output_text"}},
+						},
+					},
+				},
+			},
+			input: []byte(`{"role": "assistant", "content": [{"text": "Hi! I'm here and working.", "type": "output_text"}]}`),
+		},
+		{
 			name:   "unmarshal message without type field (role missing, should error)",
 			expRes: ResponseInputItemUnionParam{},
 			input:  []byte(`{"content": "Hello"}`),

--- a/internal/endpointspec/endpointspec_test.go
+++ b/internal/endpointspec/endpointspec_test.go
@@ -331,6 +331,28 @@ func TestResponsesEndpointSpec_ParseBody(t *testing.T) {
 		require.Equal(t, "user", parsed.Input.OfInputItemList[0].OfMessage.Role)
 		require.Nil(t, mutated)
 	})
+
+	t.Run("multi_turn_input_with_assistant_output_without_type_field", func(t *testing.T) {
+		body := []byte(`{
+			"model": "gpt-4.7",
+			"input": [
+				{"role": "user", "content": "Hello"},
+				{"role": "assistant", "content": [{"type": "output_text", "text": "Hi there"}]},
+				{"role": "user", "content": "Continue"}
+			]
+		}`)
+
+		model, parsed, stream, mutated, err := spec.ParseBody(body, false)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4.7", model)
+		require.False(t, stream)
+		require.NotNil(t, parsed)
+		require.NotNil(t, parsed.Input.OfInputItemList)
+		require.Len(t, parsed.Input.OfInputItemList, 3)
+		require.NotNil(t, parsed.Input.OfInputItemList[1].OfOutputMessage)
+		require.Equal(t, "assistant", parsed.Input.OfInputItemList[1].OfOutputMessage.Role)
+		require.Nil(t, mutated)
+	})
 }
 
 func TestResponsesEndpointSpec_GetTranslator(t *testing.T) {


### PR DESCRIPTION
**Description**

Fix OpenAI Responses API request parsing for multi-turn inputs that include assistant output messages without an explicit `type: "message"` field.

Some clients, including OpenCode, send prior assistant turns as items like:

```json
{"role":"assistant","content":[{"type":"output_text","text":"..."}]}
```
Previously, typeless message-like items were always parsed as EasyInputMessageParam, whose content union only accepts input content types. That caused JSON unmarshalling to fail on output_text.

This change treats typeless assistant messages as output messages when they match the ResponseOutputMessage shape, while preserving the existing easy-message fallback for other typeless message inputs.

**Special notes for reviewers (if applicable)**

I used ai assistance to help draft the tests. I reviewed and own the final change.
