### PR TITLE
fix: make error processing consistent across ai gateway

### DIFF
--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -96,7 +96,7 @@ func translateAnthropicToolChoice(openAIToolChoice *openai.ChatCompletionToolCho
 			toolChoice = anthropic.ToolChoiceUnionParam{OfTool: &anthropic.ToolChoiceToolParam{Name: choice}}
 			toolChoice.OfTool.DisableParallelToolUse = disableParallelToolUse
 		default:
-			return anthropic.ToolChoiceUnionParam{}, fmt.Errorf("unsupported tool_choice value: %s", choice)
+			return anthropic.ToolChoiceUnionParam{}, fmt.Errorf("%w: unsupported tool_choice value: %s", internalapi.ErrInvalidRequestBody, choice)
 		}
 	case openai.ChatCompletionNamedToolChoice:
 		if choice.Type == openai.ToolTypeFunction && choice.Function.Name != "" {
@@ -109,7 +109,7 @@ func translateAnthropicToolChoice(openAIToolChoice *openai.ChatCompletionToolCho
 			}
 		}
 	default:
-		return anthropic.ToolChoiceUnionParam{}, fmt.Errorf("unsupported tool_choice type: %T", openAIToolChoice)
+		return anthropic.ToolChoiceUnionParam{}, fmt.Errorf("%w: unsupported tool_choice type: %T", internalapi.ErrInvalidRequestBody, openAIToolChoice)
 	}
 	return toolChoice, nil
 }
@@ -132,9 +132,13 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 	if len(openAITools) > 0 {
 		anthropicTools := make([]anthropic.ToolUnionParam, 0, len(openAITools))
 		for _, openAITool := range openAITools {
-			if openAITool.Type != openai.ToolTypeFunction || openAITool.Function == nil {
-				// Anthropic only supports 'function' tools, so we skip others.
-				continue
+			if openAITool.Type != openai.ToolTypeFunction {
+				err = fmt.Errorf("%w: tool type must be 'function', got %q", internalapi.ErrInvalidRequestBody, openAITool.Type)
+				return
+			}
+			if openAITool.Function == nil {
+				err = fmt.Errorf("%w: tool function definition is required", internalapi.ErrInvalidRequestBody)
+				return
 			}
 			toolParam := anthropic.ToolParam{
 				Name:        openAITool.Function.Name,
@@ -150,7 +154,7 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 			if openAITool.Function.Parameters != nil {
 				paramsMap, ok := openAITool.Function.Parameters.(map[string]any)
 				if !ok {
-					err = fmt.Errorf("failed to cast tool parameters to map[string]interface{}")
+					err = fmt.Errorf("%w: failed to cast tool parameters to map[string]interface{}", internalapi.ErrInvalidRequestBody)
 					return
 				}
 
@@ -232,7 +236,7 @@ func convertImageContentToAnthropic(imageURL string, fields *openai.AnthropicCon
 	case strings.HasPrefix(imageURL, "data:"):
 		contentType, data, err := parseDataURI(imageURL)
 		if err != nil {
-			return anthropic.ContentBlockParamUnion{}, fmt.Errorf("failed to parse image URL: %w", err)
+			return anthropic.ContentBlockParamUnion{}, fmt.Errorf("%w: failed to parse image URL: %v", internalapi.ErrInvalidRequestBody, err)
 		}
 		base64Data := base64.StdEncoding.EncodeToString(data)
 		if contentType == string(constant.ValueOf[constant.ApplicationPDF]()) {
@@ -246,7 +250,7 @@ func convertImageContentToAnthropic(imageURL string, fields *openai.AnthropicCon
 			imgBlock.OfImage.CacheControl = cacheControlParam
 			return imgBlock, nil
 		}
-		return anthropic.ContentBlockParamUnion{}, fmt.Errorf("invalid media_type for image '%s'", contentType)
+		return anthropic.ContentBlockParamUnion{}, fmt.Errorf("%w: invalid media_type for image '%s'", internalapi.ErrInvalidRequestBody, contentType)
 	case strings.HasSuffix(strings.ToLower(imageURL), ".pdf"):
 		docBlock := anthropic.NewDocumentBlock(anthropic.URLPDFSourceParam{URL: imageURL})
 		docBlock.OfDocument.CacheControl = cacheControlParam
@@ -283,9 +287,9 @@ func convertContentPartsToAnthropic(parts []openai.ChatCompletionContentPartUser
 			resultContent = append(resultContent, block)
 
 		case contentPart.OfInputAudio != nil:
-			return nil, fmt.Errorf("input audio content not supported yet")
+			return nil, fmt.Errorf("%w: input audio content not supported yet", internalapi.ErrInvalidRequestBody)
 		case contentPart.OfFile != nil:
-			return nil, fmt.Errorf("file content not supported yet")
+			return nil, fmt.Errorf("%w: file content not supported yet", internalapi.ErrInvalidRequestBody)
 		}
 	}
 	return resultContent, nil

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -54,6 +54,7 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 		expectedTools      []anthropic.ToolUnionParam
 		expectedToolChoice anthropic.ToolChoiceUnionParam
 		expectErr          bool
+		expectUserFacing   bool
 	}{
 		{
 			name: "auto tool choice",
@@ -249,45 +250,33 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 				Tools:      openaiTestTool,
 				ToolChoice: &openai.ChatCompletionToolChoiceUnion{Value: "invalid_choice"},
 			},
-			expectErr: true,
+			expectErr:        true,
+			expectUserFacing: true,
 		},
 		{
-			name: "skips function tool with nil function definition",
+			name: "rejects tool with nil function definition",
 			openAIReq: &openai.ChatCompletionRequest{
 				Tools: []openai.Tool{
 					{
 						Type:     "function",
-						Function: nil, // This tool has the correct type but a nil definition and should be skipped.
-					},
-					{
-						Type:     "function",
-						Function: &openai.FunctionDefinition{Name: "get_weather"}, // This is a valid tool.
+						Function: nil,
 					},
 				},
 			},
-			// We expect only the valid function tool to be translated.
-			expectedTools: []anthropic.ToolUnionParam{
-				{OfTool: &anthropic.ToolParam{Name: "get_weather", Description: anthropic.String("")}},
-			},
-			expectErr: false,
+			expectErr:        true,
+			expectUserFacing: true,
 		},
 		{
-			name: "skips non-function tools",
+			name: "rejects non-function tool type",
 			openAIReq: &openai.ChatCompletionRequest{
 				Tools: []openai.Tool{
 					{
 						Type: "retrieval",
 					},
-					{
-						Type:     "function",
-						Function: &openai.FunctionDefinition{Name: "get_weather"},
-					},
 				},
 			},
-			expectedTools: []anthropic.ToolUnionParam{
-				{OfTool: &anthropic.ToolParam{Name: "get_weather", Description: anthropic.String("")}},
-			},
-			expectErr: false,
+			expectErr:        true,
+			expectUserFacing: true,
 		},
 		{
 			name: "tool definition without type field",
@@ -360,7 +349,24 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 				Tools:      openaiTestTool,
 				ToolChoice: &openai.ChatCompletionToolChoiceUnion{Value: 123}, // Use an integer to trigger the default case.
 			},
-			expectErr: true,
+			expectErr:        true,
+			expectUserFacing: true,
+		},
+		{
+			name: "invalid tool parameters type (not a map)",
+			openAIReq: &openai.ChatCompletionRequest{
+				Tools: []openai.Tool{
+					{
+						Type: "function",
+						Function: &openai.FunctionDefinition{
+							Name:       "bad_tool",
+							Parameters: "this is not a map",
+						},
+					},
+				},
+			},
+			expectErr:        true,
+			expectUserFacing: true,
 		},
 		{
 			name: "nested schema in tool's defintions",
@@ -440,6 +446,10 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 			tools, toolChoice, err := translateOpenAItoAnthropicTools(tt.openAIReq.Tools, tt.openAIReq.ToolChoice, tt.openAIReq.ParallelToolCalls)
 			if tt.expectErr {
 				require.Error(t, err)
+				if tt.expectUserFacing {
+					require.ErrorIs(t, err, internalapi.ErrInvalidRequestBody,
+						"error should be user-facing (wrapped with ErrInvalidRequestBody) to produce HTTP 422")
+				}
 			} else {
 				require.NoError(t, err)
 				if tt.openAIReq.ToolChoice != nil {
@@ -509,10 +519,11 @@ func TestFinishReasonTranslation(t *testing.T) {
 // TestContentTranslationCoverage adds specific coverage for the openAIToAnthropicContent helper.
 func TestContentTranslationCoverage(t *testing.T) {
 	tests := []struct {
-		name            string
-		inputContent    any
-		expectedContent []anthropic.ContentBlockParamUnion
-		expectErr       bool
+		name              string
+		inputContent      any
+		expectedContent   []anthropic.ContentBlockParamUnion
+		expectErr         bool
+		expectUserFacing  bool
 	}{
 		{
 			name:         "nil content",
@@ -578,9 +589,32 @@ func TestContentTranslationCoverage(t *testing.T) {
 			},
 		},
 		{
-			name:         "audio content error",
-			inputContent: []openai.ChatCompletionContentPartUserUnionParam{{OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{}}},
-			expectErr:    true,
+			name:             "audio content error",
+			inputContent:     []openai.ChatCompletionContentPartUserUnionParam{{OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{}}},
+			expectErr:        true,
+			expectUserFacing: true,
+		},
+		{
+			name: "invalid base64 image data URI",
+			inputContent: []openai.ChatCompletionContentPartUserUnionParam{
+				{OfImageURL: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "data:image/png;base64,NOT_VALID!!!"}}},
+			},
+			expectErr:        true,
+			expectUserFacing: true,
+		},
+		{
+			name: "unsupported image media type",
+			inputContent: []openai.ChatCompletionContentPartUserUnionParam{
+				{OfImageURL: &openai.ChatCompletionContentPartImageParam{ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: "data:image/bmp;base64,dGVzdA=="}}},
+			},
+			expectErr:        true,
+			expectUserFacing: true,
+		},
+		{
+			name:             "file content error",
+			inputContent:     []openai.ChatCompletionContentPartUserUnionParam{{OfFile: &openai.ChatCompletionContentPartFileParam{}}},
+			expectErr:        true,
+			expectUserFacing: true,
 		},
 	}
 
@@ -589,6 +623,10 @@ func TestContentTranslationCoverage(t *testing.T) {
 			content, err := openAIToAnthropicContent(tt.inputContent)
 			if tt.expectErr {
 				require.Error(t, err)
+				if tt.expectUserFacing {
+					require.ErrorIs(t, err, internalapi.ErrInvalidRequestBody,
+						"error should be user-facing (wrapped with ErrInvalidRequestBody) to produce HTTP 422")
+				}
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
**Description**
The Anthropic translator (`anthropic_helper.go`) detected several classes of invalid user input during
format conversion — invalid base64 image data, unsupported image media types, malformed tool definitions,
invalid tool_choice values, and unsupported content types — but returned them as plain Go errors. Because
these errors were not wrapped with `ErrInvalidRequestBody`, the extproc error handler couldn't distinguish
them from real internal failures and Envoy defaulted to HTTP 500.

This is the same category of fix as #1621, which established the `ErrInvalidRequestBody` → HTTP 422
framework. The Anthropic translator had several error paths that were missed in that PR.

## Changes

- **Image content**: wrap `parseDataURI` failure and unsupported media type errors with
  `ErrInvalidRequestBody` → 500 becomes 422, matching the Gemini and Bedrock translators
- **Tool definitions**: reject tools with a missing or non-`"function"` type and nil function definition
  instead of silently skipping them → 200 becomes 422
- **Tool parameters**: wrap the `map[string]any` type-cast failure with `ErrInvalidRequestBody` → 500
  becomes 422
- **Tool choice**: wrap unsupported value/type errors with `ErrInvalidRequestBody` → 500 becomes 422
- **Content types**: wrap unsupported audio and file content errors with `ErrInvalidRequestBody` → 500
  becomes 422

## Note

The silent acceptance of malformed tool definitions (missing `type` field) was a behavioral gap, not just
a missing error wrap — the translator was skipping invalid tools without error. The fix changes this to an
explicit rejection, making the Anthropic path consistent with how the Gemini translator handles the same
case.
