### PR TITLE
fix: buffer non-streaming response body across multi-chunk ext_proc messages

### DIFF
--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -116,13 +116,20 @@ type (
 		responseEncoding   string
 		compressedBuf      []byte // accumulates raw compressed bytes across streaming chunks
 		decompressedOffset int    // tracks decompressed bytes already returned
-		translator         translator.Translator[ReqT, tracingapi.Span[RespT, RespChunkT]]
-		modelNameOverride  internalapi.ModelNameOverride
-		headerMutator      *headermutator.HeaderMutator
-		bodyMutator        *bodymutator.BodyMutator
-		backendName        string
-		routeName          string
-		handler            filterapi.BackendAuthHandler
+		// responseBodyBuf accumulates raw response-body bytes across HttpBody chunks
+		// for non-streaming responses. Envoy can deliver a non-streaming response across
+		// multiple ResponseBody messages (e.g. chained behind FULL_DUPLEX_STREAMED
+		// ext_proc filters, the final chunk is empty with EndOfStream=true). Buffering
+		// until EndOfStream hands the translator one complete body and avoids io.EOF on
+		// the empty tail.
+		responseBodyBuf   []byte
+		translator        translator.Translator[ReqT, tracingapi.Span[RespT, RespChunkT]]
+		modelNameOverride internalapi.ModelNameOverride
+		headerMutator     *headermutator.HeaderMutator
+		bodyMutator       *bodymutator.BodyMutator
+		backendName       string
+		routeName         string
+		handler           filterapi.BackendAuthHandler
 		// cost is the cost of the request that is accumulated during the processing of the response.
 		costs metrics.TokenUsage
 		// metrics tracking.
@@ -459,6 +466,26 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) ProcessRespo
 			u.metrics.RecordRequestCompletion(ctx, true, u.requestHeaders)
 		}
 	}()
+
+	// Non-streaming responses may be delivered across multiple HttpBody chunks
+	// (notably an empty trailing chunk with EndOfStream=true when chained behind
+	// FULL_DUPLEX_STREAMED ext_proc filters). Accumulate raw bytes and only invoke
+	// the translator once the full body is available; otherwise the non-streaming
+	// translators' unconditional json.Decode would surface io.EOF on the empty
+	// chunk and envoy would synthesize a 500.
+	if !u.parent.stream {
+		u.responseBodyBuf = append(u.responseBodyBuf, body.Body...)
+		if !body.EndOfStream {
+			return &extprocv3.ProcessingResponse{
+				Response: &extprocv3.ProcessingResponse_ResponseBody{
+					ResponseBody: &extprocv3.BodyResponse{
+						Response: &extprocv3.CommonResponse{},
+					},
+				},
+			}, nil
+		}
+		body = &extprocv3.HttpBody{Body: u.responseBodyBuf, EndOfStream: true}
+	}
 
 	// Decompress the body if needed.
 	// For streaming responses with content-encoding, use stateful decompression

--- a/internal/extproc/processor_impl_test.go
+++ b/internal/extproc/processor_impl_test.go
@@ -290,7 +290,7 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 			parent:     &chatCompletionProcessorRouterFilter{},
 		}
 		mt.retErr = errors.New("test error")
-		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{})
+		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{EndOfStream: true})
 		require.ErrorContains(t, err, "test error")
 		mm.RequireRequestFailure(t)
 		require.Zero(t, mm.inputTokenCount)
@@ -436,6 +436,114 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 		require.Equal(t, 138, mm.streamingOutputTokens) // accumulated output tokens from stream
 		require.Equal(t, 3, mm.cachedInputTokenCount)
 		require.Equal(t, 21, mm.cacheCreationInputTokenCount)
+	})
+}
+
+// eofOnEmptyBodyTranslator mimics the production behaviour of the
+// non-streaming OpenAI translators (openai_embeddings.go, openai_openai.go
+// non-stream branch): it calls json.NewDecoder(body).Decode(...) on every
+// invocation, so an empty body returns io.EOF wrapped as
+// "failed to unmarshal body: EOF". It also records each body it sees so a
+// test can assert "translator was invoked once with the full body" once the
+// processor-level multi-chunk buffering fix lands.
+type eofOnEmptyBodyTranslator struct {
+	mockTranslator
+	receivedBodies [][]byte
+}
+
+func (m *eofOnEmptyBodyTranslator) ResponseBody(
+	_ map[string]string, body io.Reader, _ bool, _ tracingapi.ChatCompletionSpan,
+) (
+	newHeaders []internalapi.Header, newBody []byte,
+	tokenUsage metrics.TokenUsage, responseModel string, err error,
+) {
+	buf, readErr := io.ReadAll(body)
+	require.NoError(m.t, readErr)
+	m.receivedBodies = append(m.receivedBodies, buf)
+
+	var resp openai.ChatCompletionResponse
+	if err := json.NewDecoder(bytes.NewReader(buf)).Decode(&resp); err != nil {
+		return nil, nil, tokenUsage, "", fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	tokenUsage.SetInputTokens(uint32(resp.Usage.PromptTokens)) //nolint:gosec
+	tokenUsage.SetTotalTokens(uint32(resp.Usage.TotalTokens))  //nolint:gosec
+	return nil, nil, tokenUsage, resp.Model, nil
+}
+
+// Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody_MultiChunkBug
+// is the processor-layer regression test for the multi-chunk EOF bug.
+//
+// When ai-gateway-extproc is chained behind FULL_DUPLEX_STREAMED ext_proc
+// filters in envoy, the response body for a non-streaming request can arrive
+// across multiple HttpBody messages — most commonly a single full-body chunk
+// followed by an empty trailing chunk with EndOfStream=true. The processor
+// currently invokes the translator on every chunk, so the empty trailing
+// chunk triggers io.EOF in json.Decode, which the processor wraps as a
+// gRPC error and envoy converts into a synthesised 500 (bytes_sent=0).
+//
+// Expected behaviour after the fix: ProcessResponseBody buffers non-streaming
+// response bodies until EndOfStream=true, then invokes the translator
+// exactly once with the full body. Both subtests below assert that contract.
+func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody_MultiChunkBug(t *testing.T) {
+	fullBody := []byte(`{"id":"x","object":"chat.completion","model":"m",` +
+		`"choices":[],"usage":{"prompt_tokens":7,"total_tokens":7}}`)
+
+	newProcessor := func(t *testing.T) (
+		*chatCompletionProcessorUpstreamFilter, *eofOnEmptyBodyTranslator, *mockMetrics,
+	) {
+		mm := &mockMetrics{}
+		mt := &eofOnEmptyBodyTranslator{mockTranslator: mockTranslator{t: t}}
+		p := &chatCompletionProcessorUpstreamFilter{
+			translator:      mt,
+			metrics:         mm,
+			responseHeaders: map[string]string{":status": "200"},
+			parent:          &chatCompletionProcessorRouterFilter{config: &filterapi.RuntimeConfig{}},
+		}
+		return p, mt, mm
+	}
+
+	// Case A — observed in production: a single non-empty chunk with
+	// EndOfStream=false, followed by an empty chunk with EndOfStream=true.
+	t.Run("empty_trailing_chunk", func(t *testing.T) {
+		p, mt, mm := newProcessor(t)
+
+		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{
+			Body: fullBody, EndOfStream: false,
+		})
+		require.NoError(t, err)
+
+		_, err = p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{
+			Body: []byte{}, EndOfStream: true,
+		})
+		require.NoError(t, err,
+			"empty trailing chunk after EndOfStream=true must not surface json.Decode EOF")
+
+		// Translator invoked exactly once, with the full buffered body.
+		require.Len(t, mt.receivedBodies, 1)
+		require.Equal(t, fullBody, mt.receivedBodies[0])
+		mm.RequireRequestSuccess(t)
+	})
+
+	// Case B — body split across two non-empty chunks. Demonstrates that the
+	// fix must buffer (a translator-side empty-body guard alone would not
+	// catch this shape).
+	t.Run("body_split_across_two_chunks", func(t *testing.T) {
+		p, mt, mm := newProcessor(t)
+
+		_, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{
+			Body: fullBody[:len(fullBody)/2], EndOfStream: false,
+		})
+		require.NoError(t, err,
+			"partial body chunk must not be decoded — buffer until EndOfStream")
+
+		_, err = p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{
+			Body: fullBody[len(fullBody)/2:], EndOfStream: true,
+		})
+		require.NoError(t, err)
+
+		require.Len(t, mt.receivedBodies, 1)
+		require.Equal(t, fullBody, mt.receivedBodies[0])
+		mm.RequireRequestSuccess(t)
 	})
 }
 

--- a/internal/translator/openai_embeddings.go
+++ b/internal/translator/openai_embeddings.go
@@ -70,8 +70,18 @@ func (o *openAIToOpenAITranslatorV1Embedding) ResponseHeaders(map[string]string)
 func (o *openAIToOpenAITranslatorV1Embedding) ResponseBody(_ map[string]string, body io.Reader, _ bool, span tracingapi.EmbeddingsSpan) (
 	newHeaders []internalapi.Header, newBody []byte, tokenUsage metrics.TokenUsage, responseModel internalapi.ResponseModel, err error,
 ) {
+	buf, err := io.ReadAll(body)
+	if err != nil {
+		return nil, nil, tokenUsage, "", fmt.Errorf("failed to read body: %w", err)
+	}
+	// An empty body is the empty trailing chunk envoy can deliver after the real
+	// body when chained behind FULL_DUPLEX_STREAMED ext_proc filters. No-op rather
+	// than surfacing a synthesized 500.
+	if len(buf) == 0 {
+		return nil, nil, tokenUsage, "", nil
+	}
 	var resp openai.EmbeddingResponse
-	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+	if err := json.Unmarshal(buf, &resp); err != nil {
 		return nil, nil, tokenUsage, "", fmt.Errorf("failed to unmarshal body: %w", err)
 	}
 

--- a/internal/translator/openai_embeddings_test.go
+++ b/internal/translator/openai_embeddings_test.go
@@ -161,6 +161,61 @@ func TestOpenAIToOpenAITranslatorV1EmbeddingResponseBody(t *testing.T) {
 	}
 }
 
+// TestOpenAIToOpenAITranslatorV1EmbeddingResponseBody_MultiChunkBug is a
+// regression test for the multi-chunk EOF bug. When ai-gateway-extproc is
+// chained behind FULL_DUPLEX_STREAMED ext_proc filters in envoy, the response
+// body can arrive in multiple HttpBody messages — including an empty trailing
+// chunk with EndOfStream=true. The translator currently ignores the
+// endOfStream argument and calls json.NewDecoder(body).Decode(&resp) on every
+// invocation, returning io.EOF (wrapped as "failed to unmarshal body: EOF")
+// on the empty chunk. Envoy converts that into a synthesised 500.
+//
+// Expected behaviour after a translator-side fix: when the body is empty,
+// the translator returns no error and a zero TokenUsage regardless of the
+// endOfStream flag. A processor-side buffering fix would prevent the
+// translator from being called with an empty body in the first place; either
+// resolution makes the assertions below pass.
+func TestOpenAIToOpenAITranslatorV1EmbeddingResponseBody_MultiChunkBug(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		body        string
+		endOfStream bool
+	}{
+		{
+			// The exact shape observed in production: an empty trailing chunk
+			// delivered with EndOfStream=true after the real body chunk was
+			// already consumed. The translator must treat this as a no-op.
+			name:        "empty_body_end_of_stream",
+			body:        "",
+			endOfStream: true,
+		},
+		{
+			// A mid-stream empty chunk (no EndOfStream yet). Translator must
+			// not attempt to decode an empty body.
+			name:        "empty_body_not_end_of_stream",
+			body:        "",
+			endOfStream: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			translator := NewEmbeddingOpenAIToOpenAITranslator("v1", "")
+			respHeaders := map[string]string{
+				"content-type":   "application/json",
+				statusHeaderName: "200",
+			}
+
+			_, _, tokenUsage, _, err := translator.ResponseBody(
+				respHeaders,
+				strings.NewReader(tc.body),
+				tc.endOfStream,
+				nil,
+			)
+			require.NoError(t, err)
+			require.Equal(t, metrics.TokenUsage{}, tokenUsage)
+		})
+	}
+}
+
 func TestOpenAIToOpenAITranslatorV1EmbeddingResponseError(t *testing.T) {
 	translator := NewEmbeddingOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Embedding)
 


### PR DESCRIPTION
**Description**

When the ext_proc filter is chained behind a `FULL_DUPLEX_STREAMED` ext_proc
filter in Envoy, a **non-streaming** response body can be delivered to
ai-gateway across multiple ext_proc `ResponseBody` messages — most commonly a
single full-body chunk (`EndOfStream=false`) followed by an empty trailing
chunk (`EndOfStream=true`), or a body split across two non-empty chunks.

`upstreamProcessor.ProcessResponseBody` invokes the translator on every chunk,
and the non-streaming translators decode unconditionally with
`json.NewDecoder(body).Decode(...)` (`internal/translator/openai_embeddings.go`,
`internal/translator/openai_openai.go`). The empty/partial chunk therefore
surfaces `io.EOF`, wrapped as `failed to unmarshal body: EOF`, which Envoy
converts into a synthesized **500 with `bytes_sent=0`**.

This is not hit by the default deployment: for non-streaming responses the
processor leaves the ext_proc response body mode at its default (`BUFFERED`) —
it only requests `STREAMED` for streaming `200` responses — so the body
normally arrives in a single chunk. The multi-chunk delivery only occurs when
ai-gateway's ext_proc is chained behind another `FULL_DUPLEX_STREAMED` ext_proc
filter.

This PR:

- Buffers raw response-body bytes for non-streaming responses in
  `ProcessResponseBody` until `EndOfStream=true`, then invokes the translator
  exactly once with the complete body. This is the primary fix and covers both
  the empty-trailing-chunk and split-body shapes for all non-streaming
  translators (chat completions, embeddings, etc.).
- Adds an empty-body guard to the OpenAI embeddings translator
  (`ResponseBody`) as defense in depth, so it is a no-op on an empty body
  rather than returning `io.EOF`.
- Adds processor- and translator-layer regression tests.

**Related Issues/PRs (if applicable)**

Related to the streaming-side counterpart fixed in #2163 (buffer Responses
streaming SSE events across ext_proc body chunks, #2162) — this PR addresses
the analogous problem on the **non-streaming** response path.

**Special notes for reviewers (if applicable)**

- `internal/translator/openai_openai.go` is intentionally **not** modified — the
  processor-level buffer fully covers the chat-completions non-streaming path,
  so no per-translator guard is needed there.
- Regression coverage:
  - `Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody_MultiChunkBug`
    (`empty_trailing_chunk`, `body_split_across_two_chunks`) — asserts the
    translator is invoked exactly once with the full buffered body.
  - `TestOpenAIToOpenAITranslatorV1EmbeddingResponseBody_MultiChunkBug`
    (`empty_body_end_of_stream`, `empty_body_not_end_of_stream`) — asserts the
    embeddings translator returns no error and zero `TokenUsage` on an empty
    body regardless of `endOfStream`.
  - Both were verified to fail with `failed to unmarshal body: EOF` when the
    processor buffer is removed.

Validation run:

```bash
go test ./internal/extproc ./internal/translator
```
