### PR TITLE
fix: handle numeric error.code in OpenAI-compatible backend responses

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1662,6 +1662,34 @@ type ErrorType struct {
 	EventID *string `json:"event_id,omitempty"`
 }
 
+// UnmarshalJSON handles backends (e.g. vLLM) that return "code" as a JSON number instead of a string.
+func (e *ErrorType) UnmarshalJSON(data []byte) error {
+	type errorTypeAlias ErrorType
+	var raw struct {
+		errorTypeAlias
+		Code json.RawMessage `json:"code,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*e = ErrorType(raw.errorTypeAlias)
+	if len(raw.Code) == 0 || string(raw.Code) == "null" {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(raw.Code, &s); err == nil {
+		e.Code = &s
+		return nil
+	}
+	var n float64
+	if err := json.Unmarshal(raw.Code, &n); err == nil {
+		s = strconv.FormatFloat(n, 'f', -1, 64)
+		e.Code = &s
+		return nil
+	}
+	return fmt.Errorf("error.code: expected string or number, got %s", string(raw.Code))
+}
+
 // ModelList is described in the OpenAI API documentation
 // https://platform.openai.com/docs/api-reference/models/list
 type ModelList struct {

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -13774,3 +13774,56 @@ func TestResponseContentPartDoneEventPartUnionUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorTypeUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		expCode *string
+		expMsg  string
+		expErr  string
+	}{
+		{
+			name:    "string code",
+			input:   `{"type":"invalid_request_error","code":"invalid_api_key","message":"bad key"}`,
+			expCode: ptr.To("invalid_api_key"),
+			expMsg:  "bad key",
+		},
+		{
+			name:    "numeric integer code",
+			input:   `{"type":"BadRequestError","code":400,"message":"bad request"}`,
+			expCode: ptr.To("400"),
+			expMsg:  "bad request",
+		},
+		{
+			name:    "null code",
+			input:   `{"type":"server_error","code":null,"message":"internal error"}`,
+			expCode: nil,
+			expMsg:  "internal error",
+		},
+		{
+			name:    "missing code",
+			input:   `{"type":"server_error","message":"internal error"}`,
+			expCode: nil,
+			expMsg:  "internal error",
+		},
+		{
+			name:   "invalid code type",
+			input:  `{"type":"error","code":["not","valid"],"message":"msg"}`,
+			expErr: "error.code: expected string or number",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var et ErrorType
+			err := json.Unmarshal([]byte(tc.input), &et)
+			if tc.expErr != "" {
+				require.ErrorContains(t, err, tc.expErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expCode, et.Code)
+			require.Equal(t, tc.expMsg, et.Message)
+		})
+	}
+}

--- a/internal/translator/anthropic_openai_test.go
+++ b/internal/translator/anthropic_openai_test.go
@@ -431,6 +431,13 @@ func TestAnthropicToOpenAITranslator_ResponseError(t *testing.T) {
 			wantErrMsg:  "Bad request",
 		},
 		{
+			name:        "JSON error with numeric code from vLLM-like backend",
+			headers:     map[string]string{contentTypeHeaderName: "application/json"},
+			body:        `{"error":{"message":"tool choice requires --enable-auto-tool-choice","type":"BadRequestError","param":null,"code":400}}`,
+			wantErrType: "BadRequestError",
+			wantErrMsg:  "tool choice requires --enable-auto-tool-choice",
+		},
+		{
 			name:        "non-JSON 400 error",
 			headers:     map[string]string{statusHeaderName: "400", contentTypeHeaderName: "text/plain"},
 			body:        "Bad request body",


### PR DESCRIPTION
**Description**

Backends like vLLM return `error.code` as a JSON number (e.g. `"code":400`) rather than a string. `ErrorType.Code` is typed `*string`, so `json.Decode` fails and the extproc returns HTTP 500 with an empty body instead of forwarding the translated error to the client.

This adds a custom `UnmarshalJSON` to `ErrorType` that accepts both string and number values for the `code` field, normalizing numbers to strings via `strconv.FormatFloat`. The fix is at the schema layer so all current and future unmarshal paths are protected. No changes needed at construction or read sites since `Code` remains `*string`.

AI (Claude Code) was used to assist with this change. The code has been reviewed and understood by the submitter.

**Related Issues/PRs (if applicable)**

Fixes #2151

**Special notes for reviewers (if applicable)**

- The only production code path that currently unmarshals `openai.Error` from a backend response is `anthropic_openai.go:198`. The openai-to-openai path passes JSON error bodies through unmodified.
- Uses the standard Go alias pattern to avoid recursive `UnmarshalJSON` calls, with an outer `Code json.RawMessage` field shadowing the embedded `Code *string`.
- `make precommit` passes cleanly. `make test` passes except for pre-existing flaky failures in `tests/internal/testupstreamlib`.