### PR TITLE
fix: prevent empty namespace from breaking RBAC name rendering in helm chart

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/_helpers.tpl
+++ b/manifests/charts/ai-gateway-helm/templates/_helpers.tpl
@@ -76,7 +76,7 @@ Create the name of the cluster role to use
 {{- if $existing }}
 {{- (include "ai-gateway-helm.controller.serviceAccountName" .) }}
 {{- else }}
-{{- printf "%s:%s" (include "ai-gateway-helm.controller.serviceAccountName" .) .Release.Namespace }}
+{{- printf "%s:%s" (include "ai-gateway-helm.controller.serviceAccountName" .) (default "default" .Release.Namespace) }}
 {{- end }}
 {{- end }}
 
@@ -85,7 +85,7 @@ Create the name of the cluster role to use
 {{- if $existing }}
 {{- "envoy-ai-gateway-inference-pool-reader" }}
 {{- else }}
-{{- printf "%s:%s" "envoy-ai-gateway-inference-pool-reader" .Release.Namespace}}
+{{- printf "%s:%s" "envoy-ai-gateway-inference-pool-reader" (default "default" .Release.Namespace)}}
 {{- end}}
 {{- end -}}
 
@@ -94,7 +94,7 @@ Create the name of the cluster role to use
 {{- if $existing }}
 {{- "envoy-ai-gateway-inference-pool-reader-binding" }}
 {{- else }}
-{{- printf "%s:%s" "envoy-ai-gateway-inference-pool-reader-binding" .Release.Namespace}}
+{{- printf "%s:%s" "envoy-ai-gateway-inference-pool-reader-binding" (default "default" .Release.Namespace)}}
 {{- end}}
 {{- end -}}
 

--- a/manifests/charts/ai-gateway-helm/templates/envoy_gateway_cluster_role_for_inference_pool.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/envoy_gateway_cluster_role_for_inference_pool.yaml
@@ -10,7 +10,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "ai-gateway-helm.inference-pool.clusterRoleName" . }}
+  name: {{ include "ai-gateway-helm.inference-pool.clusterRoleName" . | quote }}
 rules:
   - apiGroups:
       - "inference.networking.k8s.io"
@@ -24,11 +24,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "ai-gateway-helm.inference-pool.clusterRoleBindingName" . }}
+  name: {{ include "ai-gateway-helm.inference-pool.clusterRoleBindingName" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "ai-gateway-helm.inference-pool.clusterRoleName" . }}
+  name: {{ include "ai-gateway-helm.inference-pool.clusterRoleName" . | quote }}
 subjects:
   - kind: ServiceAccount
     # The service account name is hardcoded to "envoy-gateway":

--- a/manifests/charts/ai-gateway-helm/templates/serviceaccount.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/serviceaccount.yaml
@@ -19,7 +19,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "ai-gateway-helm.controller.clusterRoleName" . }}
+  name: {{ include "ai-gateway-helm.controller.clusterRoleName" . | quote }}
 rules:
   - apiGroups: [""]
     resources:
@@ -103,11 +103,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "ai-gateway-helm.controller.clusterRoleName" . }}
+  name: {{ include "ai-gateway-helm.controller.clusterRoleName" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "ai-gateway-helm.controller.clusterRoleName" . }}
+  name: {{ include "ai-gateway-helm.controller.clusterRoleName" . | quote }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "ai-gateway-helm.controller.serviceAccountName" . }}


### PR DESCRIPTION
**Description**

The controller and inference-pool `ClusterRole`/`ClusterRoleBinding` names are built with `printf "%s:%s" <base> .Release.Namespace` to keep them unique per-release (introduced in #1511). When `.Release.Namespace` is empty, this renders `name: <base>:` — an unquoted trailing colon that strict YAML parsers reject with `mapping values are not allowed in this context`. The whole render fails and zero resources are produced.

This doesn't trigger via `helm install` or `helm template` (the CLI always defaults the namespace), only where a renderer leaves it unset — e.g. the Helm SDK's `engine.Render` without `ReleaseOptions`, or Replicated's image-extraction render.

The fix adds two independent layers of defense across the three affected helpers (`_helpers.tpl`) and their six call sites (`serviceaccount.yaml`, `envoy_gateway_cluster_role_for_inference_pool.yaml`):

- Wrap the namespace in `default "default"` so the `printf` argument is never empty. No behavior change for real installs, where the namespace is always populated.
- Quote the rendered `name` fields so a trailing colon is always unambiguous.

Either layer fixes the failure on its own; both are included for robustness.

**Special notes for reviewers (if applicable)**

Verified with `helm lint` and `helm template` (default and explicit namespaces) — names render correctly as `<base>:<namespace>` with no change to existing behavior.
