### PR TITLE
fix: insert AI Gateway extproc after the buffer filter

### DIFF
--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -854,9 +854,20 @@ func shouldAIGatewayExtProcBeInserted(filters []*httpconnectionmanagerv3.HttpFil
 
 // insertAIGatewayExtProcFilter inserts the AI Gateway extproc filter into the HTTP connection manager.
 //
-// The order is simple: make sure that the AI Gateway extproc filter is the very first extproc filter in the standard
-// Envoy Gateway order. See:
+// The order is mostly simple: make sure that the AI Gateway extproc filter is the first extproc filter in the
+// standard Envoy Gateway order. See:
 // https://github.com/envoyproxy/gateway/blob/f1e6dab770fabc70d175237380eedfc1f9b1a9e5/internal/xds/translator/httpfilters.go#L93
+//
+// There is one exception: the HTTP buffer filter (envoy.filters.http.buffer). In Envoy Gateway's canonical
+// filter order the buffer filter is placed *before* the ext_proc filters, so a user who raises the request
+// buffer limit via the buffer filter (e.g. through an EnvoyPatchPolicy) expects that limit to apply to the AI
+// Gateway extproc as well. The AI Gateway extproc runs with RequestBodyMode: BUFFERED, so inserting it ahead of
+// the buffer filter would make it buffer the request body against the (smaller) default per-connection buffer
+// limit and reject large request bodies with a 413 before the buffer filter's larger limit can take effect. To
+// avoid this, when a buffer filter sits at or after the chosen insertion point we insert the AI Gateway extproc
+// immediately after the last buffer filter instead. The AI Gateway extproc is then the first ext_proc filter to
+// run after the buffer filter (not necessarily the first ext_proc filter overall), so a user-supplied ext_proc
+// placed ahead of the buffer filter, e.g. api-key auth, still runs before it.
 func insertAIGatewayExtProcFilter(mgr *httpconnectionmanagerv3.HttpConnectionManager, filter *httpconnectionmanagerv3.HttpFilter) error {
 	insertIndex := -1
 outer:
@@ -871,6 +882,21 @@ outer:
 	if insertIndex == -1 {
 		return errors.New("failed to find insertion point for AI Gateway extproc filter")
 	}
+
+	// Find the last buffer filter so we can insert the AI Gateway extproc after it (see the buffer-filter
+	// exception in the function doc above).
+	lastBufferIndex := -1
+	for i, existingFilter := range mgr.HttpFilters {
+		if strings.HasPrefix(existingFilter.Name, egv1a1.EnvoyFilterBuffer.String()) {
+			lastBufferIndex = i
+		}
+	}
+	// When the buffer filter sits at or after the ext_proc insertion point, insert the AI Gateway extproc
+	// immediately after it instead. Behavior is unchanged when no buffer filter exists (lastBufferIndex == -1).
+	if lastBufferIndex >= insertIndex {
+		insertIndex = lastBufferIndex + 1
+	}
+
 	mgr.HttpFilters = append(mgr.HttpFilters, filter)
 	copy(mgr.HttpFilters[insertIndex+1:], mgr.HttpFilters[insertIndex:])
 	mgr.HttpFilters[insertIndex] = filter

--- a/internal/extensionserver/post_translate_modify_test.go
+++ b/internal/extensionserver/post_translate_modify_test.go
@@ -168,6 +168,48 @@ func TestInsertAIGatewayExtProcFilter(t *testing.T) {
 			expectedPosition:    2,
 			expectedFilterCount: 6,
 		},
+		{
+			// Mirrors the EKS setup where an api-key ext_proc and a buffer filter are added ahead of AI
+			// Gateway. The ext_proc at index 0 matches afterExtProcFilterPrefixes, but the buffer filter
+			// must still run first so its larger request buffer limit applies to AI Gateway's BUFFERED
+			// extproc. AI Gateway is inserted after the buffer filter (position 2).
+			name: "insert after buffer when ext_proc precedes buffer",
+			existingFilters: []*httpconnectionmanagerv3.HttpFilter{
+				{Name: "envoy.filters.http.ext_proc.apikey"},
+				{Name: "envoy.filters.http.buffer"},
+				{Name: "envoy.filters.http.jwt_authn"},
+				{Name: "envoy.filters.http.rbac"},
+				{Name: "envoy.filters.http.router"},
+			},
+			expectedPosition:    2,
+			expectedFilterCount: 6,
+		},
+		{
+			// When the buffer filter already precedes the first ext_proc filter, AI Gateway is inserted
+			// right after the buffer filter (position 1), preserving Envoy Gateway's buffer-before-extproc
+			// ordering.
+			name: "insert after buffer when buffer precedes ext_proc",
+			existingFilters: []*httpconnectionmanagerv3.HttpFilter{
+				{Name: "envoy.filters.http.buffer"},
+				{Name: "envoy.filters.http.ext_proc.apikey"},
+				{Name: "envoy.filters.http.rbac"},
+				{Name: "envoy.filters.http.router"},
+			},
+			expectedPosition:    1,
+			expectedFilterCount: 5,
+		},
+		{
+			// Regression guard: with no buffer filter present, insertion behavior is unchanged and AI
+			// Gateway lands ahead of the first ext_proc filter (position 0).
+			name: "no buffer filter leaves ext_proc insertion unchanged",
+			existingFilters: []*httpconnectionmanagerv3.HttpFilter{
+				{Name: "envoy.filters.http.ext_proc.apikey"},
+				{Name: "envoy.filters.http.rbac"},
+				{Name: "envoy.filters.http.router"},
+			},
+			expectedPosition:    0,
+			expectedFilterCount: 4,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description**

**Problem**

If a buffer filter (`envoy.filters.http.buffer`) is added to the chain, for example via an EnvoyPatchPolicy to raise the request buffer limit, the AI Gateway extproc could be placed ahead of it. The AI Gateway extproc runs with `RequestBodyMode: BUFFERED`, so when it runs before the buffer filter it buffers the body against Envoy Gateway's default 32 KiB downstream per-connection limit and returns `413 Payload Too Large` for larger bodies before the buffer filter's higher limit applies.

The buffer filter raises the stream's buffer limit to `max_request_bytes`, but only for filters that decode after it. This was hit in practice with large request bodies such as Gemini CLI tool definitions.

**Solution**

When a buffer filter sits at or after the computed ext_proc insertion point, insert the AI Gateway extproc immediately after the last buffer filter. Envoy Gateway already orders the buffer filter before ext_proc, so this honors that order. Behavior is unchanged when no buffer filter is present.

This works because EnvoyPatchPolicy patches are applied before the extension hook runs and Envoy Gateway does not re-sort filters afterward, so the buffer filter is visible to this code.

The extension server only moves its own filter, not the user's buffer filter, so this fixes the 413 for AI Gateway's extproc specifically and not for other co-resident BUFFERED ext_procs.

**Testing**

Added table tests for three cases: ext_proc before buffer (inserted after buffer), buffer before ext_proc (inserted after buffer), and no buffer filter (unchanged).
