### PR TITLE
api: mark ServiceQuota as todo

### DIFF
--- a/api/v1alpha1/quota_policy.go
+++ b/api/v1alpha1/quota_policy.go
@@ -40,6 +40,9 @@ type QuotaPolicySpec struct {
 	// Quota for all models served by AIServiceBackend(s). This value can be overridden for specific models using the "PerModelQuotas"
 	// configuration.
 	//
+	// Currently, the rate limit configuration is properly set up, but the descriptor set is not being set in the Envoy Configuration
+	// TODO: Add changes in the extension server to support ServiceQuota enforcement.
+	//
 	// +optional
 	ServiceQuota ServiceQuotaDefinition `json:"serviceQuota,omitempty"`
 	// PerModelQuotas specifies quota for different models served by the AIServiceBackend(s) where this

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_quotapolicies.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_quotapolicies.yaml
@@ -370,6 +370,8 @@ spec:
                 description: |-
                   Quota for all models served by AIServiceBackend(s). This value can be overridden for specific models using the "PerModelQuotas"
                   configuration.
+
+                  Currently, the rate limit configuration is properly set up, but the descriptor set is not being set in the Envoy Configuration
                 properties:
                   costExpression:
                     description: |-

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -2337,7 +2337,7 @@ QuotaPolicySpec specifies rules for computing token based costs of requests.
   name="serviceQuota"
   type="[ServiceQuotaDefinition](#github-com-envoyproxy-ai-gateway-api-v1alpha1-servicequotadefinition)"
   required="false"
-  description="Quota for all models served by AIServiceBackend(s). This value can be overridden for specific models using the `PerModelQuotas`<br />configuration."
+  description="Quota for all models served by AIServiceBackend(s). This value can be overridden for specific models using the `PerModelQuotas`<br />configuration.<br />Currently, the rate limit configuration is properly set up, but the descriptor set is not being set in the Envoy Configuration"
 /><ApiField
   name="perModelQuotas"
   type="[PerModelQuota](#github-com-envoyproxy-ai-gateway-api-v1alpha1-permodelquota) array"


### PR DESCRIPTION
**Description**
ServiceQuota currently needs to be implemented. The extension server does not inject the descriptor set but the rate limit config is properly configured. Adding it as a TODO/follow up.
