### PR TITLE
api: update quota policy docs

### DIFF
--- a/api/v1alpha1/quota_policy.go
+++ b/api/v1alpha1/quota_policy.go
@@ -12,8 +12,10 @@ import (
 )
 
 // QuotaPolicy specifies token quota configuration for inference services.
-// Providing a list of backends in the AIGatewayRouteRule allows failover to a different service
-// if token quota for a service had been exceeded.
+// Generates rate limit configuration and tracks quota usage.
+// Reject requests with 429 once all related quota to that request has been exceeded.
+//
+// TODO: Waiting on next release of Envoyproxy that will support routing based on non-exceeded quotas.
 //
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_quotapolicies.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_quotapolicies.yaml
@@ -28,10 +28,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |-
+        description: |
           QuotaPolicy specifies token quota configuration for inference services.
-          Providing a list of backends in the AIGatewayRouteRule allows failover to a different service
-          if token quota for a service had been exceeded.
+          Generates rate limit configuration and tracks quota usage.
+          Reject requests with 429 once all related quota to that request has been exceeded.
         properties:
           apiVersion:
             description: |-

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -481,8 +481,9 @@ MCPRouteList contains a list of MCPRoute.
 - [QuotaPolicyList](#github-com-envoyproxy-ai-gateway-api-v1alpha1-quotapolicylist)
 
 QuotaPolicy specifies token quota configuration for inference services.
-Providing a list of backends in the AIGatewayRouteRule allows failover to a different service
-if token quota for a service had been exceeded.
+Generates rate limit configuration and tracks quota usage.
+Reject requests with 429 once all related quota to that request has been exceeded.
+
 
 ##### Fields
 


### PR DESCRIPTION
**Description**

The failover logic depends on an Envoyproxy commit that has not been officially released. Marking that feature as a todo and will enable it once the changes are stable.