### PR TITLE
docs: declare v1beta1 stable for v1.0 and add v1.0.x compatibility row

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -46,6 +46,12 @@ Migration paths for alpha versions will be the best effort and will be documente
 **For stable versions**, we will never break the APIs unless there is a critical security issue.
 We will provide a migration path in the release notes in case we need to break the APIs.
 
+As of the v1.0.0 release, `v1beta1` is the committed **stable** control-plane API and is
+covered by the stable-version guarantee above. The `v1alpha1` API remains served but
+deprecated, and will be removed in a future release per the deprecation policy. Note that
+`QuotaPolicy` is `v1alpha1`-only and is therefore **not** part of the stable surface; in
+particular, its `serviceQuota` field is accepted but not yet enforced end-to-end.
+
 ### Upgrading the Envoy AI Gateway controller
 
 We guarantee that simply upgrading the controller will not break the existing configuration assuming there's no _un-migrated_ resources including breaking change left in the k8s API server. In other words, after the proper use of the API and migration path described above, the user should be able to upgrade the controller without any issue. However, this does mean that we do NOT guarantee that the existing configuration will work across more than two version of the controller. For example if you are using the version N of the controller, and you want to upgrade to the version N+2, you should first upgrade to the version N+1 while following the migration path if applicable, and then upgrade to the version N+2.

--- a/site/docs/compatibility.md
+++ b/site/docs/compatibility.md
@@ -10,8 +10,8 @@ This document provides compatibility information for Envoy AI Gateway releases w
 
 | AI Gateway | Envoy Gateway                 | Kubernetes | Gateway API | Support Status |
 | ---------- | ----------------------------- | ---------- | ----------- | -------------- |
-| main       | v1.7.x+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Development    |
-| v1.0.x     | v1.8.x+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Supported      |
+| main       | v1.8.1+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Development    |
+| v1.0.x     | v1.8.1+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Supported      |
 | v0.7.x     | v1.8.x+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Supported      |
 | v0.6.x     | v1.7.x+ (Envoy Proxy v1.37.x) | v1.32+     | v1.4.x      | Supported      |
 | v0.5.x     | v1.6.x+ (Envoy Proxy v1.35.x) | v1.32+     | v1.4.x      | Supported      |

--- a/site/docs/compatibility.md
+++ b/site/docs/compatibility.md
@@ -11,6 +11,7 @@ This document provides compatibility information for Envoy AI Gateway releases w
 | AI Gateway | Envoy Gateway                 | Kubernetes | Gateway API | Support Status |
 | ---------- | ----------------------------- | ---------- | ----------- | -------------- |
 | main       | v1.7.x+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Development    |
+| v1.0.x     | v1.8.x+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Supported      |
 | v0.7.x     | v1.8.x+ (Envoy Proxy v1.38.x) | v1.32+     | v1.5.x      | Supported      |
 | v0.6.x     | v1.7.x+ (Envoy Proxy v1.37.x) | v1.32+     | v1.4.x      | Supported      |
 | v0.5.x     | v1.6.x+ (Envoy Proxy v1.35.x) | v1.32+     | v1.4.x      | Supported      |


### PR DESCRIPTION
**Description**

Prepare release documentation for the upcoming **v1.0.0** release. Docs-only change in two parts:

- **`RELEASES.md`** — record the API stability commitment that motivates the major version bump. As of v1.0.0, `v1beta1` is the committed **stable** control-plane API and is covered by the existing "never break unless critical security" guarantee. `v1alpha1` remains served but deprecated and will be removed in a future release per the deprecation policy. `QuotaPolicy` stays `v1alpha1`-only and is therefore outside the stable surface; in particular its `serviceQuota` field is accepted but not yet enforced end-to-end.
- **`site/docs/compatibility.md`** — add the `v1.0.x` row to the compatibility matrix (Envoy Gateway v1.8.x+, Envoy Proxy v1.38.x, Kubernetes v1.32+, Gateway API v1.5.x).

No API, controller, or data-plane code changes.

AI usage: these docs were drafted with assistance from Claude (Claude Code) and reviewed by the author.

**Related Issues/PRs (if applicable)**

**Special notes for reviewers (if applicable)**

This is forward-looking v1.0 release-prep. The new `v1.0.x` compatibility row is marked `Supported` and the `RELEASES.md` wording says "as of the v1.0.0 release", even though v1.0.0 has not been tagged yet. Intent is for this to land as part of, or immediately before, the v1.0 cut rather than necessarily merging standalone today.

Two items intentionally left to maintainers:

- EOL rolling in the compatibility matrix. With the v0.7 to v1.0 major jump, which of v0.7.x / v0.6.x / v0.5.x roll to End of Life is a judgment call; this PR only adds the `v1.0.x` row and does not change existing support statuses.
- The `serviceQuota` docs accuracy fix tracked on the `docs/quota-policy-accuracy` branch is complementary to the `RELEASES.md` note added here.
