### PR TITLE
docs: fixed incorrect documentation

### DIFF
--- a/api/v1alpha1/quota_policy.go
+++ b/api/v1alpha1/quota_policy.go
@@ -101,7 +101,7 @@ type QuotaDefinition struct {
 	CostExpression *string `json:"costExpression,omitempty"`
 	// The "Mode" determines how quota is charged to the "DefaultBucket" and matching "BucketRules".
 	// In the "shared" mode the quota is charged to all matching "BucketRules" AND the "DefaultBucket"
-	// and request is allowed only if the quota is available in all matching buckets.
+	// and request is allowed only if the quota is available in at least one matching buckets.
 	// Defaults to "Shared".
 	//
 	// +optional

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_quotapolicies.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_quotapolicies.yaml
@@ -355,7 +355,7 @@ spec:
                           description: |-
                             The "Mode" determines how quota is charged to the "DefaultBucket" and matching "BucketRules".
                             In the "shared" mode the quota is charged to all matching "BucketRules" AND the "DefaultBucket"
-                            and request is allowed only if the quota is available in all matching buckets.
+                            and request is allowed only if the quota is available in at least one matching buckets.
                             Defaults to "Shared".
                           enum:
                           - Shared

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -2302,7 +2302,7 @@ QuotaDefinition specified expression for computing request cost and rules for ma
   type="[QuotaBucketMode](#github-com-envoyproxy-ai-gateway-api-v1alpha1-quotabucketmode)"
   required="false"
   defaultValue="Shared"
-  description="The `Mode` determines how quota is charged to the `DefaultBucket` and matching `BucketRules`.<br />In the `shared` mode the quota is charged to all matching `BucketRules` AND the `DefaultBucket`<br />and request is allowed only if the quota is available in all matching buckets.<br />Defaults to `Shared`."
+  description="The `Mode` determines how quota is charged to the `DefaultBucket` and matching `BucketRules`.<br />In the `shared` mode the quota is charged to all matching `BucketRules` AND the `DefaultBucket`<br />and request is allowed only if the quota is available in at least one matching buckets.<br />Defaults to `Shared`."
 /><ApiField
   name="defaultBucket"
   type="[QuotaValue](#github-com-envoyproxy-ai-gateway-api-v1alpha1-quotavalue)"


### PR DESCRIPTION
**Description**

These limits are quota mode which behaves as the inverse of traditional rate limit. Updating the document to reflect that.