### PR TITLE
fix: allow x-ai-eg-model in headerMutation

### DIFF
--- a/internal/headermutator/header_mutator.go
+++ b/internal/headermutator/header_mutator.go
@@ -110,14 +110,19 @@ func (h *HeaderMutator) Mutate(headers map[string]string, onRetry bool) (sets []
 //
 // Skip Envoy AI Gateway headers since some of them are populated after the originalHeaders are captured.
 // This should be safe since these headers are managed by Envoy AI Gateway itself, not expected to be
-// modified by users via header mutation API.
+// modified by users via header mutation API. The exception is x-ai-eg-model: it is user-visible in
+// AIGatewayRoute matching and can be useful to rewrite before forwarding upstream.
 //
 // Also, skip Envoy pseudo-headers beginning with ':', such as ":method", ":path", etc.
 // This is important because these headers are not only sensitive to our implementation detail as well as
 // it can cause unexpected behavior if they are modified unexpectedly. User shouldn't need to
 // modify these headers via header mutation API.
 func shouldIgnoreHeader(key string) bool {
-	return strings.HasPrefix(key, ":") ||
-		strings.HasPrefix(key, internalapi.EnvoyAIGatewayHeaderPrefix) ||
-		strings.EqualFold(key, internalapi.EnvoyOriginalPathHeader)
+	if strings.HasPrefix(key, ":") || strings.EqualFold(key, internalapi.EnvoyOriginalPathHeader) {
+		return true
+	}
+	if strings.EqualFold(key, internalapi.ModelNameHeaderKeyDefault) {
+		return false
+	}
+	return strings.HasPrefix(key, internalapi.EnvoyAIGatewayHeaderPrefix)
 }

--- a/internal/headermutator/header_mutator_test.go
+++ b/internal/headermutator/header_mutator_test.go
@@ -87,4 +87,28 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 		require.Equal(t, "original", headers["only-in-original"])
 		require.Equal(t, "pikachu", headers["in-original-too-but-previous-attempt-set"])
 	})
+
+	t.Run("allow model header mutation", func(t *testing.T) {
+		headers := map[string]string{
+			internalapi.ModelNameHeaderKeyDefault: "some-model",
+			internalapi.OriginalPathHeader:        "/v1/chat/completions",
+		}
+		mutations := &filterapi.HTTPHeaderMutation{
+			Set: []filterapi.HTTPHeader{{
+				Name:  internalapi.ModelNameHeaderKeyDefault,
+				Value: "different-model",
+			}},
+		}
+
+		mutator := NewHeaderMutator(mutations, nil)
+		sets, removes := mutator.Mutate(headers, false)
+
+		require.Empty(t, removes)
+		require.Len(t, sets, 1)
+		require.Equal(t, internalapi.ModelNameHeaderKeyDefault, sets[0][0])
+		require.Equal(t, "different-model", sets[0][1])
+		require.Equal(t, "different-model", headers[internalapi.ModelNameHeaderKeyDefault])
+		// Other internal AI Gateway headers should remain protected.
+		require.Equal(t, "/v1/chat/completions", headers[internalapi.OriginalPathHeader])
+	})
 }


### PR DESCRIPTION
Description

Right now `headerMutation.set` pretty much drops `x-ai-eg-model`, so the backend still sees the original model header.
This lets `x-ai-eg-model` pass through `shouldIgnoreHeader` and keeps the rest of `x-ai-eg-*` blocked.

Repro
1. Apply the route from #1872 with `headerMutation.set.name: x-ai-eg-model`.
2. Send a `/v1/chat/completions` request with model `some-model`.
3. Check the upstream request headers.
4. Before this patch: `x-ai-eg-model: some-model`
5. After this patch: `x-ai-eg-model: different-model`

Related Issues/PRs (if applicable)

Fixes #1872
Related PR: #1977

Special notes for reviewers (if applicable)

Added a small regression test in `internal/headermutator`.
