### PR TITLE
docs: update homepage release card to v1.0

### DIFF
--- a/site/src/components/HomepageFeatures/index.tsx
+++ b/site/src/components/HomepageFeatures/index.tsx
@@ -19,11 +19,11 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: 'v0.7 Release now available',
+    title: 'v1.0 Release now available',
     image: require('@site/static/img/3.png').default,
     description: (
       <>
-        The v0.7 Release of Envoy AI Gateway is now available. See the <a href="/release-notes/v0.7">release notes</a> for more information.
+        The v1.0 Release of Envoy AI Gateway is now available. See the <a href="/release-notes/v1.0">release notes</a> for more information.
       </>
     ),
   },


### PR DESCRIPTION
**Description**

The homepage "Release now available" feature card still advertised the v0.7 release after the v1.0 GA cut (#2258), so the live site at aigateway.envoyproxy.io shows "v0.7 Release now available" even though 1.0 is the default documentation version. This updates the card title, body text, and link to point at the v1.0 release notes.

The docs version dropdown itself already defaults to 1.0 (via `lastVersion` in `docusaurus.config.ts`) — this PR only fixes the hand-maintained homepage card in `site/src/components/HomepageFeatures/index.tsx` that was missed during the version cut.

**Related Issues/PRs (if applicable)**

Related PR: #2258

**Special notes for reviewers (if applicable)**

Docs/site-only change; no code, API, or behavior impact. Prepared with the help of Claude Code (Claude Opus 4.8) and reviewed before submission.
