### PR TITLE
docs: copy edits to v1.0 release content

### DIFF
--- a/site/blog/2026/2026-06-23-v1.0-release-announcement.md
+++ b/site/blog/2026/2026-06-23-v1.0-release-announcement.md
@@ -130,8 +130,8 @@ how you already deploy and operate it.
 Tencent, Netflix, and Nutanix**, alongside a growing roster of independent contributors who join our **weekly
 community meetings**, file issues, and ship code.
 
-Just as importantly, the project has been hardened by real production use. Our thanks to the
-organizations who shared feedback and production insights along the way — including **Bloomberg, LY
+Just as importantly, the project has been shaped by real-world use. Our thanks to the
+organizations who used, tested, and shared feedback along the way — including **LY
 Corporation, Alan by Comma Soft, and the National Research Platform**.
 
 [![Star History Chart](https://api.star-history.com/svg?repos=envoyproxy/ai-gateway&type=Date)](https://www.star-history.com/#envoyproxy/ai-gateway&Date)
@@ -166,7 +166,7 @@ The roadmap is community-driven — and we'd love your help shaping it.
 ## 🙏 Acknowledgments
 
 1.0 belongs to everyone who got us here: the maintainers and contributors who wrote the code and reviews,
-the early adopters who ran pre-releases in production and told us what broke, and the broader Gateway API,
+the early adopters who tested pre-releases and told us what broke, and the broader Gateway API,
 Envoy, and CNCF communities whose standards we build on. Thank you.
 
 The future of AI infrastructure is **open, stable, and community-driven**. We can't wait to see what you

--- a/site/src/pages/release-notes/v1.0.mdx
+++ b/site/src/pages/release-notes/v1.0.mdx
@@ -141,7 +141,7 @@ If you are on an older release, upgrade one or two minor versions at a time and 
 1.0 belongs to everyone who got us here. Our deepest thanks to:
 
 - The **maintainers** across Tetrate, Bloomberg, Tencent, and Nutanix, and the many independent contributors who shaped the project through code, reviews, and weekly community meetings.
-- The **early adopters** — including Bloomberg, LY Corporation, Alan by Comma Soft, and NRP — who ran Envoy AI Gateway in production and fed back what mattered.
+- The **early adopters** — including LY Corporation, Alan by Comma Soft, and NRP — who used, tested, and fed back what mattered.
 - The broader **Gateway API, Envoy, and CNCF** communities whose standards this project is built on.
 
 ## 🔮 What's Next (Beyond 1.0)


### PR DESCRIPTION
**Description**

Copy edits to the v1.0 release content — the announcement blog post and the v1.0 release notes page. This refines wording in the acknowledgements/adopter sections for accuracy and tone. No product capabilities, code, or generated files are affected.

Files changed:

- `site/blog/2026/2026-06-23-v1.0-release-announcement.md`
- `site/src/pages/release-notes/v1.0.mdx`

**Related Issues/PRs (if applicable)**

**Special notes for reviewers (if applicable)**

Docs-only change.
