### PR TITLE
blog: add Linkedin profile url for gavrissh

### DIFF
--- a/site/blog/authors.yml
+++ b/site/blog/authors.yml
@@ -105,3 +105,4 @@ gavrissh:
   page: true
   socials:
     github: gavrissh
+    linkedin: https://www.linkedin.com/in/gavrish-prabhu


### PR DESCRIPTION
**Description**

Adding Linkedin url to the author profile 

