### PR TITLE
fix: treat empty body as non-fatal in decodeContentIfNeeded

### DIFF
--- a/internal/extproc/util.go
+++ b/internal/extproc/util.go
@@ -30,6 +30,19 @@ type contentDecodingResult struct {
 // Currently, supports gzip and brotli encoding, but can be extended to support other encodings in the future.
 // Returns a reader for the (potentially decompressed) body and metadata about the encoding.
 func decodeContentIfNeeded(body []byte, contentEncoding string) (contentDecodingResult, error) {
+	// An empty body has nothing to decompress. gzip.NewReader reads the gzip
+	// header eagerly, so building it over zero bytes fails immediately with
+	// io.EOF. That gets surfaced as a fatal "failed to decode gzip: EOF" and
+	// aborts an otherwise-successful upstream response. This can happen when the
+	// upstream sends Content-Encoding: gzip with an empty body, or when a
+	// streaming response is buffered to end-of-stream with no payload. Treat an
+	// empty body as nothing to decode and pass it through unchanged.
+	if len(body) == 0 {
+		return contentDecodingResult{
+			reader:    bytes.NewReader(body),
+			isEncoded: false,
+		}, nil
+	}
 	switch contentEncoding {
 	case "gzip":
 		reader, err := gzip.NewReader(bytes.NewReader(body))

--- a/internal/extproc/util_test.go
+++ b/internal/extproc/util_test.go
@@ -75,6 +75,17 @@ func TestDecodeContentIfNeeded(t *testing.T) {
 			wantEncoding: "",
 			wantErr:      true,
 		},
+		{
+			// An empty body with Content-Encoding: gzip must not error. gzip.NewReader
+			// over zero bytes returns io.EOF; treating that as a decode failure aborts
+			// an otherwise-successful upstream response.
+			name:         "empty gzip body",
+			body:         []byte{},
+			encoding:     "gzip",
+			wantEncoded:  false,
+			wantEncoding: "",
+			wantErr:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description**

When an upstream response is gzip-encoded but has an empty body, the gateway aborts a response that was actually fine.

`decodeContentIfNeeded` builds a `gzip.NewReader` to decompress the body. `gzip.NewReader` reads the gzip header immediately, and over a zero-byte body that read returns `io.EOF`. The function returns that as `failed to decode gzip: EOF`, which the ext_proc layer treats as fatal, so the client gets nothing even though the upstream returned a successful response. We saw this in production as an ext_proc abort with `response_code: 200` but `bytes_sent: 0`.

This happens when an upstream sends `Content-Encoding: gzip` with an empty body, or when a streaming response is buffered to end-of-stream with no payload (for example, the connection terminated before any body bytes arrived). The streaming path also runs the accumulated buffer through `decodeContentIfNeeded`, so an empty buffer hits the same error.

The fix returns an empty body as-is instead of trying to build a decompressor. It is intentionally narrow: a non-empty but malformed gzip body still errors exactly as before, and only the zero-length case is treated as a pass-through.

Tests: added an `empty gzip body` case to `TestDecodeContentIfNeeded` covering an empty body with `Content-Encoding: gzip`. `gofmt`, `go vet`, and the `internal/extproc` package tests pass.

**Related Issues/PRs (if applicable)**

N/A

**Special notes for reviewers (if applicable)**

The guard lives in `decodeContentIfNeeded` rather than at the call sites because both the buffered and streaming paths flow through it, so a single check covers both.
