### PR TITLE
fix(translator): return error instead of panicking on stream marshal failure

### DIFF
--- a/internal/translator/openai_awsbedrock.go
+++ b/internal/translator/openai_awsbedrock.go
@@ -737,7 +737,9 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(_ map[string
 			}
 			err = serializeOpenAIChatCompletionChunk(oaiEvent, &newBody)
 			if err != nil {
-				panic(fmt.Errorf("failed to marshal event: %w", err))
+				// Return the error so Envoy can handle the failure gracefully instead of
+				// panicking, which would crash extproc and disrupt all in-flight requests.
+				return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("failed to marshal streaming event: %w", err)
 			}
 			if span != nil {
 				span.RecordResponseChunk(oaiEvent)

--- a/internal/translator/openai_awsbedrock_test.go
+++ b/internal/translator/openai_awsbedrock_test.go
@@ -1518,6 +1518,35 @@ func TestOpenAIToAWSBedrockTranslator_ResponseError(t *testing.T) {
 	}
 }
 
+// TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_Streaming_MarshalError verifies that a failure
+// to serialize a converted streaming chunk is returned to the caller instead of panicking and
+// crashing extproc. See https://github.com/envoyproxy/ai-gateway/issues/2288.
+func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_Streaming_MarshalError(t *testing.T) {
+	// Valid chunks never fail to marshal, so inject a marshal failure on the serialization path.
+	original := jsonMarshal
+	jsonMarshal = func(any) ([]byte, error) { return nil, fmt.Errorf("injected marshal failure") }
+	t.Cleanup(func() { jsonMarshal = original })
+
+	// Encode a single content-block delta so convertEvent yields a chunk that is then serialized.
+	buf := bytes.NewBuffer(nil)
+	encoder := eventstream.NewEncoder()
+	payload, err := json.Marshal(awsbedrock.ConverseStreamEvent{
+		EventType: awsbedrock.ConverseStreamEventTypeContentBlockDelta.String(),
+		Delta:     &awsbedrock.ConverseStreamEventContentBlockDelta{Text: ptr.To("hello")},
+	})
+	require.NoError(t, err)
+	require.NoError(t, encoder.Encode(buf, eventstream.Message{
+		Headers: eventstream.Headers{{Name: ":event-type", Value: eventstream.StringValue("chunk")}},
+		Payload: payload,
+	}))
+
+	o := &openAIToAWSBedrockTranslatorV1ChatCompletion{stream: true, requestModel: "claude-sonnet-4"}
+	require.NotPanics(t, func() {
+		_, _, _, _, err = o.ResponseBody(nil, buf, true, nil)
+	})
+	require.ErrorContains(t, err, "injected marshal failure")
+}
+
 func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T) {
 	t.Run("invalid body", func(t *testing.T) {
 		o := &openAIToAWSBedrockTranslatorV1ChatCompletion{}

--- a/internal/translator/util.go
+++ b/internal/translator/util.go
@@ -30,6 +30,10 @@ var (
 	sseDoneFullLine = append(append(sseDataPrefix, sseDoneMessage...), '\n')
 )
 
+// jsonMarshal indirects [json.Marshal] so tests can simulate marshalling
+// failures on the streaming serialization path, which valid chunks never trigger.
+var jsonMarshal = json.Marshal
+
 // regDataURI follows the web uri regex definition.
 // https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data#syntax
 var regDataURI = regexp.MustCompile(`\Adata:(.+?)?(;base64)?,`)
@@ -63,7 +67,7 @@ func systemMsgToDeveloperMsg(msg openai.ChatCompletionSystemMessageParam) openai
 // serialize a ChatCompletionResponseChunk, this is common for all chat completion request
 func serializeOpenAIChatCompletionChunk(chunk *openai.ChatCompletionResponseChunk, buf *[]byte) error {
 	var chunkBytes []byte
-	chunkBytes, err := json.Marshal(chunk)
+	chunkBytes, err := jsonMarshal(chunk)
 	if err != nil {
 		return fmt.Errorf("failed to marshal stream chunk: %w", err)
 	}


### PR DESCRIPTION
**Description**

The OpenAI to AWS Bedrock streaming translator calls `panic()` when a converted chunk fails to serialize (`internal/translator/openai_awsbedrock.go:740`). A panic on the response path crashes the extproc process and tears down every in-flight request through the gateway, instead of failing just the one request. This returns the error to the caller, matching the non-streaming decode path a few lines futher down in the same function.

In practice a valid chunk almost never fails to marshal (it is all string and int fields), so the panic guarded a path that is hard to hit with real data. To still cover it, a small `jsonMarshal` seam is added in `util.go` that the test swaps to force a marshal failure.

**Related Issues/PRs (if applicable)**

Fixes #2288

**Special notes for reviewers (if applicable)**

The `jsonMarshal` package var defaults to `json.Marshal`, so there is no behaviour change outside tests. The new test asserts `ResponseBody` returns the error and does not panic. The `internal/translator`, `internal/metrics` and `internal/extproc` packages pass, vet and gofmt are clean.
