### PR TITLE
fix(backendauth): resolve AWS signing host from `:authority` header

### DIFF
--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -80,9 +80,12 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 
 // Do implements [Handler.Do].
 //
-// The method reads :method, :path, and :authority from requestHeaders (HTTP/2 pseudo-headers).
-// When :authority is present, the signed request targets that host; when absent, the host defaults to
-// the standard AWS Bedrock endpoint for the configured region (bedrock-runtime.<region>.amazonaws.com).
+// The method reads :method, :path, :authority, and host from requestHeaders. It resolves the host
+// for the signed request in the following order:
+//  1. the :authority pseudo-header, when present;
+//  2. the host header, when :authority is absent;
+//  3. the standard AWS Bedrock endpoint for the configured region
+//     (bedrock-runtime.<region>.amazonaws.com), when both host and :authority are absent.
 //
 // The transformation must set :path in the header mutation and provide the request body
 // before this method is called.
@@ -90,6 +93,9 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, m
 	method := requestHeaders[":method"]
 	path := requestHeaders[":path"]
 	authority := requestHeaders[":authority"]
+	if authority == "" {
+		authority = requestHeaders["host"]
+	}
 	if authority == "" {
 		authority = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
 	}

--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -92,12 +92,12 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, mutatedBody []byte) ([]internalapi.Header, error) {
 	method := requestHeaders[":method"]
 	path := requestHeaders[":path"]
-	authority := requestHeaders[":authority"]
-	if authority == "" {
-		authority = requestHeaders["host"]
+	host := requestHeaders[":authority"]
+	if host == "" {
+		host = requestHeaders["host"]
 	}
-	if authority == "" {
-		authority = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
+	if host == "" {
+		host = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
 	}
 
 	var body []byte
@@ -107,7 +107,7 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, m
 
 	payloadHash := sha256.Sum256(body)
 	req, err := http.NewRequest(method,
-		fmt.Sprintf("https://%s%s", authority, path),
+		fmt.Sprintf("https://%s%s", host, path),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)

--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -80,10 +80,9 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 
 // Do implements [Handler.Do].
 //
-// The method reads :method, :path, :authority, and :scheme from requestHeaders (HTTP/2 pseudo-headers).
+// The method reads :method, :path, and :authority from requestHeaders (HTTP/2 pseudo-headers).
 // When :authority is present, the signed request targets that host; when absent, the host defaults to
 // the standard AWS Bedrock endpoint for the configured region (bedrock-runtime.<region>.amazonaws.com).
-// When :scheme is present, it is used as the URL scheme; when absent, "https" is used.
 //
 // The transformation must set :path in the header mutation and provide the request body
 // before this method is called.

--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -80,20 +80,34 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 
 // Do implements [Handler.Do].
 //
-// This assumes that during the transformation, the path is set in the header mutation as well as
-// the body in the body mutation.
+// The method reads :method, :path, :authority, and :scheme from requestHeaders (HTTP/2 pseudo-headers).
+// When :authority is present, the signed request targets that host; when absent, the host defaults to
+// the standard AWS Bedrock endpoint for the configured region (bedrock-runtime.<region>.amazonaws.com).
+// When :scheme is present, it is used as the URL scheme; when absent, "https" is used.
+//
+// The transformation must set :path in the header mutation and provide the request body
+// before this method is called.
 func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, mutatedBody []byte) ([]internalapi.Header, error) {
 	method := requestHeaders[":method"]
 	path := requestHeaders[":path"]
+	authority := requestHeaders[":authority"]
+	scheme := requestHeaders[":scheme"]
 
 	var body []byte
 	if len(mutatedBody) > 0 {
 		body = mutatedBody
 	}
 
+	if authority == "" {
+		authority = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
+	}
+	if scheme == "" {
+		scheme = "https"
+	}
+
 	payloadHash := sha256.Sum256(body)
 	req, err := http.NewRequest(method,
-		fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com%s", a.region, path),
+		fmt.Sprintf("%s://%s%s", scheme, authority, path),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)

--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -91,23 +91,18 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, m
 	method := requestHeaders[":method"]
 	path := requestHeaders[":path"]
 	authority := requestHeaders[":authority"]
-	scheme := requestHeaders[":scheme"]
+	if authority == "" {
+		authority = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
+	}
 
 	var body []byte
 	if len(mutatedBody) > 0 {
 		body = mutatedBody
 	}
 
-	if authority == "" {
-		authority = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
-	}
-	if scheme == "" {
-		scheme = "https"
-	}
-
 	payloadHash := sha256.Sum256(body)
 	req, err := http.NewRequest(method,
-		fmt.Sprintf("%s://%s%s", scheme, authority, path),
+		fmt.Sprintf("https://%s%s", authority, path),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)

--- a/internal/backendauth/aws_test.go
+++ b/internal/backendauth/aws_test.go
@@ -235,27 +235,6 @@ func TestAWSHandler_Do(t *testing.T) {
 		require.Contains(t, headers, "X-Amz-Date")
 	})
 
-	t.Run("custom scheme from :scheme header", func(t *testing.T) {
-		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
-		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
-			CredentialFileLiteral: awsFileBody,
-			Region:                "us-east-1",
-		})
-		require.NoError(t, err)
-
-		// When :scheme is present, Do must use it instead of the default "https".
-		hdrs, err := handler.Do(t.Context(), map[string]string{
-			":method": "POST",
-			":path":   "/model/test-model/invoke",
-			":scheme": "https",
-		}, []byte(`{"test": "data"}`))
-		require.NoError(t, err)
-
-		headers := stringPairsToMap(hdrs)
-		require.Contains(t, headers, "Authorization")
-		require.Contains(t, headers, "X-Amz-Date")
-	})
-
 	t.Run("multiple regions", func(t *testing.T) {
 		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
 		regions := []string{"us-east-1", "eu-west-1", "ap-southeast-1"}

--- a/internal/backendauth/aws_test.go
+++ b/internal/backendauth/aws_test.go
@@ -213,6 +213,49 @@ func TestAWSHandler_Do(t *testing.T) {
 		require.Contains(t, headers, "X-Amz-Date")
 	})
 
+	t.Run("custom authority from :authority header", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// When :authority is present, Do must use it as the host rather than the
+		// default bedrock-runtime endpoint.
+		hdrs, err := handler.Do(t.Context(), map[string]string{
+			":method":    "POST",
+			":path":      "/model/test-model/invoke",
+			":authority": "vpce-0123456789abcdef0-xyz.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		}, []byte(`{"test": "data"}`))
+		require.NoError(t, err)
+
+		headers := stringPairsToMap(hdrs)
+		require.Contains(t, headers, "Authorization")
+		require.Contains(t, headers, "X-Amz-Date")
+	})
+
+	t.Run("custom scheme from :scheme header", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// When :scheme is present, Do must use it instead of the default "https".
+		hdrs, err := handler.Do(t.Context(), map[string]string{
+			":method": "POST",
+			":path":   "/model/test-model/invoke",
+			":scheme": "https",
+		}, []byte(`{"test": "data"}`))
+		require.NoError(t, err)
+
+		headers := stringPairsToMap(hdrs)
+		require.Contains(t, headers, "Authorization")
+		require.Contains(t, headers, "X-Amz-Date")
+	})
+
 	t.Run("multiple regions", func(t *testing.T) {
 		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
 		regions := []string{"us-east-1", "eu-west-1", "ap-southeast-1"}

--- a/internal/backendauth/aws_test.go
+++ b/internal/backendauth/aws_test.go
@@ -235,6 +235,44 @@ func TestAWSHandler_Do(t *testing.T) {
 		require.Contains(t, headers, "X-Amz-Date")
 	})
 
+	t.Run("custom authority from host header", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// When :authority is absent, Do must fall back to the host header.
+		hdrs, err := handler.Do(t.Context(), map[string]string{
+			":method": "POST",
+			":path":   "/model/test-model/invoke",
+			"host":    "vpce-0123456789abcdef0-xyz.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		}, []byte(`{"test": "data"}`))
+		require.NoError(t, err)
+
+		headers := stringPairsToMap(hdrs)
+		require.Contains(t, headers, "Authorization")
+		require.Contains(t, headers, "X-Amz-Date")
+	})
+
+	t.Run("invalid method fails request creation", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// An invalid HTTP method token causes http.NewRequest to fail.
+		_, err = handler.Do(t.Context(), map[string]string{
+			":method": "INVALID METHOD",
+			":path":   "/model/test-model/invoke",
+		}, []byte(`{"test": "data"}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot create request")
+	})
+
 	t.Run("multiple regions", func(t *testing.T) {
 		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
 		regions := []string{"us-east-1", "eu-west-1", "ap-southeast-1"}


### PR DESCRIPTION
**Description**

- The `awsHandler.Do` method previously hardcoded the request URL as `https://bedrock-runtime.<region>.amazonaws.com<path>`, ignoring the `:authority` HTTP/2 pseudo-header passed in by the ExtProc filter. 
- This prevented the handler from targeting custom endpoints such as AWS Private VPC endpoints, custom domain proxies, or any non-standard Bedrock host.

This commit makes the host selection dynamic:

- Reads the host from the `:authority` pseudo-header when present.
- Falls back to the `host` header when `:authority` is absent.
- Falls back to `bedrock-runtime.<region>.amazonaws.com` when both `host` and `:authority` are absent, preserving existing behavior.
- Updates the `Do` doc comment to describe the resolution logic, following the inclusive documentation style.
- Adds tests to cover the new `:authority` and `host` fallback branches.

**Related Issues/PRs**

Addresses the TODO left in: https://github.com/envoyproxy/ai-gateway/pull/61#discussion_r1900599982

> "I believe we always use `bedrock-runtime.*.amazonaws.com` so hardcoded — let's see if someone complains"

**Special notes for reviewers**

- The fallback for `:authority` and `host` is identical to the original hardcoded
  values, so there is no behavior change for existing deployments that do not set this
  header.
- The `:authority` pseudo-header in Envoy's ExtProc is set to the (potentially rewritten)
  upstream host, making it the correct source of truth for the target endpoint — not the
  static region string on the handler struct.
- The `region` field on `awsHandler` is still used in the default URL.

