### PR TITLE
fix(controller): dedupe namespaces when locating gateway objects

### DIFF
--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1148,8 +1148,22 @@ func (c *GatewayController) getObjectsForGateway(ctx context.Context, gw *gwapiv
 		"%s=%s,%s=%s", egOwningGatewayNameLabel, gw.Name, egOwningGatewayNamespaceLabel, gw.Namespace,
 	)}
 
+	// Envoy Gateway may run either in the Gateway's own namespace (controller
+	// colocated with the Gateways) or in a separate Envoy Gateway system
+	// namespace, so we look in both. When the two are the same namespace —
+	// common when Envoy Gateway is installed alongside the Gateways it manages —
+	// we must scan it only once. Listing the same namespace twice double-counts
+	// the same objects and records the namespace twice in distinctNamespaces,
+	// spuriously tripping the multiple-namespaces guard below and breaking
+	// reconciliation for an otherwise valid single-namespace deployment.
 	var distinctNamespaces []string
+	seenNamespaces := make(map[string]struct{}, 2)
 	for _, ns := range []string{gw.Namespace, c.envoyGatewayNamespace} {
+		if _, ok := seenNamespaces[ns]; ok {
+			continue
+		}
+		seenNamespaces[ns] = struct{}{}
+
 		var ps *corev1.PodList
 		ps, err = c.kube.CoreV1().Pods(ns).List(ctx, listOption)
 		if err != nil {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -2837,3 +2837,43 @@ func TestGatewayController_getObjectsForGatewayNamespaceInconsistency(t *testing
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "found gateway-labeled objects in multiple namespaces")
 }
+
+// TestGatewayController_getObjectsForGatewaySameNamespace verifies that when Envoy
+// Gateway is colocated with the Gateways it manages (gw.Namespace ==
+// envoyGatewayNamespace), the gateway-labeled objects in that single namespace are
+// scanned only once instead of being double-counted. Without de-duplicating the
+// namespaces to scan, the same objects are found on both passes, the namespace is
+// recorded twice, and the controller spuriously fails with "found gateway-labeled
+// objects in multiple namespaces" — breaking reconciliation for an otherwise valid
+// single-namespace deployment.
+func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
+	const gwName, namespace = "gw", "inference"
+	labels := map[string]string{
+		egOwningGatewayNameLabel:      gwName,
+		egOwningGatewayNamespaceLabel: namespace,
+	}
+	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: namespace}}
+
+	kube := fake2.NewClientset()
+	// Envoy Gateway is deployed in the same namespace as the Gateway, so
+	// gw.Namespace and the envoyGatewayNamespace passed below are identical.
+	c := NewGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, namespace,
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	_, err := kube.CoreV1().Pods(namespace).Create(t.Context(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: namespace, Labels: labels},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = kube.AppsV1().Deployments(namespace).Create(t.Context(), &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: namespace, Labels: labels},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	gotNamespace, pods, deployments, _, err := c.getObjectsForGateway(t.Context(), gw)
+	require.NoError(t, err)
+	require.Equal(t, namespace, gotNamespace)
+	// The shared namespace must be scanned exactly once; scanning it twice would
+	// double-count the same objects.
+	require.Len(t, pods, 1)
+	require.Len(t, deployments, 1)
+}


### PR DESCRIPTION
**Description**

`getObjectsForGateway` scans for gateway-labeled pods/deployments/daemonsets across both `gw.Namespace` and the configured `envoyGatewayNamespace`. When Envoy Gateway is colocated with the Gateways it manages, those two namespaces are identical, so the loop lists the same namespace twice, finds the same objects on both passes, and appends the namespace to `distinctNamespaces` twice. The `len(distinctNamespaces) > 1` guard then fires on a perfectly valid single-namespace deployment:

```
failed to get objects for gateway ai-gateway: found gateway-labeled objects in multiple namespaces: [inference inference]
```

Because reconciliation aborts, the controller never regenerates the per-gateway filter-config `Secret`, so newly rolled extproc pods crash-loop with `config version mismatch: expected "<new>", got "<old>"` and the data plane can never converge after a controller upgrade.

This regressed after v0.7.0, which performed a single cluster-wide `List` and did not have the two-namespace loop.

**Fix**: de-duplicate the namespaces before scanning, so a shared namespace is examined exactly once. Genuinely distinct namespaces (e.g. Envoy Gateway running in a separate system namespace from the Gateway) still populate `distinctNamespaces` with two entries and continue to trip the guard, so the existing safety check is preserved.

**Testing**:

- Added `TestGatewayController_getObjectsForGatewaySameNamespace`, which configures `gw.Namespace == envoyGatewayNamespace`, places a gateway-labeled pod and deployment in that single namespace, and asserts reconciliation succeeds with no error, returns the correct namespace, and does not double-count the objects (`len(pods) == 1`, `len(deployments) == 1`). The test fails on `main` with the exact `found gateway-labeled objects in multiple namespaces: [inference inference]` error and passes with this change.
- The existing `TestGatewayController_getObjectsForGatewayNamespaceInconsistency` (genuinely distinct namespaces) continues to pass, confirming the multi-namespace guard still fires when it should.
- `make format`, `golangci-lint run ./internal/controller/...` (0 issues), and `go test ./internal/controller/...` all pass.

**Related Issues/PRs (if applicable)**

Fixes #2301

**Special notes for reviewers (if applicable)**

This affects any deployment where Envoy Gateway is installed in the same namespace as the Gateways it manages (for example a Helm install that sets `envoyGateway.namespace` to the Gateways' namespace). It surfaced in production on v1.0.0 after a controller upgrade, where the data plane could not converge to the new extproc image because the filter-config `Secret` was never re-stamped to the new version.
