### PR TITLE
feat(apischema): adding support for `namespace` and `tool_search` tool for Codex cli

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -2842,6 +2842,8 @@ type ResponseToolUnion struct {
 	OfCustom           *CustomToolParam
 	OfWebSearchPreview *WebSearchPreviewToolParam
 	OfApplyPatch       *ApplyPatchToolParam
+	OfNamespace        *ToolNamespaceParam
+	OfToolSearch       *ToolSearchParam
 }
 
 func (t ResponseToolUnion) MarshalJSON() ([]byte, error) { // nolint:gocritic
@@ -2870,6 +2872,10 @@ func (t ResponseToolUnion) MarshalJSON() ([]byte, error) { // nolint:gocritic
 		return json.Marshal(t.OfWebSearchPreview)
 	case t.OfApplyPatch != nil:
 		return json.Marshal(t.OfApplyPatch)
+	case t.OfNamespace != nil:
+		return json.Marshal(t.OfNamespace)
+	case t.OfToolSearch != nil:
+		return json.Marshal(t.OfToolSearch)
 	default:
 		return nil, errors.New("no tool to marshal in ToolUnionParam")
 	}
@@ -2950,6 +2956,18 @@ func (t *ResponseToolUnion) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		t.OfApplyPatch = &ap
+	case "namespace":
+		var ns ToolNamespaceParam
+		if err := json.Unmarshal(data, &ns); err != nil {
+			return err
+		}
+		t.OfNamespace = &ns
+	case "tool_search":
+		var ts ToolSearchParam
+		if err := json.Unmarshal(data, &ts); err != nil {
+			return err
+		}
+		t.OfToolSearch = &ts
 	default:
 		return errors.New("unknown tool type")
 	}
@@ -3653,6 +3671,35 @@ type WebSearchPreviewToolUserLocationParam struct {
 type ApplyPatchToolParam struct {
 	// The type of the tool. Always `apply_patch`.
 	Type string `json:"type"`
+}
+
+// ToolNamespaceParam mirrors the "namespace" tool type emitted by the OpenAI
+// Codex CLI. It groups multiple sub-tools to keep large tool inventories
+// organised. See https://github.com/openai/codex/blob/main/codex-rs/tools/src/responses_api.rs
+type ToolNamespaceParam struct {
+	// The type of the namespace tool. Always `namespace`.
+	Type string `json:"type"`
+	// The name of the namespace.
+	Name string `json:"name,omitzero"`
+	// A description of the namespace.
+	Description string `json:"description,omitzero"`
+	// The sub-tools grouped under this namespace. Stored as raw JSON so that
+	// any tool shape is accepted and forwarded transparently.
+	Tools json.RawMessage `json:"tools,omitzero"`
+}
+
+// ToolSearchParam mirrors the "tool_search" tool type emitted by the OpenAI
+// Codex CLI. It is Codex's dynamic-tool-discovery meta-tool.
+// See https://github.com/openai/codex/blob/main/codex-rs/tools/src/tool_spec.rs
+type ToolSearchParam struct {
+	// The type of the tool search tool. Always `tool_search`.
+	Type string `json:"type"`
+	// The execution mode for tool search (e.g. "remote").
+	Execution string `json:"execution,omitzero"`
+	// A description of the tool search.
+	Description string `json:"description,omitzero"`
+	// A JSON Schema describing the parameters accepted by tool search.
+	Parameters json.RawMessage `json:"parameters,omitzero"`
 }
 
 // A text input to the model.

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -3009,6 +3009,30 @@ func TestResponseToolUnionMarshalJSON(t *testing.T) {
 			expRes: `{"type": "apply_patch"}`,
 		},
 		{
+			name: "marshal namespace",
+			input: ResponseToolUnion{
+				OfNamespace: &ToolNamespaceParam{
+					Type:        "namespace",
+					Name:        "my_namespace",
+					Description: "A group of tools",
+					Tools:       json.RawMessage(`[{"type":"function","name":"tool1","parameters":{"type":"object","properties":{}}}]`),
+				},
+			},
+			expRes: `{"type": "namespace", "name": "my_namespace", "description": "A group of tools", "tools": [{"type":"function","name":"tool1","parameters":{"type":"object","properties":{}}}]}`,
+		},
+		{
+			name: "marshal tool_search",
+			input: ResponseToolUnion{
+				OfToolSearch: &ToolSearchParam{
+					Type:        "tool_search",
+					Execution:   "remote",
+					Description: "discover tools",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+			expRes: `{"type": "tool_search", "execution": "remote", "description": "discover tools", "parameters": {"type":"object"}}`,
+		},
+		{
 			name:   "marshal no field set",
 			input:  ResponseToolUnion{},
 			expErr: "no tool to marshal",
@@ -3237,6 +3261,30 @@ func TestResponseToolUnionUnmarshalJSON(t *testing.T) {
 			expRes: ResponseToolUnion{
 				OfApplyPatch: &ApplyPatchToolParam{
 					Type: "apply_patch",
+				},
+			},
+		},
+		{
+			name:  "unmarshal namespace",
+			input: []byte(`{"type":"namespace","name":"my_namespace","description":"A group of tools","tools":[{"type":"function","name":"tool1","parameters":{"type":"object","properties":{}}}]}`),
+			expRes: ResponseToolUnion{
+				OfNamespace: &ToolNamespaceParam{
+					Type:        "namespace",
+					Name:        "my_namespace",
+					Description: "A group of tools",
+					Tools:       json.RawMessage(`[{"type":"function","name":"tool1","parameters":{"type":"object","properties":{}}}]`),
+				},
+			},
+		},
+		{
+			name:  "unmarshal tool_search",
+			input: []byte(`{"type":"tool_search","execution":"remote","description":"discover tools","parameters":{"type":"object"}}`),
+			expRes: ResponseToolUnion{
+				OfToolSearch: &ToolSearchParam{
+					Type:        "tool_search",
+					Execution:   "remote",
+					Description: "discover tools",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
 				},
 			},
 		},


### PR DESCRIPTION
**Description**
The fix follows the issue's proposed design: https://github.com/envoyproxy/ai-gateway/issues/2164. 
Using json.RawMessage for ToolNamespaceParam.Tools instead of a specific ResponsesApiNamespaceTool type — this is more forward-compatible since the Responses API translator is passthrough-only and just re-marshals/forwards tools as-is.