### PR TITLE
fix: dedup candidate namespaces in getObjectsForGateway

### DIFF
--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1148,12 +1148,6 @@ func (c *GatewayController) getObjectsForGateway(ctx context.Context, gw *gwapiv
 		"%s=%s,%s=%s", egOwningGatewayNameLabel, gw.Name, egOwningGatewayNamespaceLabel, gw.Namespace,
 	)}
 
-	// Dedup the candidate namespaces: when Envoy Gateway runs in the same namespace as the
-	// Gateway resource (i.e. controller-namespace mode with EG installed alongside the workload),
-	// gw.Namespace and c.envoyGatewayNamespace are equal. Without dedup the loop below would
-	// list the same objects twice and the consistency check at the end would incorrectly report
-	// `found gateway-labeled objects in multiple namespaces: [<ns> <ns>]` even though everything
-	// is correctly scoped to a single namespace.
 	candidateNamespaces := make([]string, 1, 2)
 	candidateNamespaces[0] = gw.Namespace
 	if c.envoyGatewayNamespace != gw.Namespace {

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1154,7 +1154,8 @@ func (c *GatewayController) getObjectsForGateway(ctx context.Context, gw *gwapiv
 	// list the same objects twice and the consistency check at the end would incorrectly report
 	// `found gateway-labeled objects in multiple namespaces: [<ns> <ns>]` even though everything
 	// is correctly scoped to a single namespace.
-	candidateNamespaces := []string{gw.Namespace}
+	candidateNamespaces := make([]string, 1, 2)
+	candidateNamespaces[0] = gw.Namespace
 	if c.envoyGatewayNamespace != gw.Namespace {
 		candidateNamespaces = append(candidateNamespaces, c.envoyGatewayNamespace)
 	}

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1148,8 +1148,19 @@ func (c *GatewayController) getObjectsForGateway(ctx context.Context, gw *gwapiv
 		"%s=%s,%s=%s", egOwningGatewayNameLabel, gw.Name, egOwningGatewayNamespaceLabel, gw.Namespace,
 	)}
 
+	// Dedup the candidate namespaces: when Envoy Gateway runs in the same namespace as the
+	// Gateway resource (i.e. controller-namespace mode with EG installed alongside the workload),
+	// gw.Namespace and c.envoyGatewayNamespace are equal. Without dedup the loop below would
+	// list the same objects twice and the consistency check at the end would incorrectly report
+	// `found gateway-labeled objects in multiple namespaces: [<ns> <ns>]` even though everything
+	// is correctly scoped to a single namespace.
+	candidateNamespaces := []string{gw.Namespace}
+	if c.envoyGatewayNamespace != gw.Namespace {
+		candidateNamespaces = append(candidateNamespaces, c.envoyGatewayNamespace)
+	}
+
 	var distinctNamespaces []string
-	for _, ns := range []string{gw.Namespace, c.envoyGatewayNamespace} {
+	for _, ns := range candidateNamespaces {
 		var ps *corev1.PodList
 		ps, err = c.kube.CoreV1().Pods(ns).List(ctx, listOption)
 		if err != nil {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -2837,3 +2837,39 @@ func TestGatewayController_getObjectsForGatewayNamespaceInconsistency(t *testing
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "found gateway-labeled objects in multiple namespaces")
 }
+
+// TestGatewayController_getObjectsForGatewaySameNamespace verifies that when the Gateway
+// resource lives in the same namespace as the Envoy Gateway controller (a common deployment
+// shape: controller-namespace mode with EG installed alongside the AI workloads), the
+// consistency check does not spuriously fire. Without the dedup of candidate namespaces, the
+// loop would list the same objects twice and report
+// `found gateway-labeled objects in multiple namespaces: [<ns> <ns>]` even though
+// everything is correctly scoped to a single namespace.
+func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
+	const gwName, ns = "gw", "shared"
+	labels := map[string]string{
+		egOwningGatewayNameLabel:      gwName,
+		egOwningGatewayNamespaceLabel: ns,
+	}
+	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+
+	kube := fake2.NewClientset()
+	// envoyGatewayNamespace == gw.Namespace.
+	c := NewGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, ns,
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	_, err := kube.CoreV1().Pods(ns).Create(t.Context(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: ns, Labels: labels},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = kube.AppsV1().Deployments(ns).Create(t.Context(), &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dep-1", Namespace: ns, Labels: labels},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	namespace, pods, deployments, _, err := c.getObjectsForGateway(t.Context(), gw)
+	require.NoError(t, err)
+	require.Equal(t, ns, namespace)
+	require.Len(t, pods, 1, "pod should not be double-counted when gw.Namespace == envoyGatewayNamespace")
+	require.Len(t, deployments, 1, "deployment should not be double-counted when gw.Namespace == envoyGatewayNamespace")
+}

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -2838,13 +2838,6 @@ func TestGatewayController_getObjectsForGatewayNamespaceInconsistency(t *testing
 	require.Contains(t, err.Error(), "found gateway-labeled objects in multiple namespaces")
 }
 
-// TestGatewayController_getObjectsForGatewaySameNamespace verifies that when the Gateway
-// resource lives in the same namespace as the Envoy Gateway controller (a common deployment
-// shape: controller-namespace mode with EG installed alongside the AI workloads), the
-// consistency check does not spuriously fire. Without the dedup of candidate namespaces, the
-// loop would list the same objects twice and report
-// `found gateway-labeled objects in multiple namespaces: [<ns> <ns>]` even though
-// everything is correctly scoped to a single namespace.
 func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
 	const gwName, ns = "gw", "shared"
 	labels := map[string]string{
@@ -2854,7 +2847,6 @@ func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
 	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
 
 	kube := fake2.NewClientset()
-	// envoyGatewayNamespace == gw.Namespace.
 	c := NewGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, ns,
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
@@ -2870,6 +2862,6 @@ func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
 	namespace, pods, deployments, _, err := c.getObjectsForGateway(t.Context(), gw)
 	require.NoError(t, err)
 	require.Equal(t, ns, namespace)
-	require.Len(t, pods, 1, "pod should not be double-counted when gw.Namespace == envoyGatewayNamespace")
-	require.Len(t, deployments, 1, "deployment should not be double-counted when gw.Namespace == envoyGatewayNamespace")
+	require.Len(t, pods, 1)
+	require.Len(t, deployments, 1)
 }


### PR DESCRIPTION
**Description**

When the Envoy Gateway controller is installed in the **same namespace** as the `Gateway` resource (a common deployment shape: controller-namespace mode with EG alongside the AI workloads), `gw.Namespace` and `c.envoyGatewayNamespace` are equal. The current implementation in `getObjectsForGateway` iterates over `[]string{gw.Namespace, c.envoyGatewayNamespace}` without dedup, lists the same pods/deployments/daemonsets twice, appends the same namespace to `distinctNamespaces` twice, and the consistency check at the end incorrectly reports:

```
found gateway-labeled objects in multiple namespaces: [<ns> <ns>]
```

The repeated namespace name in the error is the tell-tale sign of the same namespace being counted twice rather than two genuinely distinct ones.

## Impact

Once the `GatewayController.Reconcile` returns this error, the controller never gets to the path that updates the `filter-config` Secret mounted into the extproc sidecar. So **any AIGatewayRoute / AIServiceBackend added after the controller starts** becomes routable in the generated `HTTPRoute` (a rule index is allocated for it) but has no matching entry in the extproc backends list. Clients see HTTP 500 with the extproc-side log:

```
error processing request message
error="rpc error: code = Internal desc = unknown backend: <ns>/<aibackend>/route/<router>/rule/<N>/ref/0"
```

For users who upgraded to v1.0.0 with same-namespace deployments and pre-existing routes, the regression is silent until the first new route is added.

## Root cause

Regression introduced in #2274 (v1.0.0), which switched from a single cluster-wide `List("")` (v0.6.0 and earlier) to a per-namespace iteration over a non-deduped slice.

```go
// before this PR — at internal/controller/gateway.go
for _, ns := range []string{gw.Namespace, c.envoyGatewayNamespace} {
    // list / append to distinctNamespaces ...
}
if len(distinctNamespaces) > 1 {
    err = fmt.Errorf("found gateway-labeled objects in multiple namespaces: %v", distinctNamespaces)
}
```

## Fix

Dedup the candidate namespaces before the List loop. Build `candidateNamespaces` from `gw.Namespace` and only append `c.envoyGatewayNamespace` if it differs. The consistency check now only fires when objects are genuinely scattered across distinct namespaces.

## Tests

- Existing `TestGatewayController_getObjectsForGatewayNamespaceInconsistency` continues to exercise the multi-namespace error path (objects in `ns` AND `envoy-gateway-system` still trigger the error).
- New `TestGatewayController_getObjectsForGatewaySameNamespace` pins down the regression: with `gw.Namespace == c.envoyGatewayNamespace` and a pod + deployment in that single namespace, `getObjectsForGateway` returns no error and the returned `pods` / `deployments` slices each contain exactly one element (not duplicates).

## Backport request

This is a silent correctness regression for same-namespace installs and would be a good candidate for a v1.0.x patch backport if a 1.0 patch line is planned.
