### PR TITLE
chore: update kiwi mcp tool to pass the tests.

### DIFF
--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -169,7 +169,7 @@ services:
           --metadata x-tenant-id=$$AIGW_TENANT_ID \
           --metadata agent-session-id=$$AIGW_SESSION_ID \
           --method tools/call \
-          --tool-name kiwi__search-flight \
+          --tool-name kiwi__search-flights-structured \
           --tool-arg flyFrom=NYC \
           --tool-arg flyTo=LAX \
           --tool-arg departureDate=15/12/2026

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -154,7 +154,7 @@ services:
           --metadata x-tenant-id=$$AIGW_TENANT_ID \
           --metadata agent-session-id=$$AIGW_SESSION_ID \
           --method tools/call \
-          --tool-name kiwi__search-flight \
+          --tool-name kiwi__search-flights-structured \
           --tool-arg flyFrom=NYC \
           --tool-arg flyTo=LAX \
           --tool-arg departureDate=15/12/2026

--- a/examples/goose/kiwi_recipe.yaml
+++ b/examples/goose/kiwi_recipe.yaml
@@ -12,7 +12,7 @@ instructions: |
   You are a helpful assistant that helps users find flights from New York to Los Angeles.
 
 prompt: |
-  Use the search-flight tool to search for flights from New York to Los Angeles on {{flight_date}}.
+  Use the search-flights-structured tool to search for flights from New York to Los Angeles on {{flight_date}}.
   When specifying the departureDate parameter, use the format dd/mm/yyyy.
   Display the first 3 results with the `final_output` tool in a specific JSON format.
   The output is in the following format where price includes the currency symbol:

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -40,7 +40,7 @@ $ npx @modelcontextprotocol/inspector --cli http://localhost:1975/mcp --transpor
 "context7__resolve-library-id"
 "context7__query-docs"
 "github__pull_request_read"
-"kiwi__search-flight"
+"kiwi__search-flights-structured"
 ```
 
 ### Accessing GitHub Pull Request Info
@@ -172,7 +172,7 @@ Now you can explore the available tools:
 ╭────────────────────────────────────────────────────────────────────╮
 │ Tools for mcp-gateway (3 tools)                                    │
 │                                                                    │
-│ ❯ 1. search-flight                                                 │
+│ ❯ 1. search-flights-structured                                      │
 │   2. microsoft_docs_search                                         │
 │   3. microsoft_docs_fetch                                          │
 ╰────────────────────────────────────────────────────────────────────╯
@@ -186,7 +186,7 @@ From here, you can start using the tools inside Claude.
 
 ⏺ I'll help you find the cheapest flight tickets from LA to San Francisco. Let me search for flights for today's date.
 
-⏺ mcp-gateway - search-flight (MCP)(flyFrom: "Los Angeles", flyTo: "San Francisco", departureDate: "13/09/2025", sort: "price", curr: "USD")
+⏺ mcp-gateway - search-flights-structured (MCP)(flyFrom: "Los Angeles", flyTo: "San Francisco", departureDate: "13/09/2025", sort: "price", curr: "USD")
   ⎿  [
        {
          "flyFrom": "LAX",

--- a/tests/data-plane-mcp/publicmcp_test.go
+++ b/tests/data-plane-mcp/publicmcp_test.go
@@ -88,7 +88,7 @@ func TestPublicMCPServers(t *testing.T) {
 		exps := []string{
 			// "context7__resolve-library-id",
 			// "context7__query-docs",
-			"kiwi__search-flight",
+			"kiwi__search-flights-structured",
 			"kiwi__feedback-to-devs",
 		}
 
@@ -130,7 +130,7 @@ func TestPublicMCPServers(t *testing.T) {
 			// 	},
 			// },
 			{
-				toolName: "kiwi__search-flight",
+				toolName: "kiwi__search-flights-structured",
 				params: map[string]any{
 					"flyFrom":                "LAX",
 					"flyTo":                  "HND",

--- a/tests/e2e-aigw/examples_mcp_test.go
+++ b/tests/e2e-aigw/examples_mcp_test.go
@@ -38,7 +38,7 @@ var (
 		// "context7__query-docs",
 		// "context7__resolve-library-id",
 		"kiwi__feedback-to-devs",
-		"kiwi__search-flight",
+		"kiwi__search-flights-structured",
 	}
 )
 
@@ -97,7 +97,7 @@ func TestMCP_standalone(t *testing.T) {
 			// 	},
 			// },
 			{
-				toolName: "kiwi__search-flight",
+				toolName: "kiwi__search-flights-structured",
 				params: map[string]any{
 					"flyFrom":                "LAX",
 					"flyTo":                  "HND",


### PR DESCRIPTION
**Description**
CI tests failed because the tool name changed: https://github.com/envoyproxy/ai-gateway/actions/runs/28460601685/job/84347247072?pr=1650. Update the kiwi mcp tool name.
