### PR TITLE
feat(helm): add controller PodDisruptionBudget to AI Gateway Helm chart

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/poddisruptionbudget.yaml
@@ -1,0 +1,27 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+{{- if .Values.controller.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ai-gateway-helm.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ai-gateway-helm.labels" . | nindent 4 }}
+  {{- with .Values.controller.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if hasKey .Values.controller.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.controller.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.controller.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ai-gateway-helm.controller.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -135,6 +135,13 @@ controller:
   replicaCount: 1
   imagePullSecrets: []
   podAnnotations: {}
+  podDisruptionBudget:
+    enabled: false
+    annotations: {}
+    # Only one of minAvailable or maxUnavailable can be set.
+    # If maxUnavailable is set, it takes precedence over minAvailable.
+    minAvailable: 1
+    # maxUnavailable: 1
   podSecurityContext: {}
   securityContext: {}
   # DEPRECATED: podEnv will be removed after v0.3. Use controller.extraEnvVars instead.


### PR DESCRIPTION
**Description**

This commit adds an optional `PodDisruptionBudget` to the `ai-gateway-helm` controller `Deployment`. This allows installations running multiple controller replicas to protect availability during voluntary disruptions such as node drains or cluster upgrades.

The `PodDisruptionBudget` is disabled by default to preserve existing install behavior. When enabled, it uses the same selector labels as the controller `Deployment` and supports **annotations**, **minAvailable**, and **maxUnavailable** configuration.

**Related Issues/PRs (if applicable)**

N/A - I didn't open an issue for this but if it needs one let me know!


**Testing**

Tested with:

- **Default render:** PDB is disabled by default.
- **Enabled render:** PDB renders as `policy/v1`.
- Selector labels match the `Deployment` selector because both use the same helper:
  - PDB uses `ai-gateway-helm.controller.selectorLabels`
  - Deployment `spec.selector.matchLabels` uses `ai-gateway-helm.controller.selectorLabels`
  - Deployment pod template labels also use `ai-gateway-helm.controller.selectorLabels`

Rendered selector was:

```yaml
  selector:
    matchLabels:
      app.kubernetes.io/name: ai-gateway-helm
      app.kubernetes.io/instance: release-name
```

I also ran:

```
  go tool -modfile=tools/go.mod helm lint manifests/charts/ai-gateway-helm
  make helm-test
```