### PR TITLE
fix: honor namespace on cross-namespace InferencePool backendRef

### DIFF
--- a/internal/controller/ai_gateway_route.go
+++ b/internal/controller/ai_gateway_route.go
@@ -262,14 +262,26 @@ func (c *AIGatewayRouteController) newHTTPRoute(ctx context.Context, dst *gwapiv
 			dstName := fmt.Sprintf("%s.%s", br.Name, backendNamespace)
 
 			if br.IsInferencePool() {
-				// Handle InferencePool backend reference.
+				// Handle InferencePool backend reference, honoring the (optionally cross-namespace)
+				// namespace specified on the backendRef.
+				if br.IsCrossNamespace(aiGatewayRoute.Namespace) {
+					if err := c.referenceGrantValidator.validateInferencePoolReference(
+						ctx,
+						aiGatewayRoute.Namespace,
+						backendNamespace,
+						br.Name,
+					); err != nil {
+						return err
+					}
+				}
+				ns := gwapiv1.Namespace(backendNamespace)
 				backendRefs = append(backendRefs,
 					gwapiv1.HTTPBackendRef{BackendRef: gwapiv1.BackendRef{
 						BackendObjectReference: gwapiv1.BackendObjectReference{
 							Group:     (*gwapiv1.Group)(br.Group),
 							Kind:      (*gwapiv1.Kind)(br.Kind),
 							Name:      gwapiv1.ObjectName(br.Name),
-							Namespace: (*gwapiv1.Namespace)(&aiGatewayRoute.Namespace),
+							Namespace: &ns,
 						},
 						Weight: br.Weight,
 					}},

--- a/internal/controller/ai_gateway_route_test.go
+++ b/internal/controller/ai_gateway_route_test.go
@@ -576,6 +576,88 @@ func Test_newHTTPRoute_InferencePool(t *testing.T) {
 	require.Empty(t, httpRoute.Spec.Rules[1].BackendRefs) // No backend refs for default rule.
 }
 
+func Test_newHTTPRoute_InferencePool_CrossNamespace(t *testing.T) {
+	newRoute := func(poolNamespace string) *aigv1b1.AIGatewayRoute {
+		return &aigv1b1.AIGatewayRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "inference-route",
+				Namespace: "gw",
+			},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+							{
+								Name:      "my-pool",
+								Namespace: ptr.To(gwapiv1.Namespace(poolNamespace)),
+								Group:     ptr.To("inference.networking.k8s.io"),
+								Kind:      ptr.To("InferencePool"),
+								Weight:    ptr.To(int32(100)),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	referenceGrant := &gwapiv1b1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-gw", Namespace: "default"},
+		Spec: gwapiv1b1.ReferenceGrantSpec{
+			From: []gwapiv1b1.ReferenceGrantFrom{{
+				Group:     aiServiceBackendGroup,
+				Kind:      aiGatewayRouteKind,
+				Namespace: "gw",
+			}},
+			To: []gwapiv1b1.ReferenceGrantTo{{
+				Group: inferencePoolGroup,
+				Kind:  inferencePoolKind,
+			}},
+		},
+	}
+
+	t.Run("cross-namespace with ReferenceGrant honors the pool namespace", func(t *testing.T) {
+		c := requireNewFakeClientWithIndexes(t)
+		require.NoError(t, c.Create(t.Context(), referenceGrant))
+
+		controller := &AIGatewayRouteController{client: c, referenceGrantValidator: newReferenceGrantValidator(c)}
+		httpRoute := &gwapiv1.HTTPRoute{}
+		require.NoError(t, controller.newHTTPRoute(t.Context(), httpRoute, newRoute("default")))
+
+		require.Len(t, httpRoute.Spec.Rules, 2)
+		require.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 1)
+		backendRef := httpRoute.Spec.Rules[0].BackendRefs[0]
+		require.Equal(t, "InferencePool", string(*backendRef.Kind))
+		require.Equal(t, "my-pool", string(backendRef.Name))
+		// The generated HTTPRoute backendRef must carry the pool's namespace, not the route's.
+		require.NotNil(t, backendRef.Namespace)
+		require.Equal(t, "default", string(*backendRef.Namespace))
+	})
+
+	t.Run("cross-namespace without ReferenceGrant is rejected", func(t *testing.T) {
+		c := requireNewFakeClientWithIndexes(t)
+
+		controller := &AIGatewayRouteController{client: c, referenceGrantValidator: newReferenceGrantValidator(c)}
+		httpRoute := &gwapiv1.HTTPRoute{}
+		err := controller.newHTTPRoute(t.Context(), httpRoute, newRoute("default"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cross-namespace reference from AIGatewayRoute in namespace gw "+
+			"to InferencePool my-pool in namespace default is not permitted")
+	})
+
+	t.Run("same-namespace reference needs no ReferenceGrant", func(t *testing.T) {
+		c := requireNewFakeClientWithIndexes(t)
+
+		controller := &AIGatewayRouteController{client: c, referenceGrantValidator: newReferenceGrantValidator(c)}
+		httpRoute := &gwapiv1.HTTPRoute{}
+		require.NoError(t, controller.newHTTPRoute(t.Context(), httpRoute, newRoute("gw")))
+
+		backendRef := httpRoute.Spec.Rules[0].BackendRefs[0]
+		require.NotNil(t, backendRef.Namespace)
+		require.Equal(t, "gw", string(*backendRef.Namespace))
+	})
+}
+
 func Test_newHTTPRoute_LabelAndAnnotationPropagation(t *testing.T) {
 	c := requireNewFakeClientWithIndexes(t)
 

--- a/internal/controller/referencegrant.go
+++ b/internal/controller/referencegrant.go
@@ -28,7 +28,7 @@ func newReferenceGrantValidator(c client.Client) *referenceGrantValidator {
 	return &referenceGrantValidator{client: c}
 }
 
-// ValidateAIServiceBackendReference validates that an AIGatewayRoute can reference an AIServiceBackend
+// validateAIServiceBackendReference validates that an AIGatewayRoute can reference an AIServiceBackend
 // in a different namespace by checking for a valid ReferenceGrant.
 //
 // Parameters:
@@ -45,39 +45,78 @@ func (v *referenceGrantValidator) validateAIServiceBackendReference(
 	backendNamespace string,
 	backendName string,
 ) error {
-	// Same namespace references don't need ReferenceGrant
-	if routeNamespace == backendNamespace {
+	return v.validateReference(ctx, routeNamespace, backendNamespace, backendName, aiServiceBackendGroup, aiServiceBackendKind)
+}
+
+// validateInferencePoolReference validates that an AIGatewayRoute can reference an InferencePool
+// in a different namespace by checking for a valid ReferenceGrant.
+//
+// Parameters:
+//   - ctx: context for the operation
+//   - routeNamespace: namespace of the AIGatewayRoute
+//   - poolNamespace: namespace of the InferencePool
+//   - poolName: name of the InferencePool (optional, for logging)
+//
+// Returns:
+//   - error: nil if the reference is valid (same namespace or valid ReferenceGrant exists), error otherwise
+func (v *referenceGrantValidator) validateInferencePoolReference(
+	ctx context.Context,
+	routeNamespace string,
+	poolNamespace string,
+	poolName string,
+) error {
+	return v.validateReference(ctx, routeNamespace, poolNamespace, poolName, inferencePoolGroup, inferencePoolKind)
+}
+
+// validateReference validates that an AIGatewayRoute can reference a target resource (identified by
+// targetGroup/targetKind) in a different namespace by checking for a valid ReferenceGrant.
+func (v *referenceGrantValidator) validateReference(
+	ctx context.Context,
+	routeNamespace string,
+	targetNamespace string,
+	targetName string,
+	targetGroup gwapiv1b1.Group,
+	targetKind gwapiv1b1.Kind,
+) error {
+	// Same namespace references don't need ReferenceGrant.
+	if routeNamespace == targetNamespace {
 		return nil
 	}
 
-	indexKey := getReferenceGrantIndexKey(backendNamespace, aiServiceBackendKind)
+	indexKey := getReferenceGrantIndexKey(targetNamespace, string(targetKind))
 	var referenceGrants gwapiv1b1.ReferenceGrantList
 	if err := v.client.List(ctx, &referenceGrants,
 		client.MatchingFields{k8sClientIndexReferenceGrantToTargetKind: indexKey},
 	); err != nil {
 		return fmt.Errorf("failed to list ReferenceGrants in namespace %s for kind %s: %w",
-			backendNamespace, aiServiceBackendKind, err)
+			targetNamespace, targetKind, err)
 	}
 
-	// Check if any ReferenceGrant allows this cross-namespace reference
+	// Check if any ReferenceGrant allows this cross-namespace reference.
 	for i := range referenceGrants.Items {
 		grant := &referenceGrants.Items[i]
-		if v.isReferenceGrantValid(grant, routeNamespace) {
+		if v.isReferenceGrantValid(grant, routeNamespace, targetGroup, targetKind) {
 			return nil
 		}
 	}
 
 	return fmt.Errorf(
-		"cross-namespace reference from AIGatewayRoute in namespace %s to AIServiceBackend %s in namespace %s is not permitted: "+
+		"cross-namespace reference from AIGatewayRoute in namespace %s to %s %s in namespace %s is not permitted: "+
 			"no valid ReferenceGrant found in namespace %s. "+
-			"A ReferenceGrant must allow AIGatewayRoute from namespace %s to reference AIServiceBackend in namespace %s",
-		routeNamespace, backendName, backendNamespace, backendNamespace, routeNamespace, backendNamespace,
+			"A ReferenceGrant must allow AIGatewayRoute from namespace %s to reference %s in namespace %s",
+		routeNamespace, targetKind, targetName, targetNamespace, targetNamespace, routeNamespace, targetKind, targetNamespace,
 	)
 }
 
-// isReferenceGrantValid checks if a ReferenceGrant allows an AIGatewayRoute to reference an AIServiceBackend.
-func (v *referenceGrantValidator) isReferenceGrantValid(grant *gwapiv1b1.ReferenceGrant, fromNamespace string) bool {
-	// Check if the grant allows references from the route's namespace
+// isReferenceGrantValid checks if a ReferenceGrant allows an AIGatewayRoute to reference the
+// target resource identified by targetGroup/targetKind.
+func (v *referenceGrantValidator) isReferenceGrantValid(
+	grant *gwapiv1b1.ReferenceGrant,
+	fromNamespace string,
+	targetGroup gwapiv1b1.Group,
+	targetKind gwapiv1b1.Kind,
+) bool {
+	// Check if the grant allows references from the route's namespace.
 	fromAllowed := false
 	for _, from := range grant.Spec.From {
 		if v.matchesFrom(&from, fromNamespace) {
@@ -90,9 +129,9 @@ func (v *referenceGrantValidator) isReferenceGrantValid(grant *gwapiv1b1.Referen
 		return false
 	}
 
-	// Check if the grant allows references to AIServiceBackend
+	// Check if the grant allows references to the target resource.
 	for _, to := range grant.Spec.To {
-		if v.matchesTo(&to) {
+		if v.matchesTo(&to, targetGroup, targetKind) {
 			return true
 		}
 	}
@@ -102,7 +141,7 @@ func (v *referenceGrantValidator) isReferenceGrantValid(grant *gwapiv1b1.Referen
 
 // matchesFrom checks if a ReferenceGrantFrom matches the AIGatewayRoute reference.
 func (v *referenceGrantValidator) matchesFrom(from *gwapiv1b1.ReferenceGrantFrom, fromNamespace string) bool {
-	// Check group
+	// Check group. AIGatewayRoute belongs to the aigateway.envoyproxy.io group.
 	if from.Group != aiServiceBackendGroup {
 		return false
 	}
@@ -120,15 +159,15 @@ func (v *referenceGrantValidator) matchesFrom(from *gwapiv1b1.ReferenceGrantFrom
 	return true
 }
 
-// matchesTo checks if a ReferenceGrantTo matches the AIServiceBackend.
-func (v *referenceGrantValidator) matchesTo(to *gwapiv1b1.ReferenceGrantTo) bool {
+// matchesTo checks if a ReferenceGrantTo matches the target resource identified by targetGroup/targetKind.
+func (v *referenceGrantValidator) matchesTo(to *gwapiv1b1.ReferenceGrantTo, targetGroup gwapiv1b1.Group, targetKind gwapiv1b1.Kind) bool {
 	// Check group
-	if to.Group != aiServiceBackendGroup {
+	if to.Group != targetGroup {
 		return false
 	}
 
 	// Check kind
-	if to.Kind != aiServiceBackendKind {
+	if to.Kind != targetKind {
 		return false
 	}
 

--- a/internal/controller/referencegrant_test.go
+++ b/internal/controller/referencegrant_test.go
@@ -280,6 +280,111 @@ func TestReferenceGrantValidator_ValidateAIServiceBackendReference(t *testing.T)
 	})
 }
 
+// TestReferenceGrantValidator_ValidateInferencePoolReference tests cross-namespace InferencePool
+// references governed by ReferenceGrant, mirroring the AIServiceBackend behavior.
+func TestReferenceGrantValidator_ValidateInferencePoolReference(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = gwapiv1b1.Install(scheme)
+	_ = aigv1a1.AddToScheme(scheme)
+
+	inferencePoolGrant := func(fromNS string, toGroup gwapiv1b1.Group, toKind gwapiv1b1.Kind) gwapiv1b1.ReferenceGrant {
+		return gwapiv1b1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "pool-ns"},
+			Spec: gwapiv1b1.ReferenceGrantSpec{
+				From: []gwapiv1b1.ReferenceGrantFrom{{
+					Group:     aiServiceBackendGroup,
+					Kind:      aiGatewayRouteKind,
+					Namespace: gwapiv1b1.Namespace(fromNS),
+				}},
+				To: []gwapiv1b1.ReferenceGrantTo{{Group: toGroup, Kind: toKind}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		routeNamespace      string
+		poolNamespace       string
+		poolName            string
+		referenceGrants     []gwapiv1b1.ReferenceGrant
+		expectedError       bool
+		expectedErrorString string
+	}{
+		{
+			name:           "Same namespace reference - should succeed",
+			routeNamespace: "default",
+			poolNamespace:  "default",
+			poolName:       "my-pool",
+		},
+		{
+			name:            "Cross-namespace with valid ReferenceGrant - should succeed",
+			routeNamespace:  "route-ns",
+			poolNamespace:   "pool-ns",
+			poolName:        "my-pool",
+			referenceGrants: []gwapiv1b1.ReferenceGrant{inferencePoolGrant("route-ns", inferencePoolGroup, inferencePoolKind)},
+		},
+		{
+			name:           "Cross-namespace without ReferenceGrant - should fail",
+			routeNamespace: "route-ns",
+			poolNamespace:  "pool-ns",
+			poolName:       "my-pool",
+			expectedError:  true,
+			expectedErrorString: "cross-namespace reference from AIGatewayRoute in namespace route-ns " +
+				"to InferencePool my-pool in namespace pool-ns is not permitted",
+		},
+		{
+			name:            "Cross-namespace with ReferenceGrant for wrong target kind - should fail",
+			routeNamespace:  "route-ns",
+			poolNamespace:   "pool-ns",
+			poolName:        "my-pool",
+			referenceGrants: []gwapiv1b1.ReferenceGrant{inferencePoolGrant("route-ns", aiServiceBackendGroup, aiServiceBackendKind)},
+			expectedError:   true,
+			// Grant targets AIServiceBackend, so the InferencePool index lookup finds no matching grant.
+			expectedErrorString: "is not permitted",
+		},
+		{
+			name:                "Cross-namespace with ReferenceGrant for wrong from namespace - should fail",
+			routeNamespace:      "route-ns",
+			poolNamespace:       "pool-ns",
+			poolName:            "my-pool",
+			referenceGrants:     []gwapiv1b1.ReferenceGrant{inferencePoolGrant("other-ns", inferencePoolGroup, inferencePoolKind)},
+			expectedError:       true,
+			expectedErrorString: "is not permitted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]client.Object, len(tt.referenceGrants))
+			for i := range tt.referenceGrants {
+				objs[i] = &tt.referenceGrants[i]
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				WithIndex(&gwapiv1b1.ReferenceGrant{}, k8sClientIndexReferenceGrantToTargetKind, referenceGrantToTargetKindIndexFunc).
+				Build()
+
+			validator := newReferenceGrantValidator(fakeClient)
+			err := validator.validateInferencePoolReference(
+				context.Background(),
+				tt.routeNamespace,
+				tt.poolNamespace,
+				tt.poolName,
+			)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.expectedErrorString != "" {
+					require.Contains(t, err.Error(), tt.expectedErrorString)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestReferenceGrantValidator_MatchesFrom_WrongGroup tests matchesFrom with wrong group
 func TestReferenceGrantValidator_MatchesFrom_WrongGroup(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -351,7 +456,7 @@ func TestReferenceGrantValidator_MatchesTo_WrongGroup(t *testing.T) {
 		Kind:  aiServiceBackendKind,
 	}
 
-	result := validator.matchesTo(to)
+	result := validator.matchesTo(to, aiServiceBackendGroup, aiServiceBackendKind)
 	require.False(t, result, "should return false for wrong group")
 }
 
@@ -369,7 +474,7 @@ func TestReferenceGrantValidator_MatchesTo_WrongKind(t *testing.T) {
 		Kind:  "WrongKind",
 	}
 
-	result := validator.matchesTo(to)
+	result := validator.matchesTo(to, aiServiceBackendGroup, aiServiceBackendKind)
 	require.False(t, result, "should return false for wrong kind")
 }
 


### PR DESCRIPTION
**Description**

`AIGatewayRoute` `rules[].backendRefs[]` accepts a `namespace` field, but when a backendRef points at an `InferencePool` in a different namespace, the controller generated the child `HTTPRoute` backendRef with the route's *own* namespace instead of the referenced one. The route then reported `ResolvedRefs: False` with `BackendNotFound: custom backend InferencePool <route-ns>/<pool-name> not found`, even with a valid `ReferenceGrant` in the pool's namespace.

This PR makes the controller honor the `namespace` specified on an `InferencePool` backendRef when generating the `HTTPRoute`, and validates cross-namespace `InferencePool` references via `ReferenceGrant` — consistent with the existing `AIServiceBackend` behavior. Same-namespace references are unaffected and require no `ReferenceGrant`.

Implementation notes:
- `newHTTPRoute` now uses `backendRef.GetNamespace(route.Namespace)` for the generated `InferencePool` backendRef instead of hardcoding the route namespace.
- The `referenceGrantValidator` is refactored to be generic over the target group/kind; `validateAIServiceBackendReference` is preserved as a thin wrapper (behavior unchanged) and a new `validateInferencePoolReference` is added.
- The Gateway controller already resolved the `InferencePool`/`BackendSecurityPolicy` using the backendRef namespace, so fixing the generated `HTTPRoute` namespace completes the end-to-end path.

**Related Issues/PRs (if applicable)**

Fixes #2230

**Special notes for reviewers (if applicable)**

Added unit tests:
- `Test_newHTTPRoute_InferencePool_CrossNamespace` — namespace honored with a valid `ReferenceGrant`, rejected without one, and same-namespace needs no grant.
- `TestReferenceGrantValidator_ValidateInferencePoolReference` — cross-namespace grant matching for `InferencePool` targets.

Verified with `go build`, `go vet`, and `go test ./internal/controller/...` (all passing), and `gofmt`.