### PR TITLE
fix(translator): preserve tool result cache control

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -587,6 +587,8 @@ type ChatCompletionToolMessageParam struct {
 	Role string `json:"role"`
 	// Tool call that this message is responding to.
 	ToolCallID string `json:"tool_call_id"`
+	// Anthropic-compatible cache breakpoint for the translated tool_result block.
+	*AnthropicContentFields `json:",inline,omitempty"`
 }
 
 // ChatCompletionAssistantMessageParamAudio Data about a previous audio response from the model.

--- a/internal/apischema/openai/vendor_fields_test.go
+++ b/internal/apischema/openai/vendor_fields_test.go
@@ -212,3 +212,22 @@ func TestChatCompletionRequest_VendorFieldsExtraction(t *testing.T) {
 		})
 	}
 }
+
+func TestChatCompletionToolMessageParam_CacheControl(t *testing.T) {
+	// Message-level cache_control on OpenAI tool results must survive decoding so
+	// the Anthropic translator can place it on the outer tool_result block.
+	raw := []byte(`{
+		"role": "tool",
+		"tool_call_id": "toolu_1",
+		"content": "search results",
+		"cache_control": {"type": "ephemeral"}
+	}`)
+
+	var msg ChatCompletionMessageParamUnion
+	require.NoError(t, json.Unmarshal(raw, &msg))
+	require.NotNil(t, msg.OfTool)
+	require.NotNil(t, msg.OfTool.AnthropicContentFields)
+	require.Equal(t, anthropic.CacheControlEphemeralParam{Type: "ephemeral"}, msg.OfTool.CacheControl)
+	require.Equal(t, "toolu_1", msg.OfTool.ToolCallID)
+	require.Equal(t, "search results", msg.OfTool.Content.Value)
+}

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -553,7 +553,12 @@ func openAIToAnthropicMessages(openAIMsgs []openai.ChatCompletionMessageParamUni
 					IsError:   anthropic.Bool(isError),
 				}
 
-				if cacheControl != nil {
+				// Prefer message-level cache_control so string tool results can
+				// carry a breakpoint; fall back to content-part markers.
+				switch {
+				case isCacheEnabled(toolMsg.AnthropicContentFields):
+					toolResultBlock.CacheControl = toolMsg.CacheControl
+				case cacheControl != nil:
 					toolResultBlock.CacheControl = *cacheControl
 				}
 

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -1642,3 +1642,103 @@ func splitSSEEvents(data string) []string {
 	}
 	return events
 }
+
+func TestOpenAIToAnthropicMessages_ToolResultCacheControl(t *testing.T) {
+	ephemeral := anthropic.CacheControlEphemeralParam{Type: constant.ValueOf[constant.Ephemeral]()}
+
+	t.Run("string content with message-level cache_control", func(t *testing.T) {
+		msgs, system, err := openAIToAnthropicMessages([]openai.ChatCompletionMessageParamUnion{
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: "toolu_1",
+				Content:    openai.ContentUnion{Value: "search results"},
+				AnthropicContentFields: &openai.AnthropicContentFields{
+					CacheControl: ephemeral,
+				},
+			}},
+		})
+		require.NoError(t, err)
+		require.Empty(t, system)
+		require.Len(t, msgs, 1)
+		require.Len(t, msgs[0].Content, 1)
+		require.NotNil(t, msgs[0].Content[0].OfToolResult)
+		require.Equal(t, "toolu_1", msgs[0].Content[0].OfToolResult.ToolUseID)
+		require.Equal(t, ephemeral, msgs[0].Content[0].OfToolResult.CacheControl)
+	})
+
+	t.Run("multipart content with message-level cache_control", func(t *testing.T) {
+		msgs, _, err := openAIToAnthropicMessages([]openai.ChatCompletionMessageParamUnion{
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: "toolu_2",
+				Content: openai.ContentUnion{Value: []openai.ChatCompletionContentPartTextParam{
+					{Type: "text", Text: "part one"},
+					{Type: "text", Text: "part two"},
+				}},
+				AnthropicContentFields: &openai.AnthropicContentFields{
+					CacheControl: ephemeral,
+				},
+			}},
+		})
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		require.NotNil(t, msgs[0].Content[0].OfToolResult)
+		require.Equal(t, ephemeral, msgs[0].Content[0].OfToolResult.CacheControl)
+		require.Len(t, msgs[0].Content[0].OfToolResult.Content, 2)
+	})
+
+	t.Run("consecutive tool results preserve per-message cache markers", func(t *testing.T) {
+		msgs, _, err := openAIToAnthropicMessages([]openai.ChatCompletionMessageParamUnion{
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: "toolu_a",
+				Content:    openai.ContentUnion{Value: "first"},
+			}},
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: "toolu_b",
+				Content:    openai.ContentUnion{Value: "second"},
+				AnthropicContentFields: &openai.AnthropicContentFields{
+					CacheControl: ephemeral,
+				},
+			}},
+		})
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		require.Len(t, msgs[0].Content, 2)
+		require.Equal(t, anthropic.CacheControlEphemeralParam{}, msgs[0].Content[0].OfToolResult.CacheControl)
+		require.Equal(t, ephemeral, msgs[0].Content[1].OfToolResult.CacheControl)
+	})
+
+	t.Run("unmarked tool result has no cache_control", func(t *testing.T) {
+		msgs, _, err := openAIToAnthropicMessages([]openai.ChatCompletionMessageParamUnion{
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: "toolu_plain",
+				Content:    openai.ContentUnion{Value: "plain result"},
+			}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, anthropic.CacheControlEphemeralParam{}, msgs[0].Content[0].OfToolResult.CacheControl)
+	})
+
+	t.Run("content-part cache_control still applies when message-level is absent", func(t *testing.T) {
+		msgs, _, err := openAIToAnthropicMessages([]openai.ChatCompletionMessageParamUnion{
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: "toolu_part",
+				Content: openai.ContentUnion{Value: []openai.ChatCompletionContentPartTextParam{
+					{
+						Type: "text",
+						Text: "cached via content part",
+						AnthropicContentFields: &openai.AnthropicContentFields{
+							CacheControl: ephemeral,
+						},
+					},
+				}},
+			}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ephemeral, msgs[0].Content[0].OfToolResult.CacheControl)
+	})
+}

--- a/tests/e2e/testdata/testupstream.yaml
+++ b/tests/e2e/testdata/testupstream.yaml
@@ -84,6 +84,13 @@ spec:
         - name: translation-testupstream-cool-model-backend
         - name: translation-testupstream-another-cool-model-backend
           weight: 0
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: anthropic.claude-cache-matrix
+      backendRefs:
+        - name: translation-testupstream-aws-anthropic-backend
 ---
 apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: AIServiceBackend
@@ -111,6 +118,20 @@ spec:
     name: AWSBedrock
   backendRef:
     name: testupstream-canary
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: translation-testupstream-aws-anthropic-backend
+  namespace: default
+spec:
+  schema:
+    name: AWSAnthropic
+    version: bedrock-2023-05-31
+  backendRef:
+    name: testupstream
     kind: Backend
     group: gateway.envoyproxy.io
 ---

--- a/tests/e2e/testupstream_test.go
+++ b/tests/e2e/testupstream_test.go
@@ -310,3 +310,156 @@ func extractFilterConfigFromSecret(ctx context.Context, name string) (string, er
 	}
 	return string(decoded), nil
 }
+
+// TestPromptCacheTranslationMatrix proves OpenAI-shim cache_control markers survive
+// translation onto the AWSAnthropic InvokeModel body for the known prompt shapes.
+func TestPromptCacheTranslationMatrix(t *testing.T) {
+	const manifest = "testdata/testupstream.yaml"
+	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(context.Background(), manifest)
+	})
+
+	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=translation-testupstream"
+	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
+
+	const (
+		expPath    = "/model/anthropic.claude-cache-matrix/invoke"
+		expHost    = "testupstream.default.svc.cluster.local"
+		upstreamID = "primary"
+	)
+	fakeResponseBody := `{"id":"msg_cache","type":"message","role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":1}}`
+
+	for _, tc := range []struct {
+		name           string
+		requestBody    string
+		expRequestBody string
+	}{
+		{
+			name: "plain_only",
+			requestBody: `{
+  "model":"anthropic.claude-cache-matrix",
+  "max_tokens":16,
+  "messages":[
+    {"role":"user","content":[{"type":"text","text":"plain prefix","cache_control":{"type":"ephemeral"}}]}
+  ]
+}`,
+			expRequestBody: `{"max_tokens":16,"messages":[{"content":[{"text":"plain prefix","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"anthropic_version":"bedrock-2023-05-31"}`,
+		},
+		{
+			name: "tool_defs_only",
+			requestBody: `{
+  "model":"anthropic.claude-cache-matrix",
+  "max_tokens":16,
+  "tools":[{
+    "type":"function",
+    "function":{
+      "name":"search_groups",
+      "description":"Search feedback groups",
+      "parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]},
+      "cache_control":{"type":"ephemeral"}
+    }
+  }],
+  "messages":[{"role":"user","content":"use tools"}]
+}`,
+			expRequestBody: `{"max_tokens":16,"messages":[{"content":[{"text":"use tools","type":"text"}],"role":"user"}],"tools":[{"input_schema":{"properties":{"query":{"type":"string"}},"required":["query"],"type":"object"},"name":"search_groups","description":"Search feedback groups","cache_control":{"type":"ephemeral"}}],"anthropic_version":"bedrock-2023-05-31"}`,
+		},
+		{
+			name: "tool_messages_bp_on_result",
+			requestBody: `{
+  "model":"anthropic.claude-cache-matrix",
+  "max_tokens":16,
+  "tools":[{
+    "type":"function",
+    "function":{
+      "name":"search_groups",
+      "description":"Search feedback groups",
+      "parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+    }
+  }],
+  "messages":[
+    {"role":"user","content":"search notifications"},
+    {"role":"assistant","tool_calls":[{"id":"toolu_1","type":"function","function":{"name":"search_groups","arguments":"{\"query\":\"notifications\"}"}}]},
+    {"role":"tool","tool_call_id":"toolu_1","content":"group results","cache_control":{"type":"ephemeral"}}
+  ]
+}`,
+			expRequestBody: `{"max_tokens":16,"messages":[{"content":[{"text":"search notifications","type":"text"}],"role":"user"},{"content":[{"id":"toolu_1","input":{"query":"notifications"},"name":"search_groups","type":"tool_use"}],"role":"assistant"},{"content":[{"tool_use_id":"toolu_1","is_error":false,"cache_control":{"type":"ephemeral"},"content":[{"text":"group results","type":"text"}],"type":"tool_result"}],"role":"user"}],"tools":[{"input_schema":{"properties":{"query":{"type":"string"}},"required":["query"],"type":"object"},"name":"search_groups","description":"Search feedback groups"}],"anthropic_version":"bedrock-2023-05-31"}`,
+		},
+		{
+			name: "tool_messages_bp_on_tool_use",
+			requestBody: `{
+  "model":"anthropic.claude-cache-matrix",
+  "max_tokens":16,
+  "tools":[{
+    "type":"function",
+    "function":{
+      "name":"search_groups",
+      "description":"Search feedback groups",
+      "parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+    }
+  }],
+  "messages":[
+    {"role":"user","content":"search notifications"},
+    {"role":"assistant","tool_calls":[{"id":"toolu_1","type":"function","function":{"name":"search_groups","arguments":"{\"query\":\"notifications\"}"},"cache_control":{"type":"ephemeral"}}]},
+    {"role":"tool","tool_call_id":"toolu_1","content":"group results"}
+  ]
+}`,
+			expRequestBody: `{"max_tokens":16,"messages":[{"content":[{"text":"search notifications","type":"text"}],"role":"user"},{"content":[{"id":"toolu_1","input":{"query":"notifications"},"name":"search_groups","cache_control":{"type":"ephemeral"},"type":"tool_use"}],"role":"assistant"},{"content":[{"tool_use_id":"toolu_1","is_error":false,"content":[{"text":"group results","type":"text"}],"type":"tool_result"}],"role":"user"}],"tools":[{"input_schema":{"properties":{"query":{"type":"string"}},"required":["query"],"type":"object"},"name":"search_groups","description":"Search feedback groups"}],"anthropic_version":"bedrock-2023-05-31"}`,
+		},
+		{
+			name: "tool_messages_bp_on_plain",
+			requestBody: `{
+  "model":"anthropic.claude-cache-matrix",
+  "max_tokens":16,
+  "tools":[{
+    "type":"function",
+    "function":{
+      "name":"search_groups",
+      "description":"Search feedback groups",
+      "parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+    }
+  }],
+  "messages":[
+    {"role":"user","content":"search notifications"},
+    {"role":"assistant","tool_calls":[{"id":"toolu_1","type":"function","function":{"name":"search_groups","arguments":"{\"query\":\"notifications\"}"}}]},
+    {"role":"tool","tool_call_id":"toolu_1","content":"group results"},
+    {"role":"user","content":[{"type":"text","text":"summarize","cache_control":{"type":"ephemeral"}}]}
+  ]
+}`,
+			expRequestBody: `{"max_tokens":16,"messages":[{"content":[{"text":"search notifications","type":"text"}],"role":"user"},{"content":[{"id":"toolu_1","input":{"query":"notifications"},"name":"search_groups","type":"tool_use"}],"role":"assistant"},{"content":[{"tool_use_id":"toolu_1","is_error":false,"content":[{"text":"group results","type":"text"}],"type":"tool_result"}],"role":"user"},{"content":[{"text":"summarize","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"tools":[{"input_schema":{"properties":{"query":{"type":"string"}},"required":["query"],"type":"object"},"name":"search_groups","description":"Search feedback groups"}],"anthropic_version":"bedrock-2023-05-31"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				fwd := e2elib.RequireNewHTTPPortForwarder(t, e2elib.EnvoyGatewayNamespace, egSelector, e2elib.EnvoyGatewayDefaultServicePort)
+				defer fwd.Kill()
+
+				req, err := http.NewRequest(http.MethodPost, fwd.Address()+"/v1/chat/completions", strings.NewReader(tc.requestBody))
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set(testupstreamlib.ResponseBodyHeaderKey, base64.StdEncoding.EncodeToString([]byte(fakeResponseBody)))
+				req.Header.Set(testupstreamlib.ExpectedPathHeaderKey, base64.StdEncoding.EncodeToString([]byte(expPath)))
+				req.Header.Set(testupstreamlib.ExpectedHostKey, expHost)
+				req.Header.Set(testupstreamlib.ExpectedTestUpstreamIDKey, upstreamID)
+				req.Header.Set(testupstreamlib.ExpectedRequestBodyHeaderKey, base64.StdEncoding.EncodeToString([]byte(tc.expRequestBody)))
+
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Logf("error: %v", err)
+					return false
+				}
+				defer func() { _ = resp.Body.Close() }()
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Logf("error reading response body: %v", err)
+					return false
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Logf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+					return false
+				}
+				return true
+			}, 20*time.Second, 1*time.Second)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

This commit preserves message-level `cache_control` fields on OpenAI tool result messages when translating requests to Anthropic-compatible backends. Previously, the OpenAI schema dropped the field before translation, so AWS Anthropic requests could not place a cache breakpoint on an outer `tool_result` block.

The translator now prefers the message-level marker and falls back to the existing content-part marker. Unit tests cover string and multipart results, consecutive tool messages, and the compatibility path for content-part markers.

**Related Issues/PRs (if applicable)**
N/A

**Special notes for reviewers (if applicable)**
I raised this PR because prompt caching worked for plain messages, tool definitions, and `tool_use` blocks, but missed when the breakpoint landed on a tool result through the OpenAI-compatible endpoint. The native Anthropic endpoint already preserved this shape.

The E2E matrix checks all five prompt shapes against the in-cluster test upstream and verifies the exact AWS Anthropic request body. It does not call a live provider.

I used Cursor to help investigate and implement this change, and I reviewed and verified the code and tests.