### PR TITLE
feat: support Azure Workload Identity (keyless) for AzureCredentials

### DIFF
--- a/api/v1beta1/backendsecurity_policy.go
+++ b/api/v1beta1/backendsecurity_policy.go
@@ -245,10 +245,14 @@ type BackendSecurityPolicyGCPCredentials struct {
 }
 
 // BackendSecurityPolicyAzureCredentials contains the supported authentication mechanisms to access Azure.
-// Only one of ClientSecretRef or OIDCExchangeToken must be specified. Credentials will not be generated if
-// neither are set.
 //
-// +kubebuilder:validation:XValidation:rule="(has(self.clientSecretRef) && !has(self.oidcExchangeToken)) || (!has(self.clientSecretRef) && has(self.oidcExchangeToken))",message="Exactly one of clientSecretRef or oidcExchangeToken must be specified"
+// When neither ClientSecretRef nor OIDCExchangeToken is specified, ambient Azure Workload Identity is
+// used: the data-plane ext_proc mints an Entra token via WorkloadIdentityCredential using the projected
+// service-account token, with no secret and no controller-side rotation. This requires the ServiceAccount
+// to be federated to the managed identity (annotated with azure.workload.identity/use). At most one of
+// ClientSecretRef or OIDCExchangeToken may be set.
+//
+// +kubebuilder:validation:XValidation:rule="!(has(self.clientSecretRef) && has(self.oidcExchangeToken))",message="At most one of clientSecretRef or oidcExchangeToken may be specified; if neither is set, ambient Azure Workload Identity (the projected service-account token) is used"
 type BackendSecurityPolicyAzureCredentials struct {
 	// ClientID is a unique identifier for an application in Azure.
 	//

--- a/internal/backendauth/azure.go
+++ b/internal/backendauth/azure.go
@@ -8,24 +8,85 @@ package backendauth
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
+// azureCognitiveServicesScope is the OAuth 2.0 scope used to request Entra tokens for Azure OpenAI /
+// Cognitive Services when authenticating with ambient Azure Workload Identity.
+const azureCognitiveServicesScope = "https://cognitiveservices.azure.com/.default"
+
 type azureHandler struct {
+	// azureAccessToken is a static, pre-rotated access token. Used when non-empty.
 	azureAccessToken string
+	// cred is the ambient Azure Workload Identity credential. Used when azureAccessToken is empty.
+	cred azcore.TokenCredential
 }
 
 func newAzureHandler(auth *filterapi.AzureAuth) (filterapi.BackendAuthHandler, error) {
-	return &azureHandler{azureAccessToken: strings.TrimSpace(auth.AccessToken)}, nil
+	if auth == nil {
+		return nil, fmt.Errorf("azure auth configuration cannot be nil")
+	}
+	if token := strings.TrimSpace(auth.AccessToken); token != "" {
+		// Static token path: the controller rotates the token into a secret.
+		return &azureHandler{azureAccessToken: token}, nil
+	}
+
+	// Ambient Azure Workload Identity path: the SDK mints an Entra token from the projected
+	// service-account token. ClientID/TenantID pin the identity when provided, otherwise the SDK
+	// reads AZURE_CLIENT_ID/AZURE_TENANT_ID from the environment.
+	opts := &azidentity.WorkloadIdentityCredentialOptions{}
+	if clientID := strings.TrimSpace(auth.ClientID); clientID != "" {
+		opts.ClientID = clientID
+	}
+	if tenantID := strings.TrimSpace(auth.TenantID); tenantID != "" {
+		opts.TenantID = tenantID
+	}
+	// Honor the optional proxy used for Azure token operations, mirroring the controller's
+	// GetClientAssertionCredentialOptions.
+	if azureProxyURL := os.Getenv("AI_GATEWAY_AZURE_PROXY_URL"); azureProxyURL != "" {
+		if proxyURL, err := url.Parse(azureProxyURL); err == nil {
+			opts.ClientOptions = azcore.ClientOptions{
+				Transport: &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}},
+			}
+		}
+	}
+
+	cred, err := azidentity.NewWorkloadIdentityCredential(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure Workload Identity credential: %w", err)
+	}
+	return newAzureHandlerWithCredential(cred), nil
+}
+
+// newAzureHandlerWithCredential builds an ambient-mode azureHandler around the given credential.
+// It exists as a seam so tests can inject a fake azcore.TokenCredential.
+func newAzureHandlerWithCredential(cred azcore.TokenCredential) *azureHandler {
+	return &azureHandler{cred: cred}
 }
 
 // Do implements [Handler.Do].
 //
-// Extracts the azure access token from the local file and set it as an authorization header.
-func (a *azureHandler) Do(_ context.Context, requestHeaders map[string]string, _ []byte) ([]internalapi.Header, error) {
-	requestHeaders["Authorization"] = fmt.Sprintf("Bearer %s", a.azureAccessToken)
-	return []internalapi.Header{{"Authorization", fmt.Sprintf("Bearer %s", a.azureAccessToken)}}, nil
+// It sets the "Authorization" header to a bearer token. When a static access token is configured it is
+// used directly; otherwise an Entra token is minted from the ambient Azure Workload Identity credential.
+func (a *azureHandler) Do(ctx context.Context, requestHeaders map[string]string, _ []byte) ([]internalapi.Header, error) {
+	accessToken := a.azureAccessToken
+	if a.cred != nil {
+		token, err := a.cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{azureCognitiveServicesScope}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Azure access token: %w", err)
+		}
+		accessToken = token.Token
+	}
+	requestHeaders["Authorization"] = fmt.Sprintf("Bearer %s", accessToken)
+	return []internalapi.Header{{"Authorization", fmt.Sprintf("Bearer %s", accessToken)}}, nil
 }

--- a/internal/backendauth/azure_test.go
+++ b/internal/backendauth/azure_test.go
@@ -6,8 +6,11 @@
 package backendauth
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
@@ -39,4 +42,31 @@ func TestNewAzureHandler_Do(t *testing.T) {
 	require.Len(t, headers, 1)
 	require.Equal(t, "Authorization", headers[0][0])
 	require.Equal(t, "Bearer some-access-token", headers[0][1])
+}
+
+// fakeTokenCredential is a stub azcore.TokenCredential used to exercise the ambient
+// Azure Workload Identity path without contacting Entra.
+type fakeTokenCredential struct {
+	token string
+	err   error
+}
+
+func (f *fakeTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if f.err != nil {
+		return azcore.AccessToken{}, f.err
+	}
+	return azcore.AccessToken{Token: f.token}, nil
+}
+
+func TestAzureHandler_Do_WorkloadIdentity(t *testing.T) {
+	handler := newAzureHandlerWithCredential(&fakeTokenCredential{token: "ambient-wi-token"})
+
+	requestHeaders := map[string]string{":method": "POST", ":path": "/model/some-random-model/chat/completion"}
+	headers, err := handler.Do(t.Context(), requestHeaders, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer ambient-wi-token", requestHeaders["Authorization"])
+	require.Len(t, headers, 1)
+	require.Equal(t, "Authorization", headers[0][0])
+	require.Equal(t, "Bearer ambient-wi-token", headers[0][1])
 }

--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -117,6 +117,18 @@ func (c *BackendSecurityPolicyController) reconcile(ctx context.Context, bsp *ai
 		}
 	}
 
+	// Skip rotation for Azure when neither client secret nor OIDC exchange is configured:
+	// ambient Azure Workload Identity (projected SA token) is resolved in the data plane.
+	if bsp.Spec.Type == aigv1b1.BackendSecurityPolicyTypeAzureCredentials {
+		if bsp.Spec.AzureCredentials != nil &&
+			bsp.Spec.AzureCredentials.ClientSecretRef == nil &&
+			bsp.Spec.AzureCredentials.OIDCExchangeToken == nil {
+			c.logger.Info("Using ambient Azure Workload Identity, skipping rotation",
+				"namespace", bsp.Namespace, "name", bsp.Name)
+			requiresRotation = false
+		}
+	}
+
 	if requiresRotation {
 		res, err = c.rotateCredential(ctx, bsp)
 		if err != nil {

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -827,13 +827,23 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 			},
 		}, nil
 	case aigv1b1.BackendSecurityPolicyTypeAzureCredentials:
-		secretName := rotators.GetBSPSecretName(backendSecurityPolicy.Name)
-		azureAccessToken, getErr := c.getSecretData(ctx, namespace, secretName, rotators.AzureAccessTokenKey)
-		if getErr != nil {
-			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+		azureCred := spec.AzureCredentials
+		// Ambient Azure Workload Identity: no rotated secret; the data plane mints the token.
+		if azureCred != nil && azureCred.ClientSecretRef == nil && azureCred.OIDCExchangeToken == nil {
+			auth = &filterapi.BackendAuth{AzureAuth: &filterapi.AzureAuth{
+				ClientID: azureCred.ClientID,
+				TenantID: azureCred.TenantID,
+			}}
+			hasStaticCred = false
+		} else {
+			secretName := rotators.GetBSPSecretName(backendSecurityPolicy.Name)
+			azureAccessToken, getErr := c.getSecretData(ctx, namespace, secretName, rotators.AzureAccessTokenKey)
+			if getErr != nil {
+				return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+			}
+			auth = &filterapi.BackendAuth{AzureAuth: &filterapi.AzureAuth{AccessToken: azureAccessToken}}
+			hasStaticCred = true
 		}
-		auth = &filterapi.BackendAuth{AzureAuth: &filterapi.AzureAuth{AccessToken: azureAccessToken}}
-		hasStaticCred = true
 	case aigv1b1.BackendSecurityPolicyTypeGCPCredentials:
 		gcpCreds := spec.GCPCredentials
 

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -895,8 +895,21 @@ func TestGatewayController_bspToFilterAPIBackendAuth(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "azure-oidc", Namespace: namespace},
 			Spec: aigv1b1.BackendSecurityPolicySpec{
-				Type:             aigv1b1.BackendSecurityPolicyTypeAzureCredentials,
-				AzureCredentials: &aigv1b1.BackendSecurityPolicyAzureCredentials{},
+				Type: aigv1b1.BackendSecurityPolicyTypeAzureCredentials,
+				AzureCredentials: &aigv1b1.BackendSecurityPolicyAzureCredentials{
+					OIDCExchangeToken: &aigv1b1.AzureOIDCExchangeToken{},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "azure-workload-identity", Namespace: namespace},
+			Spec: aigv1b1.BackendSecurityPolicySpec{
+				Type: aigv1b1.BackendSecurityPolicyTypeAzureCredentials,
+				AzureCredentials: &aigv1b1.BackendSecurityPolicyAzureCredentials{
+					ClientID: "azure-client-id",
+					TenantID: "azure-tenant-id",
+					// No ClientSecretRef or OIDCExchangeToken - uses ambient Workload Identity.
+				},
 			},
 		},
 		{
@@ -1008,6 +1021,12 @@ func TestGatewayController_bspToFilterAPIBackendAuth(t *testing.T) {
 			bspName: "azure-oidc",
 			exp: &filterapi.BackendAuth{
 				AzureAuth: &filterapi.AzureAuth{AccessToken: "thisisazurecredentials"},
+			},
+		},
+		{
+			bspName: "azure-workload-identity",
+			exp: &filterapi.BackendAuth{
+				AzureAuth: &filterapi.AzureAuth{ClientID: "azure-client-id", TenantID: "azure-tenant-id"},
 			},
 		},
 		{

--- a/internal/filterapi/filterconfig.go
+++ b/internal/filterapi/filterconfig.go
@@ -292,7 +292,15 @@ func (a AnthropicAPIKeyAuth) LogValue() slog.Value {
 // AzureAuth defines the file containing azure access token that will be mounted to the external proc.
 type AzureAuth struct {
 	// AccessToken is the access token as a literal string.
-	AccessToken string `json:"accessToken"`
+	// When empty, the handler authenticates using ambient Azure Workload Identity
+	// (the projected service-account token), pinning the identity with ClientID/TenantID when set.
+	AccessToken string `json:"accessToken,omitempty"`
+	// ClientID optionally pins the managed identity client ID for ambient Workload Identity.
+	// When empty, the SDK reads AZURE_CLIENT_ID from the environment.
+	ClientID string `json:"clientID,omitempty"`
+	// TenantID optionally pins the Entra tenant ID for ambient Workload Identity.
+	// When empty, the SDK reads AZURE_TENANT_ID from the environment.
+	TenantID string `json:"tenantID,omitempty"`
 }
 
 // LogValue implements slog.LogValuer for AzureAuth to redact sensitive information.

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_backendsecuritypolicies.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_backendsecuritypolicies.yaml
@@ -9818,10 +9818,10 @@ spec:
                 - tenantID
                 type: object
                 x-kubernetes-validations:
-                - message: Exactly one of clientSecretRef or oidcExchangeToken must
-                    be specified
-                  rule: (has(self.clientSecretRef) && !has(self.oidcExchangeToken))
-                    || (!has(self.clientSecretRef) && has(self.oidcExchangeToken))
+                - message: At most one of clientSecretRef or oidcExchangeToken may
+                    be specified; if neither is set, ambient Azure Workload Identity
+                    (the projected service-account token) is used
+                  rule: '!(has(self.clientSecretRef) && has(self.oidcExchangeToken))'
               credentialOverride:
                 description: |-
                   CredentialOverride, when set, sources the upstream credential per-request instead of using

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -3556,8 +3556,12 @@ BackendSecurityPolicyAzureAPIKey specifies the Azure OpenAI API key.
 - [BackendSecurityPolicySpec](#github-com-envoyproxy-ai-gateway-api-v1beta1-backendsecuritypolicyspec)
 
 BackendSecurityPolicyAzureCredentials contains the supported authentication mechanisms to access Azure.
-Only one of ClientSecretRef or OIDCExchangeToken must be specified. Credentials will not be generated if
-neither are set.
+
+When neither ClientSecretRef nor OIDCExchangeToken is specified, ambient Azure Workload Identity is
+used: the data-plane ext_proc mints an Entra token via WorkloadIdentityCredential using the projected
+service-account token, with no secret and no controller-side rotation. This requires the ServiceAccount
+to be federated to the managed identity (annotated with azure.workload.identity/use). At most one of
+ClientSecretRef or OIDCExchangeToken may be set.
 
 ##### Fields
 

--- a/site/docs/capabilities/llm-integrations/connect-providers.md
+++ b/site/docs/capabilities/llm-integrations/connect-providers.md
@@ -168,6 +168,27 @@ spec:
 The secret must contain the Azure client secret with the key name `"client-secret"`.
 :::
 
+###### Azure Workload Identity (keyless)
+
+When neither `clientSecretRef` nor `oidcExchangeToken` is set, Envoy AI Gateway uses ambient Azure Workload Identity: the data-plane ext_proc mints an Entra token from the projected service-account token, so there is no client secret to store and no controller-side rotation.
+
+```yaml
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: BackendSecurityPolicy
+metadata:
+  name: azure-auth-workload-identity
+  namespace: default
+spec:
+  type: AzureCredentials
+  azureCredentials:
+    clientID: "your-managed-identity-client-id"
+    tenantID: "your-azure-tenant-id"
+```
+
+:::note
+The pod's ServiceAccount must be federated to the managed identity (annotated with `azure.workload.identity/use`).
+:::
+
 ##### GCP Credentials
 
 Used for connecting to GCP Vertex AI and Anthropic on GCP. Supports three authentication methods:

--- a/tests/crdcel/main_test.go
+++ b/tests/crdcel/main_test.go
@@ -142,12 +142,8 @@ func TestBackendSecurityPolicies(t *testing.T) {
 			expErr: "spec.azureCredentials.tenantID in body should be at least 1 chars long",
 		},
 		{
-			name:   "azure_missing_auth.yaml",
-			expErr: "Exactly one of clientSecretRef or oidcExchangeToken must be specified",
-		},
-		{
 			name:   "azure_multiple_auth.yaml",
-			expErr: "Exactly one of clientSecretRef or oidcExchangeToken must be specified",
+			expErr: "At most one of clientSecretRef or oidcExchangeToken may be specified",
 		},
 		// CEL validation test cases - these should fail due to type mismatch.
 		{
@@ -180,6 +176,7 @@ func TestBackendSecurityPolicies(t *testing.T) {
 		},
 		{name: "azure_oidc.yaml"},
 		{name: "azure_valid_credentials.yaml"},
+		{name: "azure_workload_identity.yaml"},
 		{name: "aws_credential_file.yaml"},
 		{name: "aws_oidc.yaml"},
 		{name: "gcp_oidc.yaml"},

--- a/tests/crdcel/testdata/backendsecuritypolicies/azure_workload_identity.yaml
+++ b/tests/crdcel/testdata/backendsecuritypolicies/azure_workload_identity.yaml
@@ -3,10 +3,12 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+# Ambient Azure Workload Identity: neither clientSecretRef nor oidcExchangeToken is set,
+# so the data-plane ext_proc mints an Entra token from the projected service-account token.
 apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: BackendSecurityPolicy
 metadata:
-  name: azure-missing-provider-policy
+  name: azure-workload-identity-policy
   namespace: default
 spec:
   type: AzureCredentials


### PR DESCRIPTION
## Description

Adds an ambient **Azure Workload Identity (keyless)** auth mode to `BackendSecurityPolicy` `type: AzureCredentials`.

When neither `clientSecretRef` nor `oidcExchangeToken` is set, the data-plane ext_proc mints an Entra token via `azidentity.WorkloadIdentityCredential` (the projected service-account token), with **no secret to store and no controller-side rotation**. This mirrors the two ambient patterns already in the repo:

- GCP Application Default Credentials (ADC) when neither `credentialsFile` nor `workloadIdentityFederationConfig` is set.
- AWS default credential chain when neither `credentialsFile` nor `oidcExchangeToken` is set.

The token is requested with the Azure Cognitive Services data-plane scope `https://cognitiveservices.azure.com/.default` (the same audience the existing Azure OIDC/client-secret rotator uses), so it authorizes Azure OpenAI inference calls.

This is offered as an alternative shape to #2378 (which adds an explicit `managedIdentity` field and mints the token controller-side with an ARM scope). See the discussion on that PR for the design trade-offs; the two substantive differences are data-plane vs controller-side minting and the token audience.

## Changes

- **CRD** (`api/v1beta1`): relax the `AzureCredentials` validation from "exactly one of clientSecretRef/oidcExchangeToken" to "at most one"; neither-set now selects ambient Workload Identity. Doc-comment updated.
- **filterapi** `AzureAuth`: add optional `clientID`/`tenantID` to pin the managed identity; `accessToken` now optional.
- **Data-plane** `internal/backendauth/azure.go`: keep the static-token path; add the ambient path using `WorkloadIdentityCredential`, honoring `AI_GATEWAY_AZURE_PROXY_URL` for the proxy transport. Adds an unexported seam for injecting a fake `azcore.TokenCredential` in tests.
- **Controller**: skip credential rotation for the ambient case; project `clientID`/`tenantID` into the filter config (no rotated secret).
- Regenerated CRD YAML and API docs; unit tests and CEL validation tests added/updated.

## How to keyless-enable

The pod's ServiceAccount must be federated to the managed identity (annotated with `azure.workload.identity/use`). Then:

```yaml
apiVersion: aigateway.envoyproxy.io/v1beta1
kind: BackendSecurityPolicy
spec:
  type: AzureCredentials
  azureCredentials:
    clientID: "<managed-identity-client-id>"
    tenantID: "<entra-tenant-id>"
    # no clientSecretRef, no oidcExchangeToken
```

## Testing

- `go build ./...`, `go vet` clean.
- `go test ./internal/backendauth/... ./internal/filterapi/... ./internal/controller/... ./tests/crdcel/...` all pass, including a new ambient-path handler test (fake credential asserts `Authorization: Bearer <token>`), a new gateway mapping case, and a new CEL `azure_workload_identity.yaml` valid fixture.
