### PR TITLE
feat: add /tokenize for chat completion on GCP Vertex AI gemini models

### DIFF
--- a/internal/apischema/gcp/gcp.go
+++ b/internal/apischema/gcp/gcp.go
@@ -151,3 +151,21 @@ type EmbedContentUsageMetadata struct {
 	PromptTokenCount int `json:"promptTokenCount,omitempty"`
 	TotalTokenCount  int `json:"totalTokenCount,omitempty"`
 }
+
+// CountTokenRequest represents the Vertex AI CountTokens API request.
+// The Vertex AI API expects a flat structure (not nested config).
+// https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/count-tokens
+type CountTokenRequest struct {
+	// The content to count tokens for.
+	// https://github.com/googleapis/go-genai/blob/6a8184fcaf8bf15f0c566616a7b356560309be9b/types.go#L858
+	Contents []genai.Content `json:"contents"`
+
+	// Optional. Instructions for the model to steer it toward better performance.
+	SystemInstruction *genai.Content `json:"systemInstruction,omitempty"`
+
+	// Optional. Code that enables the system to interact with external systems.
+	Tools []*genai.Tool `json:"tools,omitempty"`
+
+	// Optional. Configuration that the model uses to generate the response.
+	GenerationConfig *genai.GenerationConfig `json:"generationConfig,omitempty"`
+}

--- a/internal/apischema/gcp/gcp.go
+++ b/internal/apischema/gcp/gcp.go
@@ -164,7 +164,7 @@ type CountTokenRequest struct {
 	SystemInstruction *genai.Content `json:"systemInstruction,omitempty"`
 
 	// Optional. Code that enables the system to interact with external systems.
-	Tools []*genai.Tool `json:"tools,omitempty"`
+	Tools []genai.Tool `json:"tools,omitempty"`
 
 	// Optional. Configuration that the model uses to generate the response.
 	GenerationConfig *genai.GenerationConfig `json:"generationConfig,omitempty"`

--- a/internal/apischema/gcp/gcp.go
+++ b/internal/apischema/gcp/gcp.go
@@ -154,7 +154,9 @@ type EmbedContentUsageMetadata struct {
 
 // CountTokenRequest represents the Vertex AI CountTokens API request.
 // The Vertex AI API expects a flat structure (not nested config).
-// https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/count-tokens
+// The request-body fields (contents, tools, systemInstruction, generationConfig) are
+// documented as optional in the REST API reference:
+// https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.publishers.models/countTokens
 type CountTokenRequest struct {
 	// The content to count tokens for.
 	// https://github.com/googleapis/go-genai/blob/6a8184fcaf8bf15f0c566616a7b356560309be9b/types.go#L858

--- a/internal/endpointspec/endpointspec.go
+++ b/internal/endpointspec/endpointspec.go
@@ -453,6 +453,8 @@ func (TokenizeEndpointSpec) GetTranslator(schema filterapi.VersionedAPISchema, m
 	switch schema.Name {
 	case filterapi.APISchemaOpenAI:
 		return translator.NewTokenizeTranslator(modelNameOverride), nil
+	case filterapi.APISchemaGCPVertexAI:
+		return translator.NewTokenizeToGCPVertexAITranslator(modelNameOverride), nil
 	case filterapi.APISchemaGCPAnthropic:
 		return translator.NewTokenizeToGCPAnthropicTranslator(schema.Version, modelNameOverride), nil
 	case filterapi.APISchemaAWSAnthropic:

--- a/internal/endpointspec/endpointspec_test.go
+++ b/internal/endpointspec/endpointspec_test.go
@@ -478,6 +478,7 @@ func TestTokenizeEndpointSpec_GetTranslator(t *testing.T) {
 	spec := TokenizeEndpointSpec{}
 	supported := []filterapi.VersionedAPISchema{
 		{Name: filterapi.APISchemaOpenAI},
+		{Name: filterapi.APISchemaGCPVertexAI},
 		{Name: filterapi.APISchemaGCPAnthropic},
 		{Name: filterapi.APISchemaAWSAnthropic},
 	}

--- a/internal/translator/gemini_helper.go
+++ b/internal/translator/gemini_helper.go
@@ -29,6 +29,7 @@ const (
 	gcpModelPublisherAnthropic     = "anthropic"
 	gcpMethodGenerateContent       = "generateContent"
 	gcpMethodStreamGenerateContent = "streamGenerateContent"
+	gcpMethodCountTokens           = "countTokens"
 	gcpMethodRawPredict            = "rawPredict"
 )
 

--- a/internal/translator/tokenize_gcpvertexai.go
+++ b/internal/translator/tokenize_gcpvertexai.go
@@ -1,0 +1,188 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"google.golang.org/genai"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/gcp"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai/tokenize"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
+)
+
+// NewTokenizeToGCPVertexAITranslator implements [Factory] for tokenize to GCP Vertex AI translation.
+func NewTokenizeToGCPVertexAITranslator(modelNameOverride internalapi.ModelNameOverride) TokenizeTranslator {
+	return &ToGCPVertexAIV1Tokenize{
+		modelNameOverride: modelNameOverride,
+	}
+}
+
+// ToGCPVertexAIV1Tokenize translates tokenize API requests to GCP Vertex AI format.
+// Converts OpenAI-compatible tokenize requests to GCP Gemini CountTokens API format.
+// https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/count-tokens
+type ToGCPVertexAIV1Tokenize struct {
+	modelNameOverride internalapi.ModelNameOverride
+	requestModel      internalapi.RequestModel
+}
+
+// tokenizeToGeminiCountToken converts an OpenAI tokenize chat request to GCP Gemini CountTokens format.
+func (o *ToGCPVertexAIV1Tokenize) tokenizeToGeminiCountToken(tokenizeChatReq *tokenize.ChatRequest, requestModel internalapi.RequestModel) (*gcp.CountTokenRequest, error) {
+	// Convert messages to Gemini Contents and SystemInstruction.
+	contents, systemInstruction, err := openAIMessagesToGeminiContents(tokenizeChatReq.Messages, requestModel)
+	if err != nil {
+		return nil, err
+	}
+	if len(contents) == 0 && systemInstruction == nil {
+		return nil, fmt.Errorf("messages must produce at least one content entry")
+	}
+
+	// Some models support only partialJSONSchema.
+	parametersJSONSchemaAvailable := responseJSONSchemaAvailable(requestModel)
+	// Convert OpenAI tools to Gemini tools.
+	tools, err := openAIToolsToGeminiTools(tokenizeChatReq.Tools, parametersJSONSchemaAvailable)
+	if err != nil {
+		return nil, fmt.Errorf("error converting tools: %w", err)
+	}
+
+	// Convert []genai.Tool to []*genai.Tool
+	var toolPtrs []*genai.Tool
+	for i := range tools {
+		toolPtrs = append(toolPtrs, &tools[i])
+	}
+
+	// Build the flat CountTokenRequest structure as expected by Vertex AI API
+	gcr := gcp.CountTokenRequest{
+		Contents:          contents,
+		SystemInstruction: systemInstruction,
+		Tools:             toolPtrs,
+	}
+
+	// Only include GenerationConfig if MediaResolution is set
+	if tokenizeChatReq.MediaResolution != "" {
+		gcr.GenerationConfig = &genai.GenerationConfig{
+			MediaResolution: tokenizeChatReq.MediaResolution,
+		}
+	}
+
+	return &gcr, nil
+}
+
+// geminiCountTokenToResponse converts a GCP Gemini CountTokens response to OpenAI tokenize format.
+func (o *ToGCPVertexAIV1Tokenize) geminiCountTokenToResponse(gcpResp *genai.CountTokensResponse) (*tokenize.Response, error) {
+	// only media_resolution is related to the # prompt tokens
+	tokenizeResp := tokenize.Response{
+		Count: int(gcpResp.TotalTokens),
+	}
+
+	return &tokenizeResp, nil
+}
+
+// RequestBody implements [TokenizeTranslator.RequestBody] for GCP Vertex AI.
+// This method translates an OpenAI tokenize request to GCP Gemini CountTokens format.
+func (o *ToGCPVertexAIV1Tokenize) RequestBody(_ []byte, tokenizeReq *tokenize.RequestUnion, _ bool) (
+	newHeaders []internalapi.Header, newBody []byte, err error,
+) {
+	// Validate that the union has exactly one request type set
+	if err = tokenizeReq.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("invalid tokenize request: %w", err)
+	}
+
+	// Store the request model to use as fallback for response model.
+	// If this is a CompletionRequest, convert the prompt to a single user message
+	// since GCP Vertex AI CountTokens only supports the Gemini contents format.
+	if tokenizeReq.ChatRequest != nil {
+		o.requestModel = tokenizeReq.ChatRequest.Model
+	} else if tokenizeReq.CompletionRequest != nil {
+		o.requestModel = tokenizeReq.CompletionRequest.Model
+		tokenizeReq.ChatRequest = &tokenize.ChatRequest{
+			Model: tokenizeReq.CompletionRequest.Model,
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{OfUser: &openai.ChatCompletionUserMessageParam{
+					Role:    "user",
+					Content: openai.StringOrUserRoleContentUnion{Value: tokenizeReq.Prompt},
+				}},
+			},
+		}
+		tokenizeReq.CompletionRequest = nil
+	}
+	if o.modelNameOverride != "" {
+		// Use modelName override if set.
+		o.requestModel = o.modelNameOverride
+	}
+
+	// Build the correct path for GCP Vertex AI Count Tokens API
+	path := buildGCPModelPathSuffix(gcpModelPublisherGoogle, o.requestModel, gcpMethodCountTokens)
+
+	gcpReq, err := o.tokenizeToGeminiCountToken(tokenizeReq.ChatRequest, o.requestModel)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error converting to Gemini request: %w", err)
+	}
+
+	newBody, err = json.Marshal(gcpReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error marshaling Gemini count token request: %w", err)
+	}
+	newHeaders = []internalapi.Header{
+		{pathHeaderName, path},
+		{contentLengthHeaderName, strconv.Itoa(len(newBody))},
+	}
+	return
+}
+
+// ResponseError implements [TokenizeTranslator.ResponseError] for GCP Vertex AI.
+// Translate GCP Vertex AI exceptions to OpenAI error type.
+func (o *ToGCPVertexAIV1Tokenize) ResponseError(respHeaders map[string]string, body io.Reader) (
+	newHeaders []internalapi.Header, newBody []byte, err error,
+) {
+	return convertGCPVertexAIErrorToOpenAI(respHeaders, body)
+}
+
+// ResponseHeaders implements [TokenizeTranslator.ResponseHeaders].
+func (o *ToGCPVertexAIV1Tokenize) ResponseHeaders(map[string]string) (newHeaders []internalapi.Header, err error) {
+	return nil, nil
+}
+
+// ResponseBody implements [TokenizeTranslator.ResponseBody] for GCP Vertex AI.
+// This method translates a GCP Gemini CountTokens response to OpenAI tokenize format.
+// GCP Vertex AI uses deterministic model mapping without virtualization, where the requested model
+// is exactly what gets executed. The response does not contain a model field, so we return
+// the request model that was originally sent.
+func (o *ToGCPVertexAIV1Tokenize) ResponseBody(_ map[string]string, body io.Reader, _ bool, span tracingapi.TokenizeSpan) (
+	newHeaders []internalapi.Header, newBody []byte, tokenUsage metrics.TokenUsage, responseModel string, err error,
+) {
+	gcpResp := &genai.CountTokensResponse{}
+	if err = json.NewDecoder(body).Decode(gcpResp); err != nil {
+		return nil, nil, tokenUsage, responseModel, fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+
+	responseModel = o.requestModel
+
+	// Convert to OpenAI format.
+	openAIResp, err := o.geminiCountTokenToResponse(gcpResp)
+	if err != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error converting GCP response to OpenAI format: %w", err)
+	}
+
+	// Marshal the OpenAI response.
+	newBody, err = json.Marshal(openAIResp)
+	if err != nil {
+		return nil, nil, metrics.TokenUsage{}, "", fmt.Errorf("error marshaling OpenAI response: %w", err)
+	}
+
+	if span != nil {
+		span.RecordResponse(openAIResp)
+	}
+	newHeaders = []internalapi.Header{{contentLengthHeaderName, strconv.Itoa(len(newBody))}}
+	return
+}

--- a/internal/translator/tokenize_gcpvertexai.go
+++ b/internal/translator/tokenize_gcpvertexai.go
@@ -55,17 +55,11 @@ func (o *ToGCPVertexAIV1Tokenize) tokenizeToGeminiCountToken(tokenizeChatReq *to
 		return nil, fmt.Errorf("error converting tools: %w", err)
 	}
 
-	// Convert []genai.Tool to []*genai.Tool
-	var toolPtrs []*genai.Tool
-	for i := range tools {
-		toolPtrs = append(toolPtrs, &tools[i])
-	}
-
 	// Build the flat CountTokenRequest structure as expected by Vertex AI API
 	gcr := gcp.CountTokenRequest{
 		Contents:          contents,
 		SystemInstruction: systemInstruction,
-		Tools:             toolPtrs,
+		Tools:             tools,
 	}
 
 	// Only include GenerationConfig if MediaResolution is set

--- a/internal/translator/tokenize_gcpvertexai.go
+++ b/internal/translator/tokenize_gcpvertexai.go
@@ -62,7 +62,10 @@ func (o *ToGCPVertexAIV1Tokenize) tokenizeToGeminiCountToken(tokenizeChatReq *to
 		Tools:             tools,
 	}
 
-	// Only include GenerationConfig if MediaResolution is set
+	// Only forward MediaResolution from GenerationConfig: among generation config
+	// fields, it's the only one that affects the prompt token count, since it controls
+	// how many tokens input media consume. Output settings like MaxOutputTokens don't
+	// affect the CountTokens result, which counts input tokens only.
 	if tokenizeChatReq.MediaResolution != "" {
 		gcr.GenerationConfig = &genai.GenerationConfig{
 			MediaResolution: tokenizeChatReq.MediaResolution,
@@ -74,7 +77,6 @@ func (o *ToGCPVertexAIV1Tokenize) tokenizeToGeminiCountToken(tokenizeChatReq *to
 
 // geminiCountTokenToResponse converts a GCP Gemini CountTokens response to OpenAI tokenize format.
 func (o *ToGCPVertexAIV1Tokenize) geminiCountTokenToResponse(gcpResp *genai.CountTokensResponse) (*tokenize.Response, error) {
-	// only media_resolution is related to the # prompt tokens
 	tokenizeResp := tokenize.Response{
 		Count: int(gcpResp.TotalTokens),
 	}

--- a/internal/translator/tokenize_gcpvertexai_test.go
+++ b/internal/translator/tokenize_gcpvertexai_test.go
@@ -1,0 +1,856 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genai"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/gcp"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai/tokenize"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+)
+
+func TestNewTokenizeToGCPVertexAITranslator(t *testing.T) {
+	translator := NewTokenizeToGCPVertexAITranslator("")
+
+	require.NotNil(t, translator)
+	concrete := translator.(*ToGCPVertexAIV1Tokenize)
+	require.Empty(t, concrete.modelNameOverride)
+	require.Empty(t, concrete.requestModel)
+}
+
+func TestToGCPVertexAIV1Tokenize_RequestBody(t *testing.T) {
+	t.Run("chat request - no model override", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "gemini-2.0-flash-001",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Hello world"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		headers, body, err := translator.RequestBody(nil, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.Equal(t, "gemini-2.0-flash-001", translator.requestModel)
+		require.Len(t, headers, 2)
+		require.Equal(t, pathHeaderName, headers[0].Key())
+		require.Contains(t, headers[0].Value(), "gemini-2.0-flash-001")
+		require.Contains(t, headers[0].Value(), "countTokens")
+		require.Equal(t, contentLengthHeaderName, headers[1].Key())
+		require.Equal(t, strconv.Itoa(len(body)), headers[1].Value())
+
+		// Verify the body contains GCP count tokens request
+		var gcpReq gcp.CountTokenRequest
+		require.NoError(t, json.Unmarshal(body, &gcpReq))
+		require.NotNil(t, gcpReq.Contents)
+		require.Len(t, gcpReq.Contents, 1)
+		require.Equal(t, "user", gcpReq.Contents[0].Role)
+		require.Len(t, gcpReq.Contents[0].Parts, 1)
+		require.Equal(t, "Hello world", gcpReq.Contents[0].Parts[0].Text)
+	})
+
+	t.Run("chat request - with model override", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{
+			modelNameOverride: "override-model",
+		}
+
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "original-model",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Test message"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		headers, body, err := translator.RequestBody(nil, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.Equal(t, "override-model", translator.requestModel)
+		require.Len(t, headers, 2)
+		require.Contains(t, headers[0].Value(), "override-model")
+	})
+
+	t.Run("chat request - with system instruction", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "gemini-1.5-pro",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfSystem: &openai.ChatCompletionSystemMessageParam{
+							Content: openai.ContentUnion{Value: "You are a helpful assistant"},
+							Role:    openai.ChatMessageRoleSystem,
+						},
+					},
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Hello"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		_, body, err := translator.RequestBody(nil, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, body)
+
+		var gcpReq gcp.CountTokenRequest
+		require.NoError(t, json.Unmarshal(body, &gcpReq))
+		require.NotNil(t, gcpReq.SystemInstruction)
+		require.Len(t, gcpReq.SystemInstruction.Parts, 1)
+		require.Equal(t, "You are a helpful assistant", gcpReq.SystemInstruction.Parts[0].Text)
+		require.Len(t, gcpReq.Contents, 1) // System message should not be in contents
+		require.Equal(t, "user", gcpReq.Contents[0].Role)
+	})
+
+	t.Run("completion request - converted to chat", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		req := &tokenize.RequestUnion{
+			CompletionRequest: &tokenize.CompletionRequest{
+				Model:  "gemini-2.0-flash-001",
+				Prompt: "Hello world",
+			},
+		}
+
+		headers, body, err := translator.RequestBody(nil, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.Equal(t, "gemini-2.0-flash-001", translator.requestModel)
+		require.Len(t, headers, 2)
+		require.Contains(t, headers[0].Value(), "gemini-2.0-flash-001")
+		require.Contains(t, headers[0].Value(), "countTokens")
+
+		var gcpReq gcp.CountTokenRequest
+		require.NoError(t, json.Unmarshal(body, &gcpReq))
+		require.Len(t, gcpReq.Contents, 1)
+		require.Equal(t, "user", gcpReq.Contents[0].Role)
+	})
+
+	t.Run("empty model string", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "", // Empty model is rejected: model is a required field.
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Test"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		_, _, err := translator.RequestBody(nil, req, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "model is required")
+	})
+
+	t.Run("message conversion error", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		// Create a request with invalid message structure that would cause conversion error
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model:    "gemini-1.5-pro",
+				Messages: []openai.ChatCompletionMessageParamUnion{}, // Empty messages
+			},
+		}
+
+		_, _, err := translator.RequestBody(nil, req, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error converting to Gemini request")
+	})
+}
+
+func TestToGCPVertexAIV1Tokenize_ResponseBody(t *testing.T) {
+	t.Run("valid GCP response", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{
+			requestModel: "gemini-2.0-flash-001",
+		}
+
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 42,
+		}
+
+		responseJSON, err := json.Marshal(gcpResp)
+		require.NoError(t, err)
+
+		headers, body, tokenUsage, responseModel, err := translator.ResponseBody(
+			nil,
+			bytes.NewReader(responseJSON),
+			false,
+			nil, // No span for simplicity
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.Equal(t, "gemini-2.0-flash-001", responseModel)
+		require.Len(t, headers, 1)
+		require.Equal(t, contentLengthHeaderName, headers[0].Key())
+
+		// Verify the response is converted to OpenAI format
+		var openAIResp tokenize.Response
+		require.NoError(t, json.Unmarshal(body, &openAIResp))
+		require.Equal(t, 42, openAIResp.Count)
+
+		// TODO: Token usage should be extracted from GCP response
+		// This is currently missing but should be implemented
+		_, hasTokens := tokenUsage.InputTokens()
+		require.False(t, hasTokens) // Current behavior - should be fixed
+	})
+
+	t.Run("empty response model fallback", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{
+			requestModel: "gemini-1.5-pro",
+		}
+
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 0,
+		}
+
+		responseJSON, err := json.Marshal(gcpResp)
+		require.NoError(t, err)
+
+		_, _, _, responseModel, err := translator.ResponseBody(
+			nil,
+			bytes.NewReader(responseJSON),
+			false,
+			nil,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, "gemini-1.5-pro", responseModel) // Falls back to request model
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{}
+
+		invalidJSON := "invalid json response"
+
+		_, _, _, _, err := translator.ResponseBody(
+			nil,
+			bytes.NewReader([]byte(invalidJSON)),
+			false,
+			nil,
+		)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to unmarshal body")
+	})
+
+	t.Run("GCP response conversion error", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{}
+
+		// Valid JSON but might cause conversion issues
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: -1, // Negative token count might cause issues
+		}
+
+		responseJSON, err := json.Marshal(gcpResp)
+		require.NoError(t, err)
+
+		_, _, _, _, err = translator.ResponseBody(
+			nil,
+			bytes.NewReader(responseJSON),
+			false,
+			nil,
+		)
+
+		// Current implementation might not validate negative tokens
+		// This documents potential improvement area
+		require.NoError(t, err) // Current behavior
+	})
+
+	t.Run("response marshaling error simulation", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{}
+
+		// Create a valid GCP response
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 10,
+		}
+
+		responseJSON, err := json.Marshal(gcpResp)
+		require.NoError(t, err)
+
+		// The current implementation should not have marshaling errors with normal data
+		_, _, _, _, err = translator.ResponseBody(nil, bytes.NewReader(responseJSON), false, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil span handling", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{
+			requestModel: "gemini-1.5-pro",
+		}
+
+		gcpResp := &genai.CountTokensResponse{TotalTokens: 5}
+		responseJSON, err := json.Marshal(gcpResp)
+		require.NoError(t, err)
+
+		// Should not panic with nil span
+		_, _, _, _, err = translator.ResponseBody(nil, bytes.NewReader(responseJSON), false, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestToGCPVertexAIV1Tokenize_ResponseError(t *testing.T) {
+	translator := &ToGCPVertexAIV1Tokenize{}
+
+	tests := []struct {
+		name            string
+		responseHeaders map[string]string
+		input           string
+		expectedType    string
+		expectedCode    string
+		expectedMessage string
+	}{
+		{
+			name: "GCP structured error response",
+			responseHeaders: map[string]string{
+				":status":      "400",
+				"content-type": "application/json",
+			},
+			input: `{
+				"error": {
+					"code": 400,
+					"message": "Invalid request: model not found",
+					"status": "INVALID_ARGUMENT",
+					"details": [{"type": "additional_info", "value": "gemini-invalid not supported"}]
+				}
+			}`,
+			expectedType:    "INVALID_ARGUMENT",
+			expectedCode:    "400",
+			expectedMessage: "Error: Invalid request: model not found\nDetails: [{\"type\": \"additional_info\", \"value\": \"gemini-invalid not supported\"}]",
+		},
+		{
+			name: "GCP structured error without details",
+			responseHeaders: map[string]string{
+				":status":      "403",
+				"content-type": "application/json",
+			},
+			input: `{
+				"error": {
+					"code": 403,
+					"message": "Permission denied",
+					"status": "PERMISSION_DENIED"
+				}
+			}`,
+			expectedType:    "PERMISSION_DENIED",
+			expectedCode:    "403",
+			expectedMessage: "Permission denied",
+		},
+		{
+			name: "Non-JSON error response",
+			responseHeaders: map[string]string{
+				":status":      "503",
+				"content-type": "text/plain",
+			},
+			input:           "Service temporarily unavailable",
+			expectedType:    "GCPVertexAIBackendError",
+			expectedCode:    "503",
+			expectedMessage: "Service temporarily unavailable",
+		},
+		{
+			name: "HTML error response",
+			responseHeaders: map[string]string{
+				":status":      "504",
+				"content-type": "text/html",
+			},
+			input:           "<html><body>Gateway Timeout</body></html>",
+			expectedType:    "GCPVertexAIBackendError",
+			expectedCode:    "504",
+			expectedMessage: "<html><body>Gateway Timeout</body></html>",
+		},
+		{
+			name: "Invalid JSON error",
+			responseHeaders: map[string]string{
+				":status":      "500",
+				"content-type": "application/json",
+			},
+			input:           "{invalid json",
+			expectedType:    "GCPVertexAIBackendError",
+			expectedCode:    "500",
+			expectedMessage: "{invalid json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers, newBody, err := translator.ResponseError(tt.responseHeaders, strings.NewReader(tt.input))
+
+			require.NoError(t, err)
+			require.NotNil(t, headers)
+			require.NotNil(t, newBody)
+
+			require.Len(t, headers, 2)
+			require.Equal(t, contentTypeHeaderName, headers[0].Key())
+			require.Equal(t, jsonContentType, headers[0].Value()) //nolint:testifylint // comparing header value, not JSON
+			require.Equal(t, contentLengthHeaderName, headers[1].Key())
+			require.Equal(t, strconv.Itoa(len(newBody)), headers[1].Value())
+
+			var openAIError openai.Error
+			require.NoError(t, json.Unmarshal(newBody, &openAIError))
+			require.Equal(t, "error", openAIError.Type)
+			require.Equal(t, tt.expectedType, openAIError.Error.Type)
+			require.Equal(t, tt.expectedCode, *openAIError.Error.Code)
+			require.Equal(t, tt.expectedMessage, openAIError.Error.Message)
+		})
+	}
+
+	t.Run("read error", func(t *testing.T) {
+		// Create a reader that will fail
+		pr, pw := io.Pipe()
+		_ = pw.CloseWithError(fmt.Errorf("simulated read error"))
+
+		_, _, err := translator.ResponseError(map[string]string{":status": "500"}, pr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read error body")
+	})
+
+	t.Run("marshal error simulation", func(t *testing.T) {
+		// This is hard to simulate with normal JSON marshal,
+		// but we can test normal operation
+		headers := map[string]string{":status": "400"}
+		input := "test error"
+
+		newHeaders, newBody, err := translator.ResponseError(headers, strings.NewReader(input))
+		require.NoError(t, err)
+		require.NotNil(t, newHeaders)
+		require.NotNil(t, newBody)
+	})
+}
+
+func TestToGCPVertexAIV1Tokenize_ResponseHeaders(t *testing.T) {
+	translator := &ToGCPVertexAIV1Tokenize{}
+
+	headers, err := translator.ResponseHeaders(map[string]string{
+		"content-type":  "application/json",
+		"custom-header": "value",
+		"cache-control": "no-cache",
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, headers) // Current implementation returns nil
+}
+
+func TestToGCPVertexAIV1Tokenize_HelperMethods(t *testing.T) {
+	translator := &ToGCPVertexAIV1Tokenize{}
+
+	t.Run("tokenizeToGeminiCountToken", func(t *testing.T) {
+		chatReq := &tokenize.ChatRequest{
+			Model: "gemini-1.5-pro",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{
+					OfUser: &openai.ChatCompletionUserMessageParam{
+						Content: openai.StringOrUserRoleContentUnion{Value: "Test message"},
+						Role:    openai.ChatMessageRoleUser,
+					},
+				},
+			},
+		}
+
+		gcpReq, err := translator.tokenizeToGeminiCountToken(chatReq, "gemini-1.5-pro")
+		require.NoError(t, err)
+		require.NotNil(t, gcpReq)
+		require.NotNil(t, gcpReq.Contents)
+		require.Len(t, gcpReq.Contents, 1)
+		require.Equal(t, "user", gcpReq.Contents[0].Role)
+		require.Equal(t, "Test message", gcpReq.Contents[0].Parts[0].Text)
+	})
+
+	t.Run("geminiCountTokenToResponse", func(t *testing.T) {
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 25,
+		}
+
+		tokenizeResp, err := translator.geminiCountTokenToResponse(gcpResp)
+		require.NoError(t, err)
+		require.NotNil(t, tokenizeResp)
+		require.Equal(t, 25, tokenizeResp.Count)
+	})
+
+	t.Run("tokenizeToGeminiCountToken with invalid messages", func(t *testing.T) {
+		chatReq := &tokenize.ChatRequest{
+			Model:    "gemini-1.5-pro",
+			Messages: []openai.ChatCompletionMessageParamUnion{}, // Empty messages
+		}
+
+		_, err := translator.tokenizeToGeminiCountToken(chatReq, "gemini-1.5-pro")
+		require.Error(t, err) // Should error on empty messages
+	})
+
+	t.Run("geminiCountTokenToResponse with zero tokens", func(t *testing.T) {
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 0,
+		}
+
+		tokenizeResp, err := translator.geminiCountTokenToResponse(gcpResp)
+		require.NoError(t, err)
+		require.Equal(t, 0, tokenizeResp.Count)
+	})
+
+	t.Run("geminiCountTokenToResponse with large token count", func(t *testing.T) {
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 1000000,
+		}
+
+		tokenizeResp, err := translator.geminiCountTokenToResponse(gcpResp)
+		require.NoError(t, err)
+		require.Equal(t, 1000000, tokenizeResp.Count)
+	})
+}
+
+func TestToGCPVertexAIV1Tokenize_IntegrationScenarios(t *testing.T) {
+	t.Run("complete flow - request to response", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		// Step 1: Process request
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "gemini-2.0-flash-001",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Count tokens in this message"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		reqHeaders, reqBody, err := translator.RequestBody(nil, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+		require.Len(t, reqHeaders, 2)
+
+		// Step 2: Simulate GCP response
+		gcpResponse := &genai.CountTokensResponse{
+			TotalTokens: 7, // "Count tokens in this message" = 7 tokens
+		}
+		gcpResponseJSON, err := json.Marshal(gcpResponse)
+		require.NoError(t, err)
+
+		// Step 3: Process response
+		_, respBody, tokenUsage, responseModel, err := translator.ResponseBody(
+			nil,
+			bytes.NewReader(gcpResponseJSON),
+			false,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, respBody)
+		require.Equal(t, "gemini-2.0-flash-001", responseModel)
+
+		// Step 4: Verify final OpenAI response
+		var finalResp tokenize.Response
+		require.NoError(t, json.Unmarshal(respBody, &finalResp))
+		require.Equal(t, 7, finalResp.Count)
+
+		// Token usage should ideally be populated but currently isn't
+		_, hasTokens := tokenUsage.InputTokens()
+		require.False(t, hasTokens) // Documents current limitation
+	})
+
+	t.Run("error flow - request error to response error", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		// Test error handling
+		headers := map[string]string{
+			":status":      "400",
+			"content-type": "application/json",
+		}
+
+		errorBody := `{
+			"error": {
+				"code": 400,
+				"message": "Invalid model specified",
+				"status": "INVALID_ARGUMENT"
+			}
+		}`
+
+		_, respBody, err := translator.ResponseError(headers, strings.NewReader(errorBody))
+		require.NoError(t, err)
+		require.NotNil(t, respBody)
+
+		var errorResp openai.Error
+		require.NoError(t, json.Unmarshal(respBody, &errorResp))
+		require.Equal(t, "error", errorResp.Type)
+		require.Equal(t, "INVALID_ARGUMENT", errorResp.Error.Type)
+		require.Contains(t, errorResp.Error.Message, "Invalid model specified")
+	})
+}
+
+// Test edge cases and identified improvements
+func TestToGCPVertexAIV1Tokenize_IdentifiedIssues(t *testing.T) {
+	t.Run("IMPROVEMENT: missing token usage extraction", func(t *testing.T) {
+		translator := &ToGCPVertexAIV1Tokenize{}
+
+		gcpResp := &genai.CountTokensResponse{
+			TotalTokens: 42, // This should be used for token metrics
+		}
+
+		responseJSON, err := json.Marshal(gcpResp)
+		require.NoError(t, err)
+
+		_, _, tokenUsage, _, err := translator.ResponseBody(nil, bytes.NewReader(responseJSON), false, nil)
+		require.NoError(t, err)
+
+		// Currently, token usage is not extracted from the GCP response
+		// This is an improvement opportunity - should extract TotalTokens as input tokens
+		inputTokens, hasInput := tokenUsage.InputTokens()
+		totalTokens, hasTotal := tokenUsage.TotalTokens()
+
+		require.False(t, hasInput) // Should ideally be true with gcpResp.TotalTokens
+		require.False(t, hasTotal) // Should ideally be true with gcpResp.TotalTokens
+		require.Equal(t, uint32(0), inputTokens)
+		require.Equal(t, uint32(0), totalTokens)
+
+		// TODO: Implement token usage extraction:
+		// tokenUsage.SetInputTokens(uint32(gcpResp.TotalTokens))
+		// tokenUsage.SetTotalTokens(uint32(gcpResp.TotalTokens))
+	})
+
+	t.Run("ISSUE RESOLVED: model field is now required", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		req := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "gemini-1.5-pro", // Model is now required field
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Test"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		// Model field is now required so this should work without panic
+		headers, body, err := translator.RequestBody(nil, req, false)
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.Equal(t, "gemini-1.5-pro", translator.requestModel)
+		require.Len(t, headers, 2)
+	})
+
+	t.Run("IMPROVEMENT: input validation missing", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		// Test with nil ChatRequest
+		req := &tokenize.RequestUnion{
+			ChatRequest: nil,
+		}
+
+		// Union validation now runs first and catches this invalid state
+		_, _, err := translator.RequestBody(nil, req, false)
+		require.Error(t, err) // Should error on invalid union
+		require.Contains(t, err.Error(), "one request type must be set")
+	})
+
+	t.Run("union validation now implemented", func(t *testing.T) {
+		translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+		// Test 1: Invalid union state - both types set
+		req := &tokenize.RequestUnion{
+			CompletionRequest: &tokenize.CompletionRequest{
+				Model:  "gpt-4",
+				Prompt: "Hello",
+			},
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "gemini-2.0-flash-001",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Test"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+
+		// Should now return an error for invalid union
+		_, _, err := translator.RequestBody(nil, req, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "only one request type can be set")
+
+		// Test 2: Invalid union state - no types set
+		emptyReq := &tokenize.RequestUnion{}
+		_, _, err = translator.RequestBody(nil, emptyReq, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "one request type must be set")
+
+		// Test 3: Valid union state - only chat set (completion not supported for Gemini)
+		validChatReq := &tokenize.RequestUnion{
+			ChatRequest: &tokenize.ChatRequest{
+				Model: "gemini-2.0-flash-001",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					{
+						OfUser: &openai.ChatCompletionUserMessageParam{
+							Content: openai.StringOrUserRoleContentUnion{Value: "Test"},
+							Role:    openai.ChatMessageRoleUser,
+						},
+					},
+				},
+			},
+		}
+		_, _, err = translator.RequestBody(nil, validChatReq, false)
+		require.NoError(t, err)
+	})
+}
+
+func TestToGCPVertexAIV1Tokenize_MediaResolution(t *testing.T) {
+	translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+	req := &tokenize.RequestUnion{
+		ChatRequest: &tokenize.ChatRequest{
+			Model: "gemini-2.0-flash-001",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{
+					OfUser: &openai.ChatCompletionUserMessageParam{
+						Role:    openai.ChatMessageRoleUser,
+						Content: openai.StringOrUserRoleContentUnion{Value: "Hello"},
+					},
+				},
+			},
+			MediaResolution: "HIGH",
+		},
+	}
+
+	_, body, err := translator.RequestBody(nil, req, false)
+	require.NoError(t, err)
+
+	var gcpReq gcp.CountTokenRequest
+	require.NoError(t, json.Unmarshal(body, &gcpReq))
+	require.NotNil(t, gcpReq.GenerationConfig)
+	require.Equal(t, genai.MediaResolution("HIGH"), gcpReq.GenerationConfig.MediaResolution)
+}
+
+func TestToGCPVertexAIV1Tokenize_ToolsConversion(t *testing.T) {
+	translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+
+	req := &tokenize.RequestUnion{
+		ChatRequest: &tokenize.ChatRequest{
+			Model: "gemini-2.0-flash-001",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{
+					OfUser: &openai.ChatCompletionUserMessageParam{
+						Role:    openai.ChatMessageRoleUser,
+						Content: openai.StringOrUserRoleContentUnion{Value: "What's the weather?"},
+					},
+				},
+			},
+			Tools: []openai.Tool{
+				{
+					Type: "function",
+					Function: &openai.FunctionDefinition{
+						Name:        "get_weather",
+						Description: "Get weather",
+						Parameters: map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"location": map[string]any{"type": "string"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, body, err := translator.RequestBody(nil, req, false)
+	require.NoError(t, err)
+
+	var gcpReq gcp.CountTokenRequest
+	require.NoError(t, json.Unmarshal(body, &gcpReq))
+	require.NotEmpty(t, gcpReq.Tools)
+}
+
+func TestToGCPVertexAIV1Tokenize_EmptyMessages(t *testing.T) {
+	translator := &ToGCPVertexAIV1Tokenize{}
+
+	chatReq := &tokenize.ChatRequest{
+		Model:    "gemini-2.0-flash-001",
+		Messages: []openai.ChatCompletionMessageParamUnion{},
+	}
+
+	_, err := translator.tokenizeToGeminiCountToken(chatReq, "gemini-2.0-flash-001")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "messages must produce at least one content entry")
+}
+
+// Benchmark tests for performance
+func BenchmarkToGCPVertexAIV1Tokenize_RequestBody(b *testing.B) {
+	translator := NewTokenizeToGCPVertexAITranslator("").(*ToGCPVertexAIV1Tokenize)
+	req := &tokenize.RequestUnion{
+		ChatRequest: &tokenize.ChatRequest{
+			Model: "gemini-2.0-flash-001",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{
+					OfUser: &openai.ChatCompletionUserMessageParam{
+						Content: openai.StringOrUserRoleContentUnion{Value: "Benchmark test message"},
+						Role:    openai.ChatMessageRoleUser,
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := translator.RequestBody(nil, req, false)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkToGCPVertexAIV1Tokenize_ResponseBody(b *testing.B) {
+	translator := &ToGCPVertexAIV1Tokenize{requestModel: "gemini-2.0-flash-001"}
+	gcpResp := &genai.CountTokensResponse{TotalTokens: 100}
+	responseJSON, _ := json.Marshal(gcpResp)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, err := translator.ResponseBody(nil, bytes.NewReader(responseJSON), false, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/translator/tokenize_gcpvertexai_test.go
+++ b/internal/translator/tokenize_gcpvertexai_test.go
@@ -227,10 +227,10 @@ func TestToGCPVertexAIV1Tokenize_ResponseBody(t *testing.T) {
 		require.NoError(t, json.Unmarshal(body, &openAIResp))
 		require.Equal(t, 42, openAIResp.Count)
 
-		// TODO: Token usage should be extracted from GCP response
-		// This is currently missing but should be implemented
+		// The /tokenize endpoint does not populate token usage metrics,
+		// matching the OpenAI tokenize translator.
 		_, hasTokens := tokenUsage.InputTokens()
-		require.False(t, hasTokens) // Current behavior - should be fixed
+		require.False(t, hasTokens)
 	})
 
 	t.Run("empty response model fallback", func(t *testing.T) {
@@ -629,19 +629,15 @@ func TestToGCPVertexAIV1Tokenize_IdentifiedIssues(t *testing.T) {
 		_, _, tokenUsage, _, err := translator.ResponseBody(nil, bytes.NewReader(responseJSON), false, nil)
 		require.NoError(t, err)
 
-		// Currently, token usage is not extracted from the GCP response
-		// This is an improvement opportunity - should extract TotalTokens as input tokens
+		// The /tokenize endpoint intentionally does not populate token usage
+		// metrics, matching the OpenAI tokenize translator.
 		inputTokens, hasInput := tokenUsage.InputTokens()
 		totalTokens, hasTotal := tokenUsage.TotalTokens()
 
-		require.False(t, hasInput) // Should ideally be true with gcpResp.TotalTokens
-		require.False(t, hasTotal) // Should ideally be true with gcpResp.TotalTokens
+		require.False(t, hasInput)
+		require.False(t, hasTotal)
 		require.Equal(t, uint32(0), inputTokens)
 		require.Equal(t, uint32(0), totalTokens)
-
-		// TODO: Implement token usage extraction:
-		// tokenUsage.SetInputTokens(uint32(gcpResp.TotalTokens))
-		// tokenUsage.SetTotalTokens(uint32(gcpResp.TotalTokens))
 	})
 
 	t.Run("ISSUE RESOLVED: model field is now required", func(t *testing.T) {

--- a/site/docs/capabilities/llm-integrations/supported-endpoints.md
+++ b/site/docs/capabilities/llm-integrations/supported-endpoints.md
@@ -363,6 +363,7 @@ curl -H "Content-Type: application/json" \
 | Provider                            | API Schema     | Translation Target                                                                                                           | Notes                                                                                 |
 | ----------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | OpenAI-compatible (e.g., vLLM)      | `OpenAI`       | Passthrough                                                                                                                  | vLLM natively supports `/tokenize`. OpenAI itself does not offer a tokenize REST API. |
+| GCP Vertex AI (Gemini)              | `GCPVertexAI`  | [Gemini CountTokens API](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/count-tokens)                 | Supports `media_resolution` parameter.                                                |
 | GCP Anthropic (Claude on Vertex AI) | `GCPAnthropic` | [Anthropic MessageCountTokens API](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens) | Uses `rawPredict` method with `count-tokens` virtual model.                           |
 | AWS Bedrock (Anthropic)             | `AWSAnthropic` | [AWS Bedrock CountTokens API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CountTokens.html)          | Uses the InvokeModel-style CountTokens API with the Anthropic Messages body.          |
 
@@ -399,7 +400,7 @@ curl -H "Content-Type: application/json" \
 
 **Response Format:**
 
-For translated backends (GCP Anthropic, AWS Bedrock Anthropic), the response contains only the token count:
+For translated backends (GCP Vertex AI, GCP Anthropic, AWS Bedrock Anthropic), the response contains only the token count:
 
 ```json
 {
@@ -421,6 +422,7 @@ For OpenAI-compatible backends that natively support tokenization (e.g., vLLM), 
 **Configuration Notes:**
 
 - For **vLLM backends**: Configure with `OpenAI` schema. vLLM natively provides `/tokenize` and the gateway passes the request through.
+- For **GCP Vertex AI**: Configure with `GCPVertexAI` schema. Requests are automatically translated to the Gemini CountTokens API. Completion prompts are automatically converted to chat messages.
 - For **GCP Anthropic**: Configure with `GCPAnthropic` schema. Requests are translated to the Anthropic MessageCountTokens API via `rawPredict`. Completion prompts are automatically converted to chat messages. Model version suffixes (`@default`, `@latest`) are automatically stripped.
 - For **AWS Bedrock (Anthropic)**: Configure with `AWSAnthropic` schema. Requests are translated to the AWS Bedrock CountTokens API using the InvokeModel-style Anthropic Messages body. Completion prompts are automatically converted to chat messages. Cross-region inference (CRIS) model ID prefixes are automatically stripped.
 
@@ -478,7 +480,7 @@ The following table summarizes which providers support which endpoints:
 | [Hunyuan](https://cloud.tencent.com/document/product/1729/111007)                                     |        ⚠️        |     ⚠️      |     ⚠️     |        ❌        |         ❌         |   ❌   |    ❌    | Via OpenAI-compatible API                                                                                            |
 | [Tencent LLM Knowledge Engine](https://www.tencentcloud.com/document/product/1255/70381)              |        ⚠️        |     ❌      |     ❌     |        ❌        |         ❌         |   ❌   |    ❌    | Via OpenAI-compatible API                                                                                            |
 | [Tetrate Agent Router Service (TARS)](https://router.tetrate.ai/)                                     |        ⚠️        |     ⚠️      |     ⚠️     |        ❌        |         ❌         |   ❌   |    ❌    | Via OpenAI-compatible API                                                                                            |
-| [Google Vertex AI](https://cloud.google.com/vertex-ai/docs/reference/rest)                            |        ✅        |     🚧      |     ✅     |        ❌        |         ❌         |   ❌   |    ❌    | Via API translation                                                                                                  |
+| [Google Vertex AI](https://cloud.google.com/vertex-ai/docs/reference/rest)                            |        ✅        |     🚧      |     ✅     |        ❌        |         ❌         |   ❌   |    ✅    | Via API translation                                                                                                  |
 | [Anthropic on Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude) |        ✅        |     ❌      |     🚧     |        ❌        |         ✅         |   ❌   |    ✅    | Via API translation                                                                                                  |
 | [Anthropic on AWS Bedrock](https://aws.amazon.com/bedrock/anthropic/)                                 |        🚧        |     ❌      |     ❌     |        ❌        |         ✅         |   ❌   |    ✅    | Native Anthropic API                                                                                                 |
 | [SambaNova](https://docs.sambanova.ai/sambastudio/latest/open-ai-api.html)                            |        ✅        |     ⚠️      |     ✅     |        ❌        |         ❌         |   ❌   |    ❌    | Via OpenAI-compatible API                                                                                            |


### PR DESCRIPTION
**Description**
Add `/tokenize` support for GCP Vertex AI via the Gemini CountTokens API (GCPVertexAI schema), with completion prompts converted to chat messages. This is a split from https://github.com/envoyproxy/ai-gateway/pull/1650 as planned.



