### PR TITLE
fix(backendauth): resolve AWS signing host dynamically from headers

### DIFF
--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -78,6 +79,37 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 	return &awsHandler{credentialsProvider: cfg.Credentials, signer: signer, region: awsAuth.Region}, nil
 }
 
+// resolveHost resolves the host for the signed AWS request in the following order:
+//  1. the special AWSSigningHostHeader header, when present;
+//  2. the :authority pseudo-header, when AWSSigningHostHeader is absent;
+//  3. the host header, when both are absent;
+//  4. the standard AWS Bedrock endpoint for the configured region
+//     (bedrock-runtime.<region>.amazonaws.com), when all headers are absent or
+//     the resolved host does not represent an amazonaws.com domain (this suffix check is
+//     a safeguard to ensure we only sign requests targeting official AWS/VPCE endpoints).
+func (a *awsHandler) resolveHost(requestHeaders map[string]string) string {
+	host := requestHeaders[internalapi.AWSSigningHostHeader]
+	if host == "" {
+		host = requestHeaders[":authority"]
+	}
+	if host == "" {
+		host = requestHeaders["host"]
+	}
+	if host != "" {
+		hostname := host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			hostname = h
+		}
+		if !strings.HasSuffix(hostname, ".amazonaws.com") {
+			host = ""
+		}
+	}
+	if host == "" {
+		host = fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
+	}
+	return host
+}
+
 // Do implements [Handler.Do].
 //
 // This assumes that during the transformation, the path is set in the header mutation as well as
@@ -85,6 +117,7 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, mutatedBody []byte) ([]internalapi.Header, error) {
 	method := requestHeaders[":method"]
 	path := requestHeaders[":path"]
+	host := a.resolveHost(requestHeaders)
 
 	var body []byte
 	if len(mutatedBody) > 0 {
@@ -93,11 +126,12 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, m
 
 	payloadHash := sha256.Sum256(body)
 	req, err := http.NewRequest(method,
-		fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com%s", a.region, path),
+		fmt.Sprintf("https://%s%s", host, path),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)
 	}
+	req.Host = host
 	// By setting the content length to -1, we can avoid the inclusion of the `Content-Length` header in the signature.
 	// https://github.com/aws/aws-sdk-go-v2/blob/755839b2eebb246c7eec79b65404aee105196d5b/aws/signer/v4/v4.go#L427-L431
 	//

--- a/internal/backendauth/aws_test.go
+++ b/internal/backendauth/aws_test.go
@@ -230,4 +230,121 @@ func TestAWSHandler_Do(t *testing.T) {
 			require.NoError(t, err, "Failed for region: %s", region)
 		}
 	})
+
+	t.Run("custom authority from :authority header", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// When :authority is present, Do must use it as the host rather than the
+		// default bedrock-runtime endpoint.
+		hdrs, err := handler.Do(t.Context(), map[string]string{
+			":method":    "POST",
+			":path":      "/model/test-model/invoke",
+			":authority": "vpce-0123456789abcdef0-xyz.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		}, []byte(`{"test": "data"}`))
+		require.NoError(t, err)
+
+		headers := stringPairsToMap(hdrs)
+		require.Contains(t, headers, "Authorization")
+		require.Contains(t, headers, "X-Amz-Date")
+	})
+
+	t.Run("custom authority from host header", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// When :authority is absent, Do must fall back to the host header.
+		hdrs, err := handler.Do(t.Context(), map[string]string{
+			":method": "POST",
+			":path":   "/model/test-model/invoke",
+			"host":    "vpce-0123456789abcdef0-xyz.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		}, []byte(`{"test": "data"}`))
+		require.NoError(t, err)
+
+		headers := stringPairsToMap(hdrs)
+		require.Contains(t, headers, "Authorization")
+		require.Contains(t, headers, "X-Amz-Date")
+	})
+
+	t.Run("invalid method fails request creation", func(t *testing.T) {
+		awsFileBody := "[default]\naws_access_key_id=test\naws_secret_access_key=secret\n"
+		handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+			CredentialFileLiteral: awsFileBody,
+			Region:                "us-east-1",
+		})
+		require.NoError(t, err)
+
+		// An invalid HTTP method token causes http.NewRequest to fail.
+		_, err = handler.Do(t.Context(), map[string]string{
+			":method": "INVALID METHOD",
+			":path":   "/model/test-model/invoke",
+		}, []byte(`{"test": "data"}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot create request")
+	})
+}
+
+func TestAWSHandler_ResolveHost(t *testing.T) {
+	handler := &awsHandler{region: "us-east-1"}
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name: "upstream metadata wins over authority",
+			headers: map[string]string{
+				internalapi.AWSSigningHostHeader: "vpce-123.bedrock-runtime.us-east-1.vpce.amazonaws.com:443",
+				":authority":                     "gateway.example.com",
+			},
+			want: "vpce-123.bedrock-runtime.us-east-1.vpce.amazonaws.com:443",
+		},
+		{
+			name:    "authority fallback when it is an amazonaws domain",
+			headers: map[string]string{":authority": "custom-bedrock.amazonaws.com"},
+			want:    "custom-bedrock.amazonaws.com",
+		},
+		{
+			name:    "fallback to regional default when authority is not an amazonaws domain",
+			headers: map[string]string{":authority": "custom-bedrock.example.com"},
+			want:    "bedrock-runtime.us-east-1.amazonaws.com",
+		},
+		{
+			name:    "host fallback when it is an amazonaws domain",
+			headers: map[string]string{"host": "bedrock-runtime.us-west-2.amazonaws.com"},
+			want:    "bedrock-runtime.us-west-2.amazonaws.com",
+		},
+		{
+			name:    "fallback to regional default when host is not an amazonaws domain",
+			headers: map[string]string{"host": "bedrock-runtime.example.com"},
+			want:    "bedrock-runtime.us-east-1.amazonaws.com",
+		},
+		{
+			name:    "default host fallback",
+			headers: map[string]string{},
+			want:    "bedrock-runtime.us-east-1.amazonaws.com",
+		},
+		{
+			name:    "non default port preserved when it is an amazonaws domain",
+			headers: map[string]string{internalapi.AWSSigningHostHeader: "custom-bedrock.amazonaws.com:8443"},
+			want:    "custom-bedrock.amazonaws.com:8443",
+		},
+		{
+			name:    "fallback to regional default when non default port host is not an amazonaws domain",
+			headers: map[string]string{internalapi.AWSSigningHostHeader: "custom-bedrock.example.com:8443"},
+			want:    "bedrock-runtime.us-east-1.amazonaws.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, handler.resolveHost(tc.headers))
+		})
+	}
 }

--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -404,6 +404,14 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) ProcessReque
 				Header:       &corev3.HeaderValue{Key: h.Key(), RawValue: []byte(h.Value())},
 			})
 		}
+
+		// AWSSigningHostHeader, if present, only exists so the AWS backend auth handler above could
+		// resolve the real signing host; it's never part of the signed request built in Do() and must
+		// never reach the actual upstream. Strip it from what Envoy forwards while leaving it in the
+		// local map, same as the CredentialOverride.InputHeaderToRemove handling below.
+		if _, ok := u.requestHeaders[internalapi.AWSSigningHostHeader]; ok {
+			headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, internalapi.AWSSigningHostHeader)
+		}
 	}
 
 	if !wantBodyReplace {

--- a/internal/headermutator/header_mutator.go
+++ b/internal/headermutator/header_mutator.go
@@ -112,11 +112,19 @@ func (h *HeaderMutator) Mutate(headers map[string]string, onRetry bool) (sets []
 // This should be safe since these headers are managed by Envoy AI Gateway itself, not expected to be
 // modified by users via header mutation API.
 //
+// AWSSigningHostHeader is exempted from that prefix skip: it exists specifically to let a backend
+// (e.g. one behind an AWS VPC endpoint) declare the host the AWS backend auth handler should sign
+// for and route to via HeaderMutation, since ext_proc runs before Envoy's own host-rewrite to the
+// Backend's FQDN and so cannot observe that host any other way.
+//
 // Also, skip Envoy pseudo-headers beginning with ':', such as ":method", ":path", etc.
 // This is important because these headers are not only sensitive to our implementation detail as well as
 // it can cause unexpected behavior if they are modified unexpectedly. User shouldn't need to
 // modify these headers via header mutation API.
 func shouldIgnoreHeader(key string) bool {
+	if strings.EqualFold(key, internalapi.AWSSigningHostHeader) {
+		return false
+	}
 	return strings.HasPrefix(key, ":") ||
 		strings.HasPrefix(key, internalapi.EnvoyAIGatewayHeaderPrefix) ||
 		strings.EqualFold(key, internalapi.EnvoyOriginalPathHeader)

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -29,6 +29,8 @@ const (
 	InternalMetadataBackendNameKey = "per_route_rule_backend_name"
 	// InternalMetadataRouteNameKey is the key used to store the route name.
 	InternalMetadataRouteNameKey = "aigw_route_name"
+	// AWSSigningHostHeader is the special header key used to specify the target AWS signing host.
+	AWSSigningHostHeader = EnvoyAIGatewayHeaderPrefix + "aws-signing-host"
 	// MCPBackendHeader is the special header key used to specify the target backend name.
 	MCPBackendHeader = EnvoyAIGatewayHeaderPrefix + "mcp-backend"
 	// MCPRouteHeader is the special header key used to identify the mcp route.


### PR DESCRIPTION
**Description**

This PR implements dynamic host resolution for AWS SigV4 signing in the AWS Backend Auth handler. 

Previously, `awsHandler.Do` hardcoded the request URL and signed host to `https://bedrock-runtime.<region>.amazonaws.com`, which ignored custom HTTP/2 pseudo-headers (like `:authority`) and `host` headers. This restriction blocked routing targeting custom domains, such as AWS PrivateLink VPC endpoints or non-standard Bedrock proxies.

To resolve this:
- Extracted host resolution into a dedicated, documented `resolveHost` helper method inside `internal/backendauth/aws.go`.
- Supported extracting host from `AWSSigningHostHeader` (`x-ai-eg-aws-signing-host`), `:authority`, or `host` headers.
- Introduced a security safeguard suffix check: if a custom host does not end with `.amazonaws.com` (ignoring ports), we discard it and fallback to the default regional bedrock endpoint. This ensures AWS credentials are never accidentally signed/transmitted to arbitrary external domains.
- Updated `Do` to use the resolved host and properly set `req.Host` before signing.
- Added comprehensive unit tests inside `internal/backendauth/aws_test.go` to cover all fallback tiers, including non-.amazonaws.com fallback, standard and non-standard ports.

**Related Issues/PRs (if applicable)**


**Special notes for reviewers (if applicable)**

- Refactoring the host extraction logic into `resolveHost` allows us to cleanly unit test the fallback tiers in isolation without needing to mock complex request signatures or credentials providers.
- Port-splitting is used solely to extract the hostname for the suffix validation check, and the original custom port remains fully preserved in the final request host header.
