### PR TITLE
controller: trigger extproc pod rollout on injected-config drift

### DIFF
--- a/cmd/aigw/translate.go
+++ b/cmd/aigw/translate.go
@@ -248,8 +248,11 @@ func translateCustomResourceObjects(
 		make(chan event.GenericEvent, eventChanBuffer),
 	)
 	gwC := controller.NewGatewayController(fakeClient, fakeClientSet, logr.FromSlogHandler(logger.Handler()), "envoy-gateway-system",
-		"docker.io/envoyproxy/ai-gateway-extproc:latest", "debug", true, func() string {
+		true, func() string {
 			return "aigw-translate"
+		}, &controller.Options{
+			ExtProcImage:    "docker.io/envoyproxy/ai-gateway-extproc:latest",
+			ExtProcLogLevel: "debug",
 		}, false,
 	)
 	// Pre-create Gateways (without reconciling) before reconciling resources so that

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -135,7 +135,7 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 	// the same options inside NewGatewayController, so both sides compute
 	// identical hashes.
 	extProcBuilder := newExtProcBuilder(options, isKubernetes133OrLater(versionInfo, logger), logger)
-	gatewayC := NewGatewayController(c, kubernetes.NewForConfigOrDie(config),
+	gatewayC := NewGatewayControllerWithAPIReader(c, mgr.GetAPIReader(), kubernetes.NewForConfigOrDie(config),
 		logger.WithName("gateway"), options.EnvoyGatewayNamespace,
 		false, uuid.NewString, options, isKubernetes133OrLater(versionInfo, logger))
 	if err = TypedControllerBuilderForCRD(mgr, &gwapiv1.Gateway{}).

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -128,9 +128,16 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 	}
 
 	gatewayEventChan := make(chan event.GenericEvent, 100)
+	// The extproc builder is shared by the mutating webhook (which injects the
+	// extproc container and stamps the config hash) and the gateway reconciler
+	// (which recomputes that hash to detect drift). The webhook uses this
+	// builder instance directly; the reconciler builds an identical one from
+	// the same options inside NewGatewayController, so both sides compute
+	// identical hashes.
+	extProcBuilder := newExtProcBuilder(options, isKubernetes133OrLater(versionInfo, logger), logger)
 	gatewayC := NewGatewayController(c, kubernetes.NewForConfigOrDie(config),
-		logger.WithName("gateway"), options.EnvoyGatewayNamespace, options.ExtProcImage, options.ExtProcLogLevel,
-		false, uuid.NewString, isKubernetes133OrLater(versionInfo, logger))
+		logger.WithName("gateway"), options.EnvoyGatewayNamespace,
+		false, uuid.NewString, options, isKubernetes133OrLater(versionInfo, logger))
 	if err = TypedControllerBuilderForCRD(mgr, &gwapiv1.Gateway{}).
 		WatchesRawSource(source.Channel(
 			gatewayEventChan,
@@ -260,25 +267,7 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 	if !options.DisableMutatingWebhook {
 		h := admission.WithCustomDefaulter(Scheme, &corev1.Pod{}, newGatewayMutator(c, mgr.GetAPIReader(), kube,
 			logger.WithName("gateway-mutator"),
-			options.ExtProcImage,
-			options.ExtProcImagePullPolicy,
-			options.ExtProcLogLevel,
-			options.ExtProcEnableRedaction,
-			options.UDSPath,
-			options.RequestHeaderAttributes,
-			options.TracingRequestHeaderAttributes,
-			options.MetricsRequestHeaderAttributes,
-			options.LogRequestHeaderAttributes,
-			options.RootPrefix,
-			options.EndpointPrefixes,
-			options.ExtProcExtraEnvVars,
-			options.ExtProcImagePullSecrets,
-			options.ExtProcMaxRecvMsgSize,
-			isKubernetes133OrLater(versionInfo, logger),
-			options.MCPSessionEncryptionSeed,
-			options.MCPSessionEncryptionIterations,
-			options.MCPFallbackSessionEncryptionSeed,
-			options.MCPFallbackSessionEncryptionIterations,
+			extProcBuilder,
 		))
 		mgr.GetWebhookServer().Register("/mutate", &webhook.Admission{Handler: h})
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -128,12 +128,10 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 	}
 
 	gatewayEventChan := make(chan event.GenericEvent, 100)
-	// The extproc builder is shared by the mutating webhook (which injects the
-	// extproc container and stamps the config hash) and the gateway reconciler
-	// (which recomputes that hash to detect drift). The webhook uses this
-	// builder instance directly; the reconciler builds an identical one from
-	// the same options inside NewGatewayController, so both sides compute
-	// identical hashes.
+	// The extproc builder is shared by the mutating webhook and the gateway
+	// reconciler. The webhook uses this builder instance to inject the container;
+	// the reconciler builds an identical one from the same options to write the
+	// desired config hash to workload pod templates.
 	extProcBuilder := newExtProcBuilder(options, isKubernetes133OrLater(versionInfo, logger), logger)
 	gatewayC := NewGatewayController(c, kubernetes.NewForConfigOrDie(config),
 		logger.WithName("gateway"), options.EnvoyGatewayNamespace,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -135,7 +135,7 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 	// the same options inside NewGatewayController, so both sides compute
 	// identical hashes.
 	extProcBuilder := newExtProcBuilder(options, isKubernetes133OrLater(versionInfo, logger), logger)
-	gatewayC := NewGatewayControllerWithAPIReader(c, mgr.GetAPIReader(), kubernetes.NewForConfigOrDie(config),
+	gatewayC := NewGatewayController(c, kubernetes.NewForConfigOrDie(config),
 		logger.WithName("gateway"), options.EnvoyGatewayNamespace,
 		false, uuid.NewString, options, isKubernetes133OrLater(versionInfo, logger))
 	if err = TypedControllerBuilderForCRD(mgr, &gwapiv1.Gateway{}).

--- a/internal/controller/extproc_builder.go
+++ b/internal/controller/extproc_builder.go
@@ -24,8 +24,8 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
-// extProcConfigHashAnnotationKey stores the webhook's extproc config hash. The
-// gateway reconciler compares it with the desired hash to detect config drift.
+// extProcConfigHashAnnotationKey stores the desired extproc config hash on
+// workload pod templates so Kubernetes rolls pods when injected config changes.
 const extProcConfigHashAnnotationKey = "aigateway.envoyproxy.io/extproc-config-hash"
 
 // extProcAdminPort is the admin port of the extproc container.
@@ -34,8 +34,8 @@ const extProcAdminPort = 1064
 // newExtProcBuilder constructs the shared extproc builder from the controller
 // options plus the runtime-resolved extProcAsSideCar flag. It is called once in
 // StartControllers; the resulting builder is shared by the mutating webhook (to
-// inject the container and stamp the config hash) and the gateway reconciler (to
-// detect drift), guaranteeing the two sides compute identical hashes.
+// inject the container) and the gateway reconciler (to compute the workload
+// template hash), guaranteeing the two sides use identical extproc config.
 func newExtProcBuilder(options *Options, extProcAsSideCar bool, logger logr.Logger) *extProcBuilder {
 	var parsedEnvVars []corev1.EnvVar
 	if options.ExtProcExtraEnvVars != "" {

--- a/internal/controller/extproc_builder.go
+++ b/internal/controller/extproc_builder.go
@@ -8,7 +8,7 @@ package controller
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	stdjson "encoding/json" //nolint: depguard // determinism is required: the hash must be byte-identical across the webhook and reconciler, and sonic's Marshal does not guarantee stable field order, which would risk an infinite rollout loop.
+	stdjson "encoding/json" //nolint: depguard // the webhook and reconciler need byte-stable hashing; sonic does not guarantee stable field order.
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -24,12 +24,8 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
-// extProcConfigHashAnnotationKey is stamped on each gateway pod by the mutating
-// webhook with a hash of the injected extproc container config. The gateway
-// reconciler recomputes the desired hash with the same builder and compares it
-// against this annotation to detect config drift (e.g. a changed
-// --extProcExtraEnvVars flag) and trigger a rollout. The controller only reads
-// this annotation; it never writes it, so a stale hash can never be persisted.
+// extProcConfigHashAnnotationKey stores the webhook's extproc config hash. The
+// gateway reconciler compares it with the desired hash to detect config drift.
 const extProcConfigHashAnnotationKey = "aigateway.envoyproxy.io/extproc-config-hash"
 
 // extProcAdminPort is the admin port of the extproc container.
@@ -81,17 +77,8 @@ func newExtProcBuilder(options *Options, extProcAsSideCar bool, logger logr.Logg
 	}
 }
 
-// extProcBuilder holds the controller-global extproc configuration and is the
-// single source of truth for the injected extproc container. It is constructed
-// once in StartControllers from Options and shared by the mutating webhook
-// (to inject the container and stamp the config hash) and the gateway reconciler
-// (to detect drift and trigger a rollout).
-//
-// Sharing one builder plus one build function is what prevents rollout loops:
-// both sides hash the output of the *same* function rather than maintaining two
-// parallel representations of the drift signal. If the webhook and reconciler
-// ever computed different hashes for identical state, the deployment would roll
-// forever — this structure makes that impossible by construction.
+// extProcBuilder holds the controller-global extproc configuration used by both
+// the mutating webhook and the gateway reconciler.
 type extProcBuilder struct {
 	image           string
 	imagePullPolicy corev1.PullPolicy
@@ -118,9 +105,7 @@ type extProcBuilder struct {
 	mcpFallbackSessionEncryptionIterations int
 }
 
-// extProcContainerInput is the per-gateway input the shared builder needs to
-// produce the extproc container. Everything not in this struct is global and
-// lives on the builder itself.
+// extProcContainerInput is the per-gateway input for extproc injection.
 type extProcContainerInput struct {
 	// gatewayConfig is the GatewayConfig referenced by the Gateway (nil if none).
 	gatewayConfig *aigv1b1.GatewayConfig
@@ -129,20 +114,14 @@ type extProcContainerInput struct {
 	needMCP bool
 }
 
-// buildExtProcContainer builds the extproc container *minus* the secret-presence-
-// driven parts: the -configPath / -configBundlePath args and the legacy/bundle
-// volumeMounts. Those depend on which filter-config secrets happen to exist at
-// pod-creation time, not on controller config, so they are excluded from the
-// drift signal (the UUID-annotation fast path handles filter-config content
-// updates). The mutating webhook adds them after this function returns; the
-// reconciler never adds them — it only hashes this base container.
+// buildExtProcContainer builds the extproc container without secret-presence
+// config args or mounts; those are handled by the webhook at pod creation time.
 func (b *extProcBuilder) buildExtProcContainer(input extProcContainerInput) corev1.Container {
 	var (
 		extProcSpec       *aigv1b1.GatewayConfigExtProc
 		kubernetesExtProc *egv1a1.KubernetesContainerSpec
 	)
-	if input.gatewayConfig != nil && input.gatewayConfig.Spec.ExtProc != nil {
-		extProcSpec = input.gatewayConfig.Spec.ExtProc
+	if extProcSpec = extProcSpecFromInput(input); extProcSpec != nil {
 		if extProcSpec.Kubernetes != nil {
 			kubernetesExtProc = extProcSpec.Kubernetes
 		}
@@ -155,7 +134,7 @@ func (b *extProcBuilder) buildExtProcContainer(input extProcContainerInput) core
 	}
 
 	envVars := b.mergeEnvVars(input.gatewayConfig)
-	image := b.resolveExtProcImage(extProcSpec)
+	image := b.extProcImage(input)
 
 	udsMountPath := filepath.Dir(b.udsPath)
 	securityContext := &corev1.SecurityContext{
@@ -221,39 +200,71 @@ func (b *extProcBuilder) buildExtProcContainer(input extProcContainerInput) core
 	return container
 }
 
-// extProcConfigDigest is the canonical representation of everything the webhook
-// injects that is drift-relevant: the extproc container (minus the secret-
-// presence-driven config-routing args/mounts, which buildExtProcContainer already
-// omits) plus the pod-spec-level imagePullSecrets, which are not part of the
-// container but are injected by the webhook and must also drift-trigger a rollout.
-// Hashing this struct — built by one shared function — is the drift signal both
-// the webhook and reconciler use.
+// extProcConfigDigest contains the config inputs that affect extproc injection.
+// It intentionally avoids hashing the full Kubernetes Container API object.
 type extProcConfigDigest struct {
-	Container        corev1.Container
-	ImagePullSecrets []corev1.LocalObjectReference
+	Image                                  string
+	ImagePullPolicy                        corev1.PullPolicy
+	LogLevel                               string
+	EnableRedaction                        bool
+	UDSPath                                string
+	RequestHeaderAttributes                *string
+	SpanRequestHeaderAttributes            *string
+	MetricsRequestHeaderAttributes         *string
+	LogRequestHeaderAttributes             *string
+	RootPrefix                             string
+	EndpointPrefixes                       string
+	ExtraEnvVars                           []corev1.EnvVar
+	ImagePullSecrets                       []corev1.LocalObjectReference
+	MaxRecvMsgSize                         int
+	ExtProcAsSideCar                       bool
+	MCPSessionEncryptionSeed               string
+	MCPSessionEncryptionIterations         int
+	MCPFallbackSessionEncryptionSeed       string
+	MCPFallbackSessionEncryptionIterations int
+	NeedMCP                                bool
+	GatewayConfigExtProc                   *aigv1b1.GatewayConfigExtProc
 }
 
-// extProcContainerHash returns a stable hex hash of the extproc config the
-// webhook injects for the given input. Both the webhook and the reconciler call
-// this with the same builder + input, so identical state yields identical
-// hashes. It is over the SAME object the builder injects (the container from
-// buildExtProcContainer plus pod-spec-level imagePullSecrets), so the drift
-// signal can never diverge from the injected config.
+// extProcContainerHash returns a stable hash of the extproc injection inputs.
 func (b *extProcBuilder) extProcContainerHash(input extProcContainerInput) string {
 	digest := extProcConfigDigest{
-		Container:        b.buildExtProcContainer(input),
-		ImagePullSecrets: b.imagePullSecrets,
+		Image:                                  b.extProcImage(input),
+		ImagePullPolicy:                        b.imagePullPolicy,
+		LogLevel:                               b.logLevel,
+		EnableRedaction:                        b.enableRedaction,
+		UDSPath:                                b.udsPath,
+		RequestHeaderAttributes:                b.requestHeaderAttributes,
+		SpanRequestHeaderAttributes:            b.spanRequestHeaderAttributes,
+		MetricsRequestHeaderAttributes:         b.metricsRequestHeaderAttributes,
+		LogRequestHeaderAttributes:             b.logRequestHeaderAttributes,
+		RootPrefix:                             b.rootPrefix,
+		EndpointPrefixes:                       b.endpointPrefixes,
+		ExtraEnvVars:                           b.extraEnvVars,
+		ImagePullSecrets:                       b.imagePullSecrets,
+		MaxRecvMsgSize:                         b.maxRecvMsgSize,
+		ExtProcAsSideCar:                       b.extProcAsSideCar,
+		MCPSessionEncryptionSeed:               b.mcpSessionEncryptionSeed,
+		MCPSessionEncryptionIterations:         b.mcpSessionEncryptionIterations,
+		MCPFallbackSessionEncryptionSeed:       b.mcpFallbackSessionEncryptionSeed,
+		MCPFallbackSessionEncryptionIterations: b.mcpFallbackSessionEncryptionIterations,
+		NeedMCP:                                input.needMCP,
+		GatewayConfigExtProc:                   extProcSpecFromInput(input),
 	}
-	// stdjson.Marshal of a struct is deterministic (fields in declaration
-	// order; map keys sorted). Since the builder always produces the same
-	// object for the same input, the bytes — and therefore the hash — are
-	// stable. stdlib json is used (not internal/json/sonic) because sonic
-	// does not guarantee stable field order, which would risk rollout loops.
-	// corev1.Container is a plain serializable struct, so Marshal cannot
-	// fail here; the error is ignored accordingly.
-	marshaled, _ := stdjson.Marshal(digest) // corev1.Container is serializable; see comment above
+	marshaled, _ := stdjson.Marshal(digest)
 	sum := sha256.Sum256(marshaled)
 	return hex.EncodeToString(sum[:])
+}
+
+func extProcSpecFromInput(input extProcContainerInput) *aigv1b1.GatewayConfigExtProc {
+	if input.gatewayConfig == nil {
+		return nil
+	}
+	return input.gatewayConfig.Spec.ExtProc
+}
+
+func (b *extProcBuilder) extProcImage(input extProcContainerInput) string {
+	return b.resolveExtProcImage(extProcSpecFromInput(input))
 }
 
 // buildExtProcBaseArgs builds the command line arguments for the extproc

--- a/internal/controller/extproc_builder.go
+++ b/internal/controller/extproc_builder.go
@@ -1,0 +1,381 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	stdjson "encoding/json" //nolint: depguard // determinism is required: the hash must be byte-identical across the webhook and reconciler, and sonic's Marshal does not guarantee stable field order, which would risk an infinite rollout loop.
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+)
+
+// extProcConfigHashAnnotationKey is stamped on each gateway pod by the mutating
+// webhook with a hash of the injected extproc container config. The gateway
+// reconciler recomputes the desired hash with the same builder and compares it
+// against this annotation to detect config drift (e.g. a changed
+// --extProcExtraEnvVars flag) and trigger a rollout. The controller only reads
+// this annotation; it never writes it, so a stale hash can never be persisted.
+const extProcConfigHashAnnotationKey = "aigateway.envoyproxy.io/extproc-config-hash"
+
+// extProcAdminPort is the admin port of the extproc container.
+const extProcAdminPort = 1064
+
+// newExtProcBuilder constructs the shared extproc builder from the controller
+// options plus the runtime-resolved extProcAsSideCar flag. It is called once in
+// StartControllers; the resulting builder is shared by the mutating webhook (to
+// inject the container and stamp the config hash) and the gateway reconciler (to
+// detect drift), guaranteeing the two sides compute identical hashes.
+func newExtProcBuilder(options *Options, extProcAsSideCar bool, logger logr.Logger) *extProcBuilder {
+	var parsedEnvVars []corev1.EnvVar
+	if options.ExtProcExtraEnvVars != "" {
+		var err error
+		parsedEnvVars, err = ParseExtraEnvVars(options.ExtProcExtraEnvVars)
+		if err != nil {
+			logger.Error(err, "failed to parse extProc extra env vars, skipping",
+				"envVars", options.ExtProcExtraEnvVars)
+		}
+	}
+
+	var parsedImagePullSecrets []corev1.LocalObjectReference
+	if options.ExtProcImagePullSecrets != "" {
+		// ParseImagePullSecrets only splits on ';' and trims; it never returns
+		// an error, so there is no defensive log branch here (unlike env vars).
+		parsedImagePullSecrets, _ = ParseImagePullSecrets(options.ExtProcImagePullSecrets)
+	}
+
+	return &extProcBuilder{
+		image:                                  options.ExtProcImage,
+		imagePullPolicy:                        options.ExtProcImagePullPolicy,
+		logLevel:                               options.ExtProcLogLevel,
+		enableRedaction:                        options.ExtProcEnableRedaction,
+		udsPath:                                options.UDSPath,
+		requestHeaderAttributes:                options.RequestHeaderAttributes,
+		spanRequestHeaderAttributes:            options.TracingRequestHeaderAttributes,
+		metricsRequestHeaderAttributes:         options.MetricsRequestHeaderAttributes,
+		logRequestHeaderAttributes:             options.LogRequestHeaderAttributes,
+		rootPrefix:                             options.RootPrefix,
+		endpointPrefixes:                       options.EndpointPrefixes,
+		extraEnvVars:                           parsedEnvVars,
+		imagePullSecrets:                       parsedImagePullSecrets,
+		maxRecvMsgSize:                         options.ExtProcMaxRecvMsgSize,
+		extProcAsSideCar:                       extProcAsSideCar,
+		mcpSessionEncryptionSeed:               options.MCPSessionEncryptionSeed,
+		mcpSessionEncryptionIterations:         options.MCPSessionEncryptionIterations,
+		mcpFallbackSessionEncryptionSeed:       options.MCPFallbackSessionEncryptionSeed,
+		mcpFallbackSessionEncryptionIterations: options.MCPFallbackSessionEncryptionIterations,
+	}
+}
+
+// extProcBuilder holds the controller-global extproc configuration and is the
+// single source of truth for the injected extproc container. It is constructed
+// once in StartControllers from Options and shared by the mutating webhook
+// (to inject the container and stamp the config hash) and the gateway reconciler
+// (to detect drift and trigger a rollout).
+//
+// Sharing one builder plus one build function is what prevents rollout loops:
+// both sides hash the output of the *same* function rather than maintaining two
+// parallel representations of the drift signal. If the webhook and reconciler
+// ever computed different hashes for identical state, the deployment would roll
+// forever — this structure makes that impossible by construction.
+type extProcBuilder struct {
+	image           string
+	imagePullPolicy corev1.PullPolicy
+	logLevel        string
+	enableRedaction bool
+	udsPath         string
+
+	requestHeaderAttributes        *string
+	spanRequestHeaderAttributes    *string
+	metricsRequestHeaderAttributes *string
+	logRequestHeaderAttributes     *string
+
+	rootPrefix       string
+	endpointPrefixes string
+
+	extraEnvVars     []corev1.EnvVar
+	imagePullSecrets []corev1.LocalObjectReference
+	maxRecvMsgSize   int
+	extProcAsSideCar bool
+
+	mcpSessionEncryptionSeed               string
+	mcpSessionEncryptionIterations         int
+	mcpFallbackSessionEncryptionSeed       string
+	mcpFallbackSessionEncryptionIterations int
+}
+
+// extProcContainerInput is the per-gateway input the shared builder needs to
+// produce the extproc container. Everything not in this struct is global and
+// lives on the builder itself.
+type extProcContainerInput struct {
+	// gatewayConfig is the GatewayConfig referenced by the Gateway (nil if none).
+	gatewayConfig *aigv1b1.GatewayConfig
+	// needMCP is true when at least one MCPRoute is attached to the Gateway,
+	// i.e. the extproc must run the MCP proxy.
+	needMCP bool
+}
+
+// buildExtProcContainer builds the extproc container *minus* the secret-presence-
+// driven parts: the -configPath / -configBundlePath args and the legacy/bundle
+// volumeMounts. Those depend on which filter-config secrets happen to exist at
+// pod-creation time, not on controller config, so they are excluded from the
+// drift signal (the UUID-annotation fast path handles filter-config content
+// updates). The mutating webhook adds them after this function returns; the
+// reconciler never adds them — it only hashes this base container.
+func (b *extProcBuilder) buildExtProcContainer(input extProcContainerInput) corev1.Container {
+	var (
+		extProcSpec       *aigv1b1.GatewayConfigExtProc
+		kubernetesExtProc *egv1a1.KubernetesContainerSpec
+	)
+	if input.gatewayConfig != nil && input.gatewayConfig.Spec.ExtProc != nil {
+		extProcSpec = input.gatewayConfig.Spec.ExtProc
+		if extProcSpec.Kubernetes != nil {
+			kubernetesExtProc = extProcSpec.Kubernetes
+		}
+	}
+
+	// Use resources from GatewayConfig if present.
+	var resources corev1.ResourceRequirements
+	if kubernetesExtProc != nil && kubernetesExtProc.Resources != nil {
+		resources = *kubernetesExtProc.Resources
+	}
+
+	envVars := b.mergeEnvVars(input.gatewayConfig)
+	image := b.resolveExtProcImage(extProcSpec)
+
+	udsMountPath := filepath.Dir(b.udsPath)
+	securityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		Privileged:   ptr.To(false),
+		RunAsGroup:   ptr.To(int64(65532)),
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To(int64(65532)),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	if kubernetesExtProc != nil && kubernetesExtProc.SecurityContext != nil {
+		securityContext = kubernetesExtProc.SecurityContext
+	}
+
+	container := corev1.Container{
+		Name:            extProcContainerName,
+		Image:           image,
+		ImagePullPolicy: b.imagePullPolicy,
+		Ports: []corev1.ContainerPort{
+			{Name: "aigw-admin", ContainerPort: extProcAdminPort},
+		},
+		Args: b.buildExtProcBaseArgs(input.needMCP),
+		Env:  envVars,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      extProcUDSVolumeName,
+				MountPath: udsMountPath,
+				ReadOnly:  false,
+			},
+		},
+		SecurityContext: securityContext,
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port:   intstr.FromInt32(extProcAdminPort),
+					Path:   "/health",
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 2,
+			TimeoutSeconds:      5,
+			PeriodSeconds:       10,
+			SuccessThreshold:    1,
+			FailureThreshold:    1,
+		},
+		Resources: resources,
+	}
+
+	// Mounts contributed by GatewayConfig are part of the drift signal.
+	if kubernetesExtProc != nil && len(kubernetesExtProc.VolumeMounts) > 0 {
+		container.VolumeMounts = append(container.VolumeMounts, kubernetesExtProc.VolumeMounts...)
+	}
+
+	if b.extProcAsSideCar {
+		// When running as a sidecar, we want to ensure the extProc container is shutdown last after Envoy is shutdown.
+		container.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+	}
+	return container
+}
+
+// extProcConfigDigest is the canonical representation of everything the webhook
+// injects that is drift-relevant: the extproc container (minus the secret-
+// presence-driven config-routing args/mounts, which buildExtProcContainer already
+// omits) plus the pod-spec-level imagePullSecrets, which are not part of the
+// container but are injected by the webhook and must also drift-trigger a rollout.
+// Hashing this struct — built by one shared function — is the drift signal both
+// the webhook and reconciler use.
+type extProcConfigDigest struct {
+	Container        corev1.Container
+	ImagePullSecrets []corev1.LocalObjectReference
+}
+
+// extProcContainerHash returns a stable hex hash of the extproc config the
+// webhook injects for the given input. Both the webhook and the reconciler call
+// this with the same builder + input, so identical state yields identical
+// hashes. It is over the SAME object the builder injects (the container from
+// buildExtProcContainer plus pod-spec-level imagePullSecrets), so the drift
+// signal can never diverge from the injected config.
+func (b *extProcBuilder) extProcContainerHash(input extProcContainerInput) string {
+	digest := extProcConfigDigest{
+		Container:        b.buildExtProcContainer(input),
+		ImagePullSecrets: b.imagePullSecrets,
+	}
+	// stdjson.Marshal of a struct is deterministic (fields in declaration
+	// order; map keys sorted). Since the builder always produces the same
+	// object for the same input, the bytes — and therefore the hash — are
+	// stable. stdlib json is used (not internal/json/sonic) because sonic
+	// does not guarantee stable field order, which would risk rollout loops.
+	// corev1.Container is a plain serializable struct, so Marshal cannot
+	// fail here; the error is ignored accordingly.
+	marshaled, _ := stdjson.Marshal(digest) // corev1.Container is serializable; see comment above
+	sum := sha256.Sum256(marshaled)
+	return hex.EncodeToString(sum[:])
+}
+
+// buildExtProcBaseArgs builds the command line arguments for the extproc
+// container excluding the secret-presence-driven -configPath / -configBundlePath
+// flags. The mutating webhook prepends those based on which filter-config
+// secrets exist; they are intentionally kept out of the drift hash.
+func (b *extProcBuilder) buildExtProcBaseArgs(needMCP bool) []string {
+	args := []string{
+		"-logLevel", b.logLevel,
+		"-extProcAddr", "unix://" + b.udsPath,
+		"-adminPort", fmt.Sprintf("%d", extProcAdminPort),
+		"-rootPrefix", b.rootPrefix,
+		"-maxRecvMsgSize", fmt.Sprintf("%d", b.maxRecvMsgSize),
+	}
+	if needMCP {
+		args = append(args,
+			"-mcpAddr", ":"+strconv.Itoa(internalapi.MCPProxyPort),
+			"-mcpSessionEncryptionSeed", b.mcpSessionEncryptionSeed,
+			"-mcpSessionEncryptionIterations", strconv.Itoa(b.mcpSessionEncryptionIterations),
+		)
+		if b.mcpFallbackSessionEncryptionSeed != "" {
+			args = append(args,
+				"-mcpFallbackSessionEncryptionSeed", b.mcpFallbackSessionEncryptionSeed,
+				"-mcpFallbackSessionEncryptionIterations", strconv.Itoa(b.mcpFallbackSessionEncryptionIterations),
+			)
+		}
+	}
+
+	if b.requestHeaderAttributes != nil {
+		args = append(args, "-requestHeaderAttributes", *b.requestHeaderAttributes)
+	}
+	if b.spanRequestHeaderAttributes != nil {
+		args = append(args, "-spanRequestHeaderAttributes", *b.spanRequestHeaderAttributes)
+	}
+	if b.metricsRequestHeaderAttributes != nil {
+		args = append(args, "-metricsRequestHeaderAttributes", *b.metricsRequestHeaderAttributes)
+	}
+	if b.logRequestHeaderAttributes != nil {
+		args = append(args, "-logRequestHeaderAttributes", *b.logRequestHeaderAttributes)
+	}
+	if b.endpointPrefixes != "" {
+		args = append(args, "-endpointPrefixes", b.endpointPrefixes)
+	}
+	if b.enableRedaction {
+		args = append(args, "-enableRedaction")
+	}
+	return args
+}
+
+// extProcUDSVolumeName is the name of the volume backing the extproc UDS socket,
+// shared between the extproc container and the envoy container.
+const extProcUDSVolumeName = mutationNamePrefix + "extproc-uds"
+
+// mergeEnvVars merges env vars; GatewayConfig overrides global while preserving order.
+func (b *extProcBuilder) mergeEnvVars(gatewayConfig *aigv1b1.GatewayConfig) []corev1.EnvVar {
+	result := make([]corev1.EnvVar, 0, len(b.extraEnvVars))
+	index := make(map[string]int, len(b.extraEnvVars))
+
+	// Add global env vars first (lowest precedence) preserving input order.
+	for _, env := range b.extraEnvVars {
+		result = append(result, env)
+		index[env.Name] = len(result) - 1
+	}
+
+	// Add GatewayConfig env vars (highest precedence) overriding in-place when names collide,
+	// otherwise append in the order they are defined.
+	if gatewayConfig != nil && gatewayConfig.Spec.ExtProc != nil && gatewayConfig.Spec.ExtProc.Kubernetes != nil {
+		for _, env := range gatewayConfig.Spec.ExtProc.Kubernetes.Env {
+			if i, ok := index[env.Name]; ok {
+				result[i] = env
+			} else {
+				result = append(result, env)
+				index[env.Name] = len(result) - 1
+			}
+		}
+	}
+
+	return result
+}
+
+// resolveExtProcImage chooses the extProc image honoring GatewayConfig overrides.
+func (b *extProcBuilder) resolveExtProcImage(extProc *aigv1b1.GatewayConfigExtProc) string {
+	if extProc == nil || extProc.Kubernetes == nil {
+		return b.image
+	}
+
+	kubernetesExtProc := extProc.Kubernetes
+	switch {
+	case kubernetesExtProc.Image != nil:
+		return *kubernetesExtProc.Image
+	case kubernetesExtProc.ImageRepository != nil:
+		return mergeImageWithRepository(b.image, *kubernetesExtProc.ImageRepository)
+	default:
+		return b.image
+	}
+}
+
+// mergeImageWithRepository reuses the tag or digest from baseImage when a repository override is provided.
+func mergeImageWithRepository(baseImage, repository string) string {
+	if repository == "" {
+		return baseImage
+	}
+
+	suffix := imageTagOrDigest(baseImage)
+	if suffix == "" {
+		return repository
+	}
+	return repository + suffix
+}
+
+// imageTagOrDigest extracts the tag (":vX") or digest ("@sha256:...") from an image reference.
+func imageTagOrDigest(image string) string {
+	if image == "" {
+		return ""
+	}
+	if idx := strings.Index(image, "@"); idx != -1 {
+		return image[idx:]
+	}
+	lastSlash := strings.LastIndex(image, "/")
+	lastColon := strings.LastIndex(image, ":")
+	if lastColon != -1 && lastColon > lastSlash {
+		return image[lastColon:]
+	}
+	return ""
+}

--- a/internal/controller/extproc_builder_test.go
+++ b/internal/controller/extproc_builder_test.go
@@ -1,0 +1,284 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package controller
+
+import (
+	"testing"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+)
+
+// newTestBuilder returns an extProcBuilder with the standard test defaults. It is
+// the single source of truth for the config the webhook injects and the
+// reconciler hashes, so the tests below exercise the actual drift signal.
+func newTestBuilder() *extProcBuilder {
+	opts := &Options{
+		ExtProcImage:                           "docker.io/envoyproxy/ai-gateway-extproc:latest",
+		ExtProcLogLevel:                        "info",
+		UDSPath:                                "/tmp/extproc.sock",
+		RootPrefix:                             "/v1",
+		ExtProcMaxRecvMsgSize:                  512 * 1024 * 1024,
+		MCPSessionEncryptionSeed:               "seed",
+		MCPSessionEncryptionIterations:         100,
+		MCPFallbackSessionEncryptionSeed:       "fallback",
+		MCPFallbackSessionEncryptionIterations: 200,
+	}
+	return newExtProcBuilder(opts, false, ctrl.Log)
+}
+
+// TestExtProcContainerHash_Deterministic pins the property the whole drift
+// mechanism relies on: the hash the webhook stamps must equal the hash the
+// reconciler recomputes for identical state. Because both sides call the same
+// builder, this holds by construction — this test guards against someone
+// introducing a second, parallel hash implementation.
+func TestExtProcContainerHash_Deterministic(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	b := newTestBuilder()
+
+	for _, tc := range []struct {
+		name  string
+		input extProcContainerInput
+	}{
+		{name: "no gateway config, no MCP", input: extProcContainerInput{}},
+		{name: "need MCP", input: extProcContainerInput{needMCP: true}},
+		{name: "with gateway config", input: extProcContainerInput{gatewayConfig: testGatewayConfig}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h1 := b.extProcContainerHash(tc.input)
+			h2 := b.extProcContainerHash(tc.input)
+			require.NotEmpty(t, h1)
+			require.Equal(t, h1, h2, "hash must be stable across recomputes")
+		})
+	}
+}
+
+// TestExtProcContainerHash_Drift asserts that every config field the issue
+// lists as "silently half-honored" actually moves the hash, so a controller
+// restart with a changed flag is detected and triggers a rollout. A change to
+// any of these must produce a different hash; otherwise the drift signal is
+// broken and the bug persists.
+func TestExtProcContainerHash_Drift(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	base := newTestBuilder()
+	// input has no GatewayConfig and no MCP, so the *global* builder fields
+	// (image, mcpSessionEncryptionSeed, …) are the ones exercised. The
+	// GatewayConfig-driven fields are exercised separately below.
+	input := extProcContainerInput{}
+	baseHash := base.extProcContainerHash(input)
+	require.NotEmpty(t, baseHash)
+
+	// Helper: mutate a copy of the builder, recompute, expect a different hash.
+	assertDrifts := func(name string, mutated *extProcBuilder) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			require.NotEqual(t, baseHash, mutated.extProcContainerHash(input),
+				"%s change must alter the config hash so drift is detected", name)
+		})
+	}
+
+	assertDrifts("extraEnvVars", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.extraEnvVars = []corev1.EnvVar{{Name: "OTEL_SERVICE_NAME", Value: "ai-gateway"}}
+		return b
+	}())
+	assertDrifts("imagePullSecrets", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.imagePullSecrets = []corev1.LocalObjectReference{{Name: "reg-cred"}}
+		return b
+	}())
+	assertDrifts("endpointPrefixes", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.endpointPrefixes = "openai:/,cohere:/cohere"
+		return b
+	}())
+	assertDrifts("enableRedaction", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.enableRedaction = true
+		return b
+	}())
+	assertDrifts("maxRecvMsgSize", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.maxRecvMsgSize = 42
+		return b
+	}())
+	assertDrifts("image", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.image = "docker.io/envoyproxy/ai-gateway-extproc:v2"
+		return b
+	}())
+	assertDrifts("logLevel", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.logLevel = "debug"
+		return b
+	}())
+	assertDrifts("requestHeaderAttributes", func() *extProcBuilder {
+		b := newTestBuilder()
+		s := "x-tenant-id:tenant.id"
+		b.requestHeaderAttributes = &s
+		return b
+	}())
+	// mcpSessionEncryptionSeed only enters the container args when needMCP is
+	// true, so verify drift under that input.
+	assertDriftsMCP := func(name string, mutated *extProcBuilder) {
+		t.Helper()
+		mcpInput := extProcContainerInput{needMCP: true}
+		require.NotEqual(t, base.extProcContainerHash(mcpInput), mutated.extProcContainerHash(mcpInput),
+			"%s change must alter the config hash when MCP is enabled", name)
+	}
+	assertDriftsMCP("mcpSessionEncryptionSeed", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.mcpSessionEncryptionSeed = "different-seed"
+		return b
+	}())
+
+	// GatewayConfig-driven fields move the hash too (resources / securityContext
+	// / volumeMounts / env override / image override), proving the reconciler
+	// detects edits to GatewayConfig.spec.extProc.kubernetes.*.
+	gcInput := extProcContainerInput{gatewayConfig: testGatewayConfig}
+	gcBaseHash := base.extProcContainerHash(gcInput)
+	t.Run("gatewayConfig resources change", func(t *testing.T) {
+		gc := testGatewayConfig.DeepCopy()
+		gc.Spec.ExtProc.Kubernetes.Resources = &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m")},
+		}
+		require.NotEqual(t, gcBaseHash, base.extProcContainerHash(extProcContainerInput{gatewayConfig: gc}))
+	})
+	t.Run("gatewayConfig env override changes", func(t *testing.T) {
+		gc := testGatewayConfig.DeepCopy()
+		gc.Spec.ExtProc.Kubernetes.Env = []corev1.EnvVar{{Name: "LOG_LEVEL", Value: "error"}}
+		require.NotEqual(t, gcBaseHash, base.extProcContainerHash(extProcContainerInput{gatewayConfig: gc}))
+	})
+	t.Run("gatewayConfig image override changes", func(t *testing.T) {
+		gc := testGatewayConfig.DeepCopy()
+		gc.Spec.ExtProc.Kubernetes.Image = ptr.To("gcr.io/custom/extproc:v9")
+		require.NotEqual(t, gcBaseHash, base.extProcContainerHash(extProcContainerInput{gatewayConfig: gc}))
+	})
+
+	// needMCP toggling the MCP args must move the hash.
+	require.NotEqual(t, baseHash, base.extProcContainerHash(extProcContainerInput{needMCP: true}),
+		"needMCP must alter the config hash")
+}
+
+// TestExtProcContainerHash_ExcludesConfigRoutingArgs ensures the secret-
+// presence-driven -configPath / -configBundlePath args are NOT part of the hash
+// (they are added by the webhook after buildExtProcContainer returns). The base
+// container's Args must contain neither flag, so secret-existence transitions
+// do not spuriously trigger rollouts.
+func TestExtProcContainerHash_ExcludesConfigRoutingArgs(t *testing.T) {
+	b := newTestBuilder()
+	container := b.buildExtProcContainer(extProcContainerInput{})
+	for _, a := range container.Args {
+		require.NotEqual(t, "-configPath", a)
+		require.NotEqual(t, "-configBundlePath", a)
+	}
+}
+
+// TestNewExtProcBuilder_MalformedInput covers the defensive parse-error log
+// branches in newExtProcBuilder. In production main.go validates these flags
+// before StartControllers, but the builder must still degrade gracefully (log +
+// skip) rather than panic on malformed input.
+func TestNewExtProcBuilder_MalformedInput(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	// "badpair" has no '=', so ParseExtraEnvVars errors.
+	b := newExtProcBuilder(&Options{
+		ExtProcExtraEnvVars:   "badpair",
+		ExtProcImage:          "img",
+		ExtProcLogLevel:       "info",
+		UDSPath:               "/tmp/extproc.sock",
+		RootPrefix:            "/",
+		ExtProcMaxRecvMsgSize: 512 * 1024 * 1024,
+	}, false, ctrl.Log)
+	require.Empty(t, b.extraEnvVars, "malformed env var must be skipped, not stored")
+}
+
+// TestBuildExtProcContainer_GatewayConfigOverrides covers the GatewayConfig-driven
+// container fields that the drift hash must include: a SecurityContext override,
+// extra VolumeMounts, Resources, and the resolveExtProcImage default branch
+// (Kubernetes set with neither Image nor ImageRepository — falls back to the
+// builder's global image).
+func TestBuildExtProcContainer_GatewayConfigOverrides(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	b := newTestBuilder()
+	gc := &aigv1b1.GatewayConfig{
+		Spec: aigv1b1.GatewayConfigSpec{
+			ExtProc: &aigv1b1.GatewayConfigExtProc{
+				Kubernetes: &egv1a1.KubernetesContainerSpec{
+					// No Image / ImageRepository → resolveExtProcImage returns the
+					// builder's global image (default branch).
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: ptr.To(int64(1000)),
+					},
+					VolumeMounts: []corev1.VolumeMount{{Name: "extra-mount", MountPath: "/extra"}},
+				},
+			},
+		},
+	}
+	container := b.buildExtProcContainer(extProcContainerInput{gatewayConfig: gc})
+	require.Equal(t, b.image, container.Image, "default branch returns the global image")
+	require.Equal(t, int64(1000), *container.SecurityContext.RunAsUser, "SecurityContext override applied")
+	require.NotEmpty(t, container.Resources.Limits, "Resources applied")
+	var foundExtra bool
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "extra-mount" {
+			foundExtra = true
+		}
+	}
+	require.True(t, foundExtra, "GatewayConfig VolumeMounts appended")
+
+	// The override fields move the hash relative to no-GatewayConfig.
+	baseHash := b.extProcContainerHash(extProcContainerInput{})
+	overrideHash := b.extProcContainerHash(extProcContainerInput{gatewayConfig: gc})
+	require.NotEqual(t, baseHash, overrideHash)
+}
+
+func TestMergeImageWithRepository(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseImage  string
+		repository string
+		expected   string
+	}{
+		{name: "empty repository returns base", baseImage: "img:v1", repository: "", expected: "img:v1"},
+		{name: "base with no tag returns repository only", baseImage: "img", repository: "gcr.io/custom", expected: "gcr.io/custom"},
+		{name: "base with tag reuses tag", baseImage: "img:v1", repository: "gcr.io/custom", expected: "gcr.io/custom:v1"},
+		{name: "base with digest reuses digest", baseImage: "img@sha256:abc", repository: "gcr.io/custom", expected: "gcr.io/custom@sha256:abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, mergeImageWithRepository(tt.baseImage, tt.repository))
+		})
+	}
+}
+
+func TestImageTagOrDigest(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{name: "empty", image: "", expected: ""},
+		{name: "digest", image: "img@sha256:abc", expected: "@sha256:abc"},
+		{name: "tag after last slash", image: "registry.io/foo:v1", expected: ":v1"},
+		{name: "no tag and no digest", image: "registry.io/foo", expected: ""},
+		{name: "colon before slash is not a tag", image: "localhost:5000/foo", expected: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, imageTagOrDigest(tt.image))
+		})
+	}
+}

--- a/internal/controller/extproc_builder_test.go
+++ b/internal/controller/extproc_builder_test.go
@@ -38,10 +38,9 @@ func newTestBuilder() *extProcBuilder {
 }
 
 // TestExtProcContainerHash_Deterministic pins the property the whole drift
-// mechanism relies on: the hash the webhook stamps must equal the hash the
-// reconciler recomputes for identical state. Because both sides call the same
-// builder, this holds by construction — this test guards against someone
-// introducing a second, parallel hash implementation.
+// mechanism relies on: the workload template hash must be stable for identical
+// extproc config. Because both webhook injection and reconciler hashing use the
+// same builder, this guards against a second, parallel hash implementation.
 func TestExtProcContainerHash_Deterministic(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
 	b := newTestBuilder()

--- a/internal/controller/extproc_builder_test.go
+++ b/internal/controller/extproc_builder_test.go
@@ -6,6 +6,7 @@
 package controller
 
 import (
+	"reflect"
 	"testing"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -55,9 +56,10 @@ func TestExtProcContainerHash_Deterministic(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h1 := b.extProcContainerHash(tc.input)
-			h2 := b.extProcContainerHash(tc.input)
 			require.NotEmpty(t, h1)
-			require.Equal(t, h1, h2, "hash must be stable across recomputes")
+			for range 20 {
+				require.Equal(t, h1, b.extProcContainerHash(tc.input), "hash must be stable across recomputes")
+			}
 		})
 	}
 }
@@ -76,6 +78,8 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 	input := extProcContainerInput{}
 	baseHash := base.extProcContainerHash(input)
 	require.NotEmpty(t, baseHash)
+	require.Equal(t, 19, reflect.TypeOf(extProcBuilder{}).NumField(),
+		"update drift coverage when extProcBuilder fields change")
 
 	// Helper: mutate a copy of the builder, recompute, expect a different hash.
 	assertDrifts := func(name string, mutated *extProcBuilder) {
@@ -94,6 +98,16 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 	assertDrifts("imagePullSecrets", func() *extProcBuilder {
 		b := newTestBuilder()
 		b.imagePullSecrets = []corev1.LocalObjectReference{{Name: "reg-cred"}}
+		return b
+	}())
+	assertDrifts("imagePullPolicy", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.imagePullPolicy = corev1.PullAlways
+		return b
+	}())
+	assertDrifts("udsPath", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.udsPath = "/var/run/extproc.sock"
 		return b
 	}())
 	assertDrifts("endpointPrefixes", func() *extProcBuilder {
@@ -127,6 +141,34 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 		b.requestHeaderAttributes = &s
 		return b
 	}())
+	assertDrifts("spanRequestHeaderAttributes", func() *extProcBuilder {
+		b := newTestBuilder()
+		s := "x-trace-id:trace.id"
+		b.spanRequestHeaderAttributes = &s
+		return b
+	}())
+	assertDrifts("metricsRequestHeaderAttributes", func() *extProcBuilder {
+		b := newTestBuilder()
+		s := "x-metric-id:metric.id"
+		b.metricsRequestHeaderAttributes = &s
+		return b
+	}())
+	assertDrifts("logRequestHeaderAttributes", func() *extProcBuilder {
+		b := newTestBuilder()
+		s := "x-log-id:log.id"
+		b.logRequestHeaderAttributes = &s
+		return b
+	}())
+	assertDrifts("rootPrefix", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.rootPrefix = "/custom"
+		return b
+	}())
+	assertDrifts("extProcAsSideCar", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.extProcAsSideCar = true
+		return b
+	}())
 	// mcpSessionEncryptionSeed only enters the container args when needMCP is
 	// true, so verify drift under that input.
 	assertDriftsMCP := func(name string, mutated *extProcBuilder) {
@@ -138,6 +180,21 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 	assertDriftsMCP("mcpSessionEncryptionSeed", func() *extProcBuilder {
 		b := newTestBuilder()
 		b.mcpSessionEncryptionSeed = "different-seed"
+		return b
+	}())
+	assertDriftsMCP("mcpSessionEncryptionIterations", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.mcpSessionEncryptionIterations = 101
+		return b
+	}())
+	assertDriftsMCP("mcpFallbackSessionEncryptionSeed", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.mcpFallbackSessionEncryptionSeed = "different-fallback"
+		return b
+	}())
+	assertDriftsMCP("mcpFallbackSessionEncryptionIterations", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.mcpFallbackSessionEncryptionIterations = 201
 		return b
 	}())
 
@@ -176,11 +233,17 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 // do not spuriously trigger rollouts.
 func TestExtProcContainerHash_ExcludesConfigRoutingArgs(t *testing.T) {
 	b := newTestBuilder()
-	container := b.buildExtProcContainer(extProcContainerInput{})
+	input := extProcContainerInput{}
+	baseHash := b.extProcContainerHash(input)
+	require.NotEmpty(t, baseHash)
+
+	container := b.buildExtProcContainer(input)
 	for _, a := range container.Args {
 		require.NotEqual(t, "-configPath", a)
 		require.NotEqual(t, "-configBundlePath", a)
 	}
+	require.Equal(t, baseHash, b.extProcContainerHash(input),
+		"secret-presence-driven config routing must not affect the workload template hash")
 }
 
 // TestNewExtProcBuilder_MalformedInput covers the defensive parse-error log

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -155,17 +155,9 @@ func (c *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Finally, we need to annotate the pods of the gateway deployment with the new uuid to propagate the filter config Secret update faster.
-	// If the pod doesn't have the extproc container, it will roll out the deployment altogether which eventually ends up
-	// the mutation hook invoked.
-	//
-	// desiredHash is the config hash the webhook would stamp on a pod created right
-	// now with the current controller flags + this Gateway's GatewayConfig + MCP
-	// state. annotateGatewayPods compares it to each pod's stamped hash to detect
-	// extproc config drift (the webhook and reconciler share one builder, so the
-	// hashes are computed identically — see extproc_builder.go).
-	desiredHash := c.extProcContainerHash(extProcContainerInput{gatewayConfig: gwConfig, needMCP: len(mcpRoutes.Items) > 0})
-	result, err := c.annotateGatewayPods(ctx, pods, deployments, daemonSets, uid, hasEffectiveRoutes, len(mcpRoutes.Items) > 0, desiredHash)
+	input := extProcContainerInput{gatewayConfig: gwConfig, needMCP: len(mcpRoutes.Items) > 0}
+	result, err := c.annotateGatewayPodsWithDesiredImage(ctx, pods, deployments, daemonSets, uid,
+		hasEffectiveRoutes, input.needMCP, c.extProcImage(input), c.extProcContainerHash(input))
 	if err != nil {
 		c.logger.Error(err, "Failed to annotate gateway pods", "namespace", gw.Namespace, "name", gw.Name)
 		return ctrl.Result{}, err
@@ -1068,45 +1060,31 @@ func (c *GatewayController) getBSPForInferencePool(ctx context.Context, namespac
 	return matchingBSPs[0], nil
 }
 
-// checkPodHasSideCar checks if a pod has the extproc sidecar container with the
-// currently-desired image, log level, and (when MCP is in use) -mcpAddr.
-//
-// It returns:
-//   - hasSideCar: true when the sidecar is structurally present and matches the
-//     image/logLevel/mcpAddr expectations (the legacy drift signal).
-//   - needsRollout: true when the sidecar is present *but* its
-//     extproc-config-hash annotation is present and differs from desiredHash,
-//     i.e. the injected config (env vars, imagePullSecrets, endpointPrefixes,
-//     enableRedaction, maxRecvMsgSize, header attributes, GatewayConfig
-//     resources/securityContext/volumeMounts, …) has drifted since the pod was
-//     created. This closes the class of drift bugs that the image/logLevel/mcpAddr
-//     check could not see.
-//
-// A pod created before this annotation existed has no hash; "missing" is treated
-// as "no drift signal" (not a rollout trigger) so upgrading the controller does
-// not roll every managed proxy once. Pods recreated after the upgrade carry the
-// annotation, and any subsequent config drift is then detected.
+// checkPodHasSideCar checks the extproc container against the controller-global
+// image. It is kept for tests and legacy callers without GatewayConfig input.
 func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, desiredHash string) (hasSideCar, needsRollout bool) {
+	return c.checkPodHasSideCarWithImage(pod, needMCP, c.image, desiredHash)
+}
+
+// checkPodHasSideCarWithImage returns whether the extproc container is current,
+// and whether a stamped config hash mismatch requires a rollout.
+func (c *GatewayController) checkPodHasSideCarWithImage(pod *corev1.Pod, needMCP bool, desiredImage, desiredHash string) (hasSideCar, needsRollout bool) {
 	podSpec := pod.Spec
 
 	if c.extProcAsSideCar {
 		for i := range podSpec.InitContainers {
-			// If there's an extproc sidecar container with the current target image, we don't need to roll out the deployment.
-			if podSpec.InitContainers[i].Name == extProcContainerName && podSpec.InitContainers[i].Image == c.image {
+			if podSpec.InitContainers[i].Name == extProcContainerName && podSpec.InitContainers[i].Image == desiredImage {
 				hasSideCar = true
 				hasMCPAddr := false
 				for j := range podSpec.InitContainers[i].Args {
-					// logLevel arg should be indexed 2 based on gateway_mutator.go, but we check all args to be safe.
 					if j > 0 && podSpec.InitContainers[i].Args[j-1] == "-logLevel" && podSpec.InitContainers[i].Args[j] != c.logLevel {
 						hasSideCar = false
 						break
 					}
-					// Check if the -mcpAddr argument is present
 					if j > 0 && podSpec.InitContainers[i].Args[j-1] == "-mcpAddr" {
 						hasMCPAddr = true
 					}
 				}
-				// If MCPRoutes exist but the sidecar doesn't have -mcpAddr, we need to roll out
 				if needMCP && !hasMCPAddr {
 					c.logger.Info("MCPRoutes exist but sidecar is missing -mcpAddr argument, triggering rollout",
 						"pod", pod.Name, "namespace", pod.Namespace)
@@ -1117,8 +1095,7 @@ func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, de
 		}
 	} else {
 		for i := range podSpec.Containers {
-			// If there's an extproc container with the current target image, we don't need to roll out the deployment.
-			if podSpec.Containers[i].Name == extProcContainerName && podSpec.Containers[i].Image == c.image {
+			if podSpec.Containers[i].Name == extProcContainerName && podSpec.Containers[i].Image == desiredImage {
 				hasSideCar = true
 				hasMCPAddr := false
 				for j := range podSpec.Containers[i].Args {
@@ -1126,12 +1103,10 @@ func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, de
 						hasSideCar = false
 						break
 					}
-					// Check if the -mcpAddr argument is present
 					if j > 0 && podSpec.Containers[i].Args[j-1] == "-mcpAddr" {
 						hasMCPAddr = true
 					}
 				}
-				// If MCPRoutes exist but the sidecar doesn't have -mcpAddr, we need to roll out
 				if needMCP && !hasMCPAddr {
 					c.logger.Info("MCPRoutes exist but sidecar is missing -mcpAddr argument, triggering rollout",
 						"pod", pod.Name, "namespace", pod.Namespace)
@@ -1142,10 +1117,6 @@ func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, de
 		}
 	}
 
-	// If the sidecar is present, additionally compare the config hash the webhook
-	// stamped at pod-creation time against the currently-desired hash. A mismatch
-	// means the injected config drifted (e.g. --extProcExtraEnvVars changed) and the
-	// pod must be rolled so the webhook re-injects the current config.
 	if hasSideCar {
 		if stamped := pod.Annotations[extProcConfigHashAnnotationKey]; stamped != "" && stamped != desiredHash {
 			needsRollout = true
@@ -1188,12 +1159,8 @@ func isRolloutInProgress(deployments []appsv1.Deployment, daemonSets []appsv1.Da
 	return false
 }
 
-// annotateGatewayPods annotates the pods of GW with the new uuid to propagate the filter config Secret update faster.
-// If the pod doesn't have the extproc container, it will roll out the deployment altogether, which eventually ends up
-// the mutation hook invoked.
-//
-// Returns a ctrl.Result that may indicate requeue is needed (e.g., when rollout is in progress).
-//
+// annotateGatewayPods annotates pods to speed filter config Secret refresh and
+// rolls workload templates only when pod template state must change.
 // See https://neonmirrors.net/post/2022-12/reducing-pod-volume-update-times/ for explanation.
 func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 	pods []corev1.Pod,
@@ -1204,17 +1171,25 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 	needMCP bool,
 	desiredHash string,
 ) (ctrl.Result, error) {
+	return c.annotateGatewayPodsWithDesiredImage(ctx, pods, deployments, daemonSets, uuid, hasEffectiveRoute, needMCP, c.image, desiredHash)
+}
+
+func (c *GatewayController) annotateGatewayPodsWithDesiredImage(ctx context.Context,
+	pods []corev1.Pod,
+	deployments []appsv1.Deployment,
+	daemonSets []appsv1.DaemonSet,
+	uuid string,
+	hasEffectiveRoute bool,
+	needMCP bool,
+	desiredImage string,
+	desiredHash string,
+) (ctrl.Result, error) {
 	if isRolloutInProgress(deployments, daemonSets) {
 		const requeueAfter = 5 * time.Second
 		c.logger.Info("rollout in progress - requeueing", "requeueAfter", requeueAfter.String())
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
-	// Detect sidecar state in one pass with early exit on inconsistent state (e.g., some pods have sidecar, some don't).
-	// If inconsistent state exists while rollout is not in progress, force rollout to self-heal.
-	//
-	// needsRollout is set when a pod has the sidecar but its stamped extproc-config-hash
-	// annotation mismatches the desired hash, i.e. the injected config has drifted.
 	seenWithSidecar := false
 	seenWithoutSidecar := false
 	seenNeedsRollout := false
@@ -1222,7 +1197,7 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 		if !pods[i].GetDeletionTimestamp().IsZero() {
 			continue
 		}
-		hasSideCar, needsRollout := c.checkPodHasSideCar(&pods[i], needMCP, desiredHash)
+		hasSideCar, needsRollout := c.checkPodHasSideCarWithImage(&pods[i], needMCP, desiredImage, desiredHash)
 		if hasSideCar {
 			seenWithSidecar = true
 		} else {
@@ -1241,8 +1216,6 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 			"podsWithSidecarSeen", seenWithSidecar, "podsWithoutSidecarSeen", seenWithoutSidecar,
 			"podsNeedingRolloutSeen", seenNeedsRollout)
 	}
-	// "all up to date": at least one pod with sidecar, none without, and none
-	// needing a config-driven rollout. For zero pods this remains false.
 	hasSideCar := seenWithSidecar && !seenWithoutSidecar && !seenNeedsRollout
 
 	for i := range pods {
@@ -1261,11 +1234,6 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 		}
 	}
 
-	// We annotate the deployments and daemonsets under three scenarios:
-	// 1. If there's an effective route but no sidecar container, we need to add the sidecar container.
-	// 2. If there's no effective route but has sidecar container,
-	//    we need to roll out the deployment to trigger the mutation webhook to remove the sidecar container.
-	// 3. If pods are inconsistent even when rollout isn't in progress, force rollout to self-heal.
 	if hasEffectiveRoute != hasSideCar || forceRollout {
 		for i := range deployments {
 			dep := &deployments[i]

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -92,12 +92,12 @@ func (c *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	aiRoutes, err := c.listAIGatewayRoutesForGateway(ctx, req.Name, req.Namespace)
+	aiRoutes, err := listAIGatewayRoutesForGateway(ctx, c.client, nil, req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	mcpRoutes, err := c.listMCPRoutesForGateway(ctx, req.Name, req.Namespace)
+	mcpRoutes, err := listMCPRoutesForGateway(ctx, c.client, nil, req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -54,12 +54,20 @@ func NewGatewayController(
 	client client.Client, kube kubernetes.Interface, logger logr.Logger, envoyGatewayNamespace string,
 	standAlone bool, uuidFn func() string, options *Options, extProcAsSideCar bool,
 ) *GatewayController {
+	return NewGatewayControllerWithAPIReader(client, nil, kube, logger, envoyGatewayNamespace, standAlone, uuidFn, options, extProcAsSideCar)
+}
+
+func NewGatewayControllerWithAPIReader(
+	client client.Client, noCacheReader client.Reader, kube kubernetes.Interface, logger logr.Logger, envoyGatewayNamespace string,
+	standAlone bool, uuidFn func() string, options *Options, extProcAsSideCar bool,
+) *GatewayController {
 	uf := uuidFn
 	if uf == nil {
 		uf = uuid.NewString
 	}
 	return &GatewayController{
 		client:                client,
+		noCacheReader:         noCacheReader,
 		kube:                  kube,
 		logger:                logger,
 		envoyGatewayNamespace: envoyGatewayNamespace,
@@ -71,7 +79,10 @@ func NewGatewayController(
 
 // GatewayController implements reconcile.TypedReconciler for gwapiv1.Gateway.
 type GatewayController struct {
-	client                client.Client
+	client client.Client
+	// noCacheReader bypasses the informer cache to avoid cache sync races when
+	// looking up routes attached to the reconciled Gateway.
+	noCacheReader         client.Reader
 	kube                  kubernetes.Interface
 	logger                logr.Logger
 	envoyGatewayNamespace string // The namespace where Envoy Gateway is deployed.
@@ -93,18 +104,12 @@ func (c *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	var aiRoutes aigv1b1.AIGatewayRouteList
-	err := c.client.List(ctx, &aiRoutes, client.MatchingFields{
-		k8sClientIndexAIGatewayRouteToAttachedGateway: fmt.Sprintf("%s.%s", req.Name, req.Namespace),
-	})
+	aiRoutes, err := c.listAIGatewayRoutesForGateway(ctx, req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	var mcpRoutes aigv1b1.MCPRouteList
-	err = c.client.List(ctx, &mcpRoutes, client.MatchingFields{
-		k8sClientIndexMCPRouteToAttachedGateway: fmt.Sprintf("%s.%s", req.Name, req.Namespace),
-	})
+	mcpRoutes, err := c.listMCPRoutesForGateway(ctx, req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -54,20 +54,12 @@ func NewGatewayController(
 	client client.Client, kube kubernetes.Interface, logger logr.Logger, envoyGatewayNamespace string,
 	standAlone bool, uuidFn func() string, options *Options, extProcAsSideCar bool,
 ) *GatewayController {
-	return NewGatewayControllerWithAPIReader(client, nil, kube, logger, envoyGatewayNamespace, standAlone, uuidFn, options, extProcAsSideCar)
-}
-
-func NewGatewayControllerWithAPIReader(
-	client client.Client, noCacheReader client.Reader, kube kubernetes.Interface, logger logr.Logger, envoyGatewayNamespace string,
-	standAlone bool, uuidFn func() string, options *Options, extProcAsSideCar bool,
-) *GatewayController {
 	uf := uuidFn
 	if uf == nil {
 		uf = uuid.NewString
 	}
 	return &GatewayController{
 		client:                client,
-		noCacheReader:         noCacheReader,
 		kube:                  kube,
 		logger:                logger,
 		envoyGatewayNamespace: envoyGatewayNamespace,
@@ -79,10 +71,7 @@ func NewGatewayControllerWithAPIReader(
 
 // GatewayController implements reconcile.TypedReconciler for gwapiv1.Gateway.
 type GatewayController struct {
-	client client.Client
-	// noCacheReader bypasses the informer cache to avoid cache sync races when
-	// looking up routes attached to the reconciled Gateway.
-	noCacheReader         client.Reader
+	client                client.Client
 	kube                  kubernetes.Interface
 	logger                logr.Logger
 	envoyGatewayNamespace string // The namespace where Envoy Gateway is deployed.
@@ -156,7 +145,7 @@ func (c *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	input := extProcContainerInput{gatewayConfig: gwConfig, needMCP: len(mcpRoutes.Items) > 0}
-	result, err := c.annotateGatewayPodsWithDesiredImage(ctx, pods, deployments, daemonSets, uid,
+	result, err := c.annotateGatewayPods(ctx, pods, deployments, daemonSets, uid,
 		hasEffectiveRoutes, input.needMCP, c.extProcImage(input), c.extProcContainerHash(input))
 	if err != nil {
 		c.logger.Error(err, "Failed to annotate gateway pods", "namespace", gw.Namespace, "name", gw.Name)
@@ -1060,15 +1049,9 @@ func (c *GatewayController) getBSPForInferencePool(ctx context.Context, namespac
 	return matchingBSPs[0], nil
 }
 
-// checkPodHasSideCar checks the extproc container against the controller-global
-// image. It is kept for tests and legacy callers without GatewayConfig input.
-func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, desiredHash string) (hasSideCar, needsRollout bool) {
-	return c.checkPodHasSideCarWithImage(pod, needMCP, c.image, desiredHash)
-}
-
-// checkPodHasSideCarWithImage returns whether the extproc container is current,
-// and whether a stamped config hash mismatch requires a rollout.
-func (c *GatewayController) checkPodHasSideCarWithImage(pod *corev1.Pod, needMCP bool, desiredImage, desiredHash string) (hasSideCar, needsRollout bool) {
+// checkPodHasSideCar returns whether the extproc container is current, and
+// whether a stamped config hash mismatch requires a rollout.
+func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, desiredImage, desiredHash string) (hasSideCar, needsRollout bool) {
 	podSpec := pod.Spec
 
 	if c.extProcAsSideCar {
@@ -1118,10 +1101,12 @@ func (c *GatewayController) checkPodHasSideCarWithImage(pod *corev1.Pod, needMCP
 	}
 
 	if hasSideCar {
+		// Missing hash means a pre-upgrade pod. Do not roll it only because the
+		// annotation is absent; later pod recreations will be stamped by the webhook.
 		if stamped := pod.Annotations[extProcConfigHashAnnotationKey]; stamped != "" && stamped != desiredHash {
 			needsRollout = true
 			c.logger.Info("extproc config hash mismatch, triggering rollout",
-				"pod", pod.Name, "namespace", pod.Namespace)
+				"pod", pod.Name, "namespace", pod.Namespace, "stamped", stamped, "desiredHash", desiredHash)
 		}
 	}
 
@@ -1169,18 +1154,6 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 	uuid string,
 	hasEffectiveRoute bool,
 	needMCP bool,
-	desiredHash string,
-) (ctrl.Result, error) {
-	return c.annotateGatewayPodsWithDesiredImage(ctx, pods, deployments, daemonSets, uuid, hasEffectiveRoute, needMCP, c.image, desiredHash)
-}
-
-func (c *GatewayController) annotateGatewayPodsWithDesiredImage(ctx context.Context,
-	pods []corev1.Pod,
-	deployments []appsv1.Deployment,
-	daemonSets []appsv1.DaemonSet,
-	uuid string,
-	hasEffectiveRoute bool,
-	needMCP bool,
 	desiredImage string,
 	desiredHash string,
 ) (ctrl.Result, error) {
@@ -1197,7 +1170,7 @@ func (c *GatewayController) annotateGatewayPodsWithDesiredImage(ctx context.Cont
 		if !pods[i].GetDeletionTimestamp().IsZero() {
 			continue
 		}
-		hasSideCar, needsRollout := c.checkPodHasSideCarWithImage(&pods[i], needMCP, desiredImage, desiredHash)
+		hasSideCar, needsRollout := c.checkPodHasSideCar(&pods[i], needMCP, desiredImage, desiredHash)
 		if hasSideCar {
 			seenWithSidecar = true
 		} else {
@@ -1234,6 +1207,10 @@ func (c *GatewayController) annotateGatewayPodsWithDesiredImage(ctx context.Cont
 		}
 	}
 
+	// Roll workload templates only when pod-template state must change:
+	// 1. effective route exists but sidecar is missing;
+	// 2. no effective route exists but sidecar remains;
+	// 3. pods are inconsistent or have stamped config-hash drift.
 	if hasEffectiveRoute != hasSideCar || forceRollout {
 		for i := range deployments {
 			dep := &deployments[i]

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1190,7 +1190,7 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 		}
 	}
 
-	// We annotate the deployments and daemonsets under three scenarios:
+	// For sidecar state changes, annotate the workloads under three scenarios:
 	// 1. If there's an effective route but no sidecar container, we need to add the sidecar container.
 	// 2. If there's no effective route but has sidecar container,
 	//    we need to roll out the deployment to trigger the mutation webhook to remove the sidecar container.
@@ -1198,6 +1198,7 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 	needsStateRollout := hasEffectiveRoute != hasSideCar || forceRollout
 	for i := range deployments {
 		dep := &deployments[i]
+		// Hash changes are written to the pod template so Kubernetes owns the rollout.
 		needsHashRollout := hasEffectiveRoute && desiredHash != "" && dep.Spec.Template.Annotations[extProcConfigHashAnnotationKey] != desiredHash
 		if !needsStateRollout && !needsHashRollout {
 			continue
@@ -1213,6 +1214,7 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 
 	for i := range daemonSets {
 		daemonSet := &daemonSets[i]
+		// Hash changes are written to the pod template so Kubernetes owns the rollout.
 		needsHashRollout := hasEffectiveRoute && desiredHash != "" && daemonSet.Spec.Template.Annotations[extProcConfigHashAnnotationKey] != desiredHash
 		if !needsStateRollout && !needsHashRollout {
 			continue

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -48,8 +48,7 @@ const (
 //
 // The extproc builder is derived from options + extProcAsSideCar via the same
 // newExtProcBuilder the mutating webhook uses (StartControllers passes the same
-// options to both), so the config hash the webhook stamps on pods can be
-// recomputed identically here to detect drift.
+// options to both), so the workload template hash matches webhook injection.
 func NewGatewayController(
 	client client.Client, kube kubernetes.Interface, logger logr.Logger, envoyGatewayNamespace string,
 	standAlone bool, uuidFn func() string, options *Options, extProcAsSideCar bool,
@@ -78,8 +77,8 @@ type GatewayController struct {
 	// standAlone indicates whether the controller is running in standalone mode.
 	standAlone bool
 	uuidFn     func() string // Function to generate a new UUID for the filter config.
-	// extProcBuilder is shared with the mutating webhook so the config hash it
-	// stamps on pods can be recomputed here to detect drift and trigger rollout.
+	// extProcBuilder is shared with the mutating webhook so the template hash
+	// computed here matches the extproc container injected by the webhook.
 	*extProcBuilder
 }
 
@@ -1049,9 +1048,8 @@ func (c *GatewayController) getBSPForInferencePool(ctx context.Context, namespac
 	return matchingBSPs[0], nil
 }
 
-// checkPodHasSideCar returns whether the extproc container is current, and
-// whether a stamped config hash mismatch requires a rollout.
-func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, desiredImage, desiredHash string) (hasSideCar, needsRollout bool) {
+// checkPodHasSideCar returns whether the extproc container is current.
+func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, desiredImage string) (hasSideCar bool) {
 	podSpec := pod.Spec
 
 	if c.extProcAsSideCar {
@@ -1100,17 +1098,7 @@ func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, de
 		}
 	}
 
-	if hasSideCar {
-		// Missing hash means a pre-upgrade pod. Do not roll it only because the
-		// annotation is absent; later pod recreations will be stamped by the webhook.
-		if stamped := pod.Annotations[extProcConfigHashAnnotationKey]; stamped != "" && stamped != desiredHash {
-			needsRollout = true
-			c.logger.Info("extproc config hash mismatch, triggering rollout",
-				"pod", pod.Name, "namespace", pod.Namespace, "stamped", stamped, "desiredHash", desiredHash)
-		}
-	}
-
-	return hasSideCar, needsRollout
+	return hasSideCar
 }
 
 // isRolloutInProgress checks whether any Deployment or DaemonSet is currently rolling out.
@@ -1165,31 +1153,26 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 
 	seenWithSidecar := false
 	seenWithoutSidecar := false
-	seenNeedsRollout := false
 	for i := range pods {
 		if !pods[i].GetDeletionTimestamp().IsZero() {
 			continue
 		}
-		hasSideCar, needsRollout := c.checkPodHasSideCar(&pods[i], needMCP, desiredImage, desiredHash)
+		hasSideCar := c.checkPodHasSideCar(&pods[i], needMCP, desiredImage)
 		if hasSideCar {
 			seenWithSidecar = true
 		} else {
 			seenWithoutSidecar = true
 		}
-		if needsRollout {
-			seenNeedsRollout = true
-		}
-		if seenWithSidecar && seenWithoutSidecar && seenNeedsRollout {
+		if seenWithSidecar && seenWithoutSidecar {
 			break
 		}
 	}
-	forceRollout := (seenWithSidecar && seenWithoutSidecar) || seenNeedsRollout
+	forceRollout := seenWithSidecar && seenWithoutSidecar
 	if forceRollout {
 		c.logger.Info("forcing rollout",
-			"podsWithSidecarSeen", seenWithSidecar, "podsWithoutSidecarSeen", seenWithoutSidecar,
-			"podsNeedingRolloutSeen", seenNeedsRollout)
+			"podsWithSidecarSeen", seenWithSidecar, "podsWithoutSidecarSeen", seenWithoutSidecar)
 	}
-	hasSideCar := seenWithSidecar && !seenWithoutSidecar && !seenNeedsRollout
+	hasSideCar := seenWithSidecar && !seenWithoutSidecar
 
 	for i := range pods {
 		pod := &pods[i]
@@ -1211,34 +1194,49 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 	// 1. If there's an effective route but no sidecar container, we need to add the sidecar container.
 	// 2. If there's no effective route but has sidecar container,
 	//    we need to roll out the deployment to trigger the mutation webhook to remove the sidecar container.
-	// 3. If pods are inconsistent even when rollout isn't in progress, or have stamped
-	//    config-hash drift, force rollout to self-heal.
-	if hasEffectiveRoute != hasSideCar || forceRollout {
-		for i := range deployments {
-			dep := &deployments[i]
-			c.logger.Info("rolling out deployment", "namespace", dep.Namespace, "name", dep.Name)
-			_, err := c.kube.AppsV1().Deployments(dep.Namespace).Patch(ctx, dep.Name, types.MergePatchType,
-				fmt.Appendf(nil,
-					`{"spec":{"template":{"metadata":{"annotations":{"%s":"%s"}}}}}`, aigatewayUUIDAnnotationKey, uuid),
-				metav1.PatchOptions{})
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to patch deployment %s: %w", dep.Name, err)
-			}
+	// 3. If pods are inconsistent even when rollout isn't in progress, force rollout to self-heal.
+	needsStateRollout := hasEffectiveRoute != hasSideCar || forceRollout
+	for i := range deployments {
+		dep := &deployments[i]
+		needsHashRollout := hasEffectiveRoute && desiredHash != "" && dep.Spec.Template.Annotations[extProcConfigHashAnnotationKey] != desiredHash
+		if !needsStateRollout && !needsHashRollout {
+			continue
 		}
+		c.logger.Info("rolling out deployment", "namespace", dep.Namespace, "name", dep.Name, "desiredHash", desiredHash)
+		_, err := c.kube.AppsV1().Deployments(dep.Namespace).Patch(ctx, dep.Name, types.MergePatchType,
+			workloadTemplateAnnotationPatch(uuid, desiredHash, needsStateRollout, needsHashRollout),
+			metav1.PatchOptions{})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to patch deployment %s: %w", dep.Name, err)
+		}
+	}
 
-		for i := range daemonSets {
-			daemonSet := &daemonSets[i]
-			c.logger.Info("rolling out daemonSet", "namespace", daemonSet.Namespace, "name", daemonSet.Name)
-			_, err := c.kube.AppsV1().DaemonSets(daemonSet.Namespace).Patch(ctx, daemonSet.Name, types.MergePatchType,
-				fmt.Appendf(nil,
-					`{"spec":{"template":{"metadata":{"annotations":{"%s":"%s"}}}}}`, aigatewayUUIDAnnotationKey, uuid),
-				metav1.PatchOptions{})
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to patch daemonset %s: %w", daemonSet.Name, err)
-			}
+	for i := range daemonSets {
+		daemonSet := &daemonSets[i]
+		needsHashRollout := hasEffectiveRoute && desiredHash != "" && daemonSet.Spec.Template.Annotations[extProcConfigHashAnnotationKey] != desiredHash
+		if !needsStateRollout && !needsHashRollout {
+			continue
+		}
+		c.logger.Info("rolling out daemonSet", "namespace", daemonSet.Namespace, "name", daemonSet.Name, "desiredHash", desiredHash)
+		_, err := c.kube.AppsV1().DaemonSets(daemonSet.Namespace).Patch(ctx, daemonSet.Name, types.MergePatchType,
+			workloadTemplateAnnotationPatch(uuid, desiredHash, needsStateRollout, needsHashRollout),
+			metav1.PatchOptions{})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to patch daemonset %s: %w", daemonSet.Name, err)
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+func workloadTemplateAnnotationPatch(uuid, desiredHash string, includeUUID, includeHash bool) []byte {
+	annotations := make([]string, 0, 2)
+	if includeUUID {
+		annotations = append(annotations, fmt.Sprintf(`"%s":"%s"`, aigatewayUUIDAnnotationKey, uuid))
+	}
+	if includeHash {
+		annotations = append(annotations, fmt.Sprintf(`"%s":"%s"`, extProcConfigHashAnnotationKey, desiredHash))
+	}
+	return []byte(fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{%s}}}}}`, strings.Join(annotations, ",")))
 }
 
 // getObjectsForGateway retrieves the pods, deployments, and daemonsets for a given Gateway.

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -46,11 +46,13 @@ const (
 
 // NewGatewayController creates a new reconcile.TypedReconciler for gwapiv1.Gateway.
 //
-// extProcImage is the image of the external processor sidecar container which will be used
-// to check if the pods of the gateway deployment need to be rolled out.
+// The extproc builder is derived from options + extProcAsSideCar via the same
+// newExtProcBuilder the mutating webhook uses (StartControllers passes the same
+// options to both), so the config hash the webhook stamps on pods can be
+// recomputed identically here to detect drift.
 func NewGatewayController(
 	client client.Client, kube kubernetes.Interface, logger logr.Logger, envoyGatewayNamespace string,
-	extProcImage string, extProcLogLevel string, standAlone bool, uuidFn func() string, extProcAsSideCar bool,
+	standAlone bool, uuidFn func() string, options *Options, extProcAsSideCar bool,
 ) *GatewayController {
 	uf := uuidFn
 	if uf == nil {
@@ -61,11 +63,9 @@ func NewGatewayController(
 		kube:                  kube,
 		logger:                logger,
 		envoyGatewayNamespace: envoyGatewayNamespace,
-		extProcImage:          extProcImage,
-		extProcLogLevel:       extProcLogLevel,
 		standAlone:            standAlone,
 		uuidFn:                uf,
-		extProcAsSideCar:      extProcAsSideCar,
+		extProcBuilder:        newExtProcBuilder(options, extProcAsSideCar, logger),
 	}
 }
 
@@ -75,14 +75,12 @@ type GatewayController struct {
 	kube                  kubernetes.Interface
 	logger                logr.Logger
 	envoyGatewayNamespace string // The namespace where Envoy Gateway is deployed.
-	extProcImage          string // The image of the external processor sidecar container.
-	extProcLogLevel       string // The log level for the extproc container.
 	// standAlone indicates whether the controller is running in standalone mode.
 	standAlone bool
 	uuidFn     func() string // Function to generate a new UUID for the filter config.
-	// Whether to run the extProc container as a sidecar (true) as a normal container (false).
-	// This is essentially a workaround for old k8s versions, and we can remove this in the future.
-	extProcAsSideCar bool
+	// extProcBuilder is shared with the mutating webhook so the config hash it
+	// stamps on pods can be recomputed here to detect drift and trigger rollout.
+	*extProcBuilder
 }
 
 // Reconcile implements the reconcile.Reconciler for gwapiv1.Gateway.
@@ -155,7 +153,14 @@ func (c *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Finally, we need to annotate the pods of the gateway deployment with the new uuid to propagate the filter config Secret update faster.
 	// If the pod doesn't have the extproc container, it will roll out the deployment altogether which eventually ends up
 	// the mutation hook invoked.
-	result, err := c.annotateGatewayPods(ctx, pods, deployments, daemonSets, uid, hasEffectiveRoutes, len(mcpRoutes.Items) > 0)
+	//
+	// desiredHash is the config hash the webhook would stamp on a pod created right
+	// now with the current controller flags + this Gateway's GatewayConfig + MCP
+	// state. annotateGatewayPods compares it to each pod's stamped hash to detect
+	// extproc config drift (the webhook and reconciler share one builder, so the
+	// hashes are computed identically — see extproc_builder.go).
+	desiredHash := c.extProcContainerHash(extProcContainerInput{gatewayConfig: gwConfig, needMCP: len(mcpRoutes.Items) > 0})
+	result, err := c.annotateGatewayPods(ctx, pods, deployments, daemonSets, uid, hasEffectiveRoutes, len(mcpRoutes.Items) > 0, desiredHash)
 	if err != nil {
 		c.logger.Error(err, "Failed to annotate gateway pods", "namespace", gw.Namespace, "name", gw.Name)
 		return ctrl.Result{}, err
@@ -1058,20 +1063,36 @@ func (c *GatewayController) getBSPForInferencePool(ctx context.Context, namespac
 	return matchingBSPs[0], nil
 }
 
-// checkPodHasSideCar checks if a pod has the extproc sidecar container with correct configuration.
-func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool) bool {
+// checkPodHasSideCar checks if a pod has the extproc sidecar container with the
+// currently-desired image, log level, and (when MCP is in use) -mcpAddr.
+//
+// It returns:
+//   - hasSideCar: true when the sidecar is structurally present and matches the
+//     image/logLevel/mcpAddr expectations (the legacy drift signal).
+//   - needsRollout: true when the sidecar is present *but* its
+//     extproc-config-hash annotation is present and differs from desiredHash,
+//     i.e. the injected config (env vars, imagePullSecrets, endpointPrefixes,
+//     enableRedaction, maxRecvMsgSize, header attributes, GatewayConfig
+//     resources/securityContext/volumeMounts, …) has drifted since the pod was
+//     created. This closes the class of drift bugs that the image/logLevel/mcpAddr
+//     check could not see.
+//
+// A pod created before this annotation existed has no hash; "missing" is treated
+// as "no drift signal" (not a rollout trigger) so upgrading the controller does
+// not roll every managed proxy once. Pods recreated after the upgrade carry the
+// annotation, and any subsequent config drift is then detected.
+func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool, desiredHash string) (hasSideCar, needsRollout bool) {
 	podSpec := pod.Spec
-	hasSideCar := false
 
 	if c.extProcAsSideCar {
 		for i := range podSpec.InitContainers {
 			// If there's an extproc sidecar container with the current target image, we don't need to roll out the deployment.
-			if podSpec.InitContainers[i].Name == extProcContainerName && podSpec.InitContainers[i].Image == c.extProcImage {
+			if podSpec.InitContainers[i].Name == extProcContainerName && podSpec.InitContainers[i].Image == c.image {
 				hasSideCar = true
 				hasMCPAddr := false
 				for j := range podSpec.InitContainers[i].Args {
 					// logLevel arg should be indexed 2 based on gateway_mutator.go, but we check all args to be safe.
-					if j > 0 && podSpec.InitContainers[i].Args[j-1] == "-logLevel" && podSpec.InitContainers[i].Args[j] != c.extProcLogLevel {
+					if j > 0 && podSpec.InitContainers[i].Args[j-1] == "-logLevel" && podSpec.InitContainers[i].Args[j] != c.logLevel {
 						hasSideCar = false
 						break
 					}
@@ -1092,11 +1113,11 @@ func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool) bo
 	} else {
 		for i := range podSpec.Containers {
 			// If there's an extproc container with the current target image, we don't need to roll out the deployment.
-			if podSpec.Containers[i].Name == extProcContainerName && podSpec.Containers[i].Image == c.extProcImage {
+			if podSpec.Containers[i].Name == extProcContainerName && podSpec.Containers[i].Image == c.image {
 				hasSideCar = true
 				hasMCPAddr := false
 				for j := range podSpec.Containers[i].Args {
-					if j > 0 && podSpec.Containers[i].Args[j-1] == "-logLevel" && podSpec.Containers[i].Args[j] != c.extProcLogLevel {
+					if j > 0 && podSpec.Containers[i].Args[j-1] == "-logLevel" && podSpec.Containers[i].Args[j] != c.logLevel {
 						hasSideCar = false
 						break
 					}
@@ -1116,7 +1137,19 @@ func (c *GatewayController) checkPodHasSideCar(pod *corev1.Pod, needMCP bool) bo
 		}
 	}
 
-	return hasSideCar
+	// If the sidecar is present, additionally compare the config hash the webhook
+	// stamped at pod-creation time against the currently-desired hash. A mismatch
+	// means the injected config drifted (e.g. --extProcExtraEnvVars changed) and the
+	// pod must be rolled so the webhook re-injects the current config.
+	if hasSideCar {
+		if stamped := pod.Annotations[extProcConfigHashAnnotationKey]; stamped != "" && stamped != desiredHash {
+			needsRollout = true
+			c.logger.Info("extproc config hash mismatch, triggering rollout",
+				"pod", pod.Name, "namespace", pod.Namespace)
+		}
+	}
+
+	return hasSideCar, needsRollout
 }
 
 // isRolloutInProgress checks whether any Deployment or DaemonSet is currently rolling out.
@@ -1164,6 +1197,7 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 	uuid string,
 	hasEffectiveRoute bool,
 	needMCP bool,
+	desiredHash string,
 ) (ctrl.Result, error) {
 	if isRolloutInProgress(deployments, daemonSets) {
 		const requeueAfter = 5 * time.Second
@@ -1173,29 +1207,38 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 
 	// Detect sidecar state in one pass with early exit on inconsistent state (e.g., some pods have sidecar, some don't).
 	// If inconsistent state exists while rollout is not in progress, force rollout to self-heal.
+	//
+	// needsRollout is set when a pod has the sidecar but its stamped extproc-config-hash
+	// annotation mismatches the desired hash, i.e. the injected config has drifted.
 	seenWithSidecar := false
 	seenWithoutSidecar := false
+	seenNeedsRollout := false
 	for i := range pods {
 		if !pods[i].GetDeletionTimestamp().IsZero() {
 			continue
 		}
-		if c.checkPodHasSideCar(&pods[i], needMCP) {
+		hasSideCar, needsRollout := c.checkPodHasSideCar(&pods[i], needMCP, desiredHash)
+		if hasSideCar {
 			seenWithSidecar = true
 		} else {
 			seenWithoutSidecar = true
 		}
-		if seenWithSidecar && seenWithoutSidecar {
+		if needsRollout {
+			seenNeedsRollout = true
+		}
+		if seenWithSidecar && seenWithoutSidecar && seenNeedsRollout {
 			break
 		}
 	}
-	forceRollout := seenWithSidecar && seenWithoutSidecar
+	forceRollout := (seenWithSidecar && seenWithoutSidecar) || seenNeedsRollout
 	if forceRollout {
-		c.logger.Info("pods are inconsistent while rollout is stable, forcing rollout",
-			"podsWithSidecarSeen", seenWithSidecar, "podsWithoutSidecarSeen", seenWithoutSidecar)
+		c.logger.Info("forcing rollout",
+			"podsWithSidecarSeen", seenWithSidecar, "podsWithoutSidecarSeen", seenWithoutSidecar,
+			"podsNeedingRolloutSeen", seenNeedsRollout)
 	}
-	// When not mixed, "all have sidecar" is equivalent to seeing at least one pod with sidecar
-	// and none without sidecar. For zero pods this remains false.
-	hasSideCar := seenWithSidecar && !seenWithoutSidecar
+	// "all up to date": at least one pod with sidecar, none without, and none
+	// needing a config-driven rollout. For zero pods this remains false.
+	hasSideCar := seenWithSidecar && !seenWithoutSidecar && !seenNeedsRollout
 
 	for i := range pods {
 		pod := &pods[i]

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1207,10 +1207,12 @@ func (c *GatewayController) annotateGatewayPods(ctx context.Context,
 		}
 	}
 
-	// Roll workload templates only when pod-template state must change:
-	// 1. effective route exists but sidecar is missing;
-	// 2. no effective route exists but sidecar remains;
-	// 3. pods are inconsistent or have stamped config-hash drift.
+	// We annotate the deployments and daemonsets under three scenarios:
+	// 1. If there's an effective route but no sidecar container, we need to add the sidecar container.
+	// 2. If there's no effective route but has sidecar container,
+	//    we need to roll out the deployment to trigger the mutation webhook to remove the sidecar container.
+	// 3. If pods are inconsistent even when rollout isn't in progress, or have stamped
+	//    config-hash drift, force rollout to self-heal.
 	if hasEffectiveRoute != hasSideCar || forceRollout {
 		for i := range deployments {
 			dep := &deployments[i]

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -149,11 +149,11 @@ func (g *gatewayMutator) listMCPRoutesForGateway(ctx context.Context, gatewayNam
 }
 
 func (c *GatewayController) listAIGatewayRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {
-	return listAIGatewayRoutesForGateway(ctx, c.client, c.noCacheReader, gatewayName, gatewayNamespace)
+	return listAIGatewayRoutesForGateway(ctx, c.client, nil, gatewayName, gatewayNamespace)
 }
 
 func (c *GatewayController) listMCPRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.MCPRouteList, error) {
-	return listMCPRoutesForGateway(ctx, c.client, c.noCacheReader, gatewayName, gatewayNamespace)
+	return listMCPRoutesForGateway(ctx, c.client, nil, gatewayName, gatewayNamespace)
 }
 
 func listAIGatewayRoutesForGateway(ctx context.Context, cacheReader client.Reader, noCacheReader client.Reader, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -141,41 +141,57 @@ func ParseImagePullSecrets(s string) ([]corev1.LocalObjectReference, error) {
 }
 
 func (g *gatewayMutator) listAIGatewayRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {
+	return listAIGatewayRoutesForGateway(ctx, g.c, g.noCacheReader, gatewayName, gatewayNamespace)
+}
+
+func (g *gatewayMutator) listMCPRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.MCPRouteList, error) {
+	return listMCPRoutesForGateway(ctx, g.c, g.noCacheReader, gatewayName, gatewayNamespace)
+}
+
+func (c *GatewayController) listAIGatewayRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {
+	return listAIGatewayRoutesForGateway(ctx, c.client, c.noCacheReader, gatewayName, gatewayNamespace)
+}
+
+func (c *GatewayController) listMCPRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.MCPRouteList, error) {
+	return listMCPRoutesForGateway(ctx, c.client, c.noCacheReader, gatewayName, gatewayNamespace)
+}
+
+func listAIGatewayRoutesForGateway(ctx context.Context, cacheReader client.Reader, noCacheReader client.Reader, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {
 	var routes aigv1b1.AIGatewayRouteList
 	key := fmt.Sprintf("%s.%s", gatewayName, gatewayNamespace)
-	cacheErr := g.c.List(ctx, &routes, client.MatchingFields{
+	cacheErr := cacheReader.List(ctx, &routes, client.MatchingFields{
 		k8sClientIndexAIGatewayRouteToAttachedGateway: key,
 	})
 	if cacheErr == nil && len(routes.Items) > 0 {
 		return routes, nil
 	}
-	if g.noCacheReader == nil {
+	if noCacheReader == nil {
 		return routes, cacheErr
 	}
 	// noCacheReader doesn't have access to cache indexes, so list then filter.
 	var all aigv1b1.AIGatewayRouteList
-	if err := g.noCacheReader.List(ctx, &all); err != nil {
+	if err := noCacheReader.List(ctx, &all); err != nil {
 		return routes, fmt.Errorf("failed to list routes: %w", err)
 	}
 	routes.Items = filterAIGatewayRoutesForGateway(all.Items, gatewayName, gatewayNamespace)
 	return routes, nil
 }
 
-func (g *gatewayMutator) listMCPRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.MCPRouteList, error) {
+func listMCPRoutesForGateway(ctx context.Context, cacheReader client.Reader, noCacheReader client.Reader, gatewayName, gatewayNamespace string) (aigv1b1.MCPRouteList, error) {
 	var routes aigv1b1.MCPRouteList
 	key := fmt.Sprintf("%s.%s", gatewayName, gatewayNamespace)
-	cacheErr := g.c.List(ctx, &routes, client.MatchingFields{
+	cacheErr := cacheReader.List(ctx, &routes, client.MatchingFields{
 		k8sClientIndexMCPRouteToAttachedGateway: key,
 	})
 	if cacheErr == nil && len(routes.Items) > 0 {
 		return routes, nil
 	}
-	if g.noCacheReader == nil {
+	if noCacheReader == nil {
 		return routes, cacheErr
 	}
 	// noCacheReader doesn't have access to cache indexes, so list then filter.
 	var all aigv1b1.MCPRouteList
-	if err := g.noCacheReader.List(ctx, &all); err != nil {
+	if err := noCacheReader.List(ctx, &all); err != nil {
 		return routes, fmt.Errorf("failed to list MCP routes: %w", err)
 	}
 	routes.Items = filterMCPRoutesForGateway(all.Items, gatewayName, gatewayNamespace)

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -36,9 +36,8 @@ type gatewayMutator struct {
 	logger        logr.Logger
 
 	// extProcBuilder is the single source of truth for the injected extproc
-	// container. It is shared with the gateway reconciler so that the config
-	// hash stamped here can be recomputed identically by the reconciler to
-	// detect drift. See extproc_builder.go.
+	// container. It is shared with the gateway reconciler so that the desired
+	// config hash written to workload templates matches webhook injection.
 	*extProcBuilder
 }
 
@@ -364,15 +363,6 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 	// creation time and must stay out of the drift hash.
 	input := extProcContainerInput{gatewayConfig: gatewayConfig, needMCP: len(mcpRoutes.Items) > 0}
 	container := g.buildExtProcContainer(input)
-
-	// Stamp the config hash so the reconciler can detect drift on later
-	// controller restarts. Computed on the base container, before the
-	// secret-presence-driven args/mounts below are added — exactly what the
-	// reconciler recomputes.
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
-	}
-	pod.Annotations[extProcConfigHashAnnotationKey] = g.extProcContainerHash(input)
 
 	// Prepend the config-routing flags so the arg order matches what extproc
 	// expects (configPath/bundlePath first, then base args).

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -147,14 +147,6 @@ func (g *gatewayMutator) listMCPRoutesForGateway(ctx context.Context, gatewayNam
 	return listMCPRoutesForGateway(ctx, g.c, g.noCacheReader, gatewayName, gatewayNamespace)
 }
 
-func (c *GatewayController) listAIGatewayRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {
-	return listAIGatewayRoutesForGateway(ctx, c.client, nil, gatewayName, gatewayNamespace)
-}
-
-func (c *GatewayController) listMCPRoutesForGateway(ctx context.Context, gatewayName, gatewayNamespace string) (aigv1b1.MCPRouteList, error) {
-	return listMCPRoutesForGateway(ctx, c.client, nil, gatewayName, gatewayNamespace)
-}
-
 func listAIGatewayRoutesForGateway(ctx context.Context, cacheReader client.Reader, noCacheReader client.Reader, gatewayName, gatewayNamespace string) (aigv1b1.AIGatewayRouteList, error) {
 	var routes aigv1b1.AIGatewayRouteList
 	key := fmt.Sprintf("%s.%s", gatewayName, gatewayNamespace)

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -9,25 +9,20 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 
-	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
-	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
 // gatewayMutator implements [admission.CustomDefaulter].
@@ -40,85 +35,23 @@ type gatewayMutator struct {
 	kube          kubernetes.Interface
 	logger        logr.Logger
 
-	extProcImage                   string
-	extProcImagePullPolicy         corev1.PullPolicy
-	extProcLogLevel                string
-	extProcEnableRedaction         bool
-	udsPath                        string
-	requestHeaderAttributes        *string
-	spanRequestHeaderAttributes    *string
-	metricsRequestHeaderAttributes *string
-	logRequestHeaderAttributes     *string
-	rootPrefix                     string
-	endpointPrefixes               string
-	extProcExtraEnvVars            []corev1.EnvVar
-	extProcImagePullSecrets        []corev1.LocalObjectReference
-	extProcMaxRecvMsgSize          int
-
-	// mcpSessionEncryptionSeed is the seed used to derive the encryption key for MCP session data.
-	mcpSessionEncryptionSeed string
-	// mcpSessionEncryptionIterations is the number of iterations to use for PBKDF2 key derivation for MCP session data.
-	mcpSessionEncryptionIterations int
-	// mcpFallbackSessionEncryptionSeed is the optional fallback seed used for MCP session key rotation.
-	mcpFallbackSessionEncryptionSeed string
-	// mcpFallbackSessionEncryptionIterations is the number of iterations used in the fallback PBKDF2 key derivation for MCP session encryption.
-	mcpFallbackSessionEncryptionIterations int
-
-	// Whether to run the extProc container as a sidecar (true) as a normal container (false).
-	// This is essentially a workaround for old k8s versions, and we can remove this in the future.
-	extProcAsSideCar bool
+	// extProcBuilder is the single source of truth for the injected extproc
+	// container. It is shared with the gateway reconciler so that the config
+	// hash stamped here can be recomputed identically by the reconciler to
+	// detect drift. See extproc_builder.go.
+	*extProcBuilder
 }
 
 func newGatewayMutator(c client.Client, noCacheReader client.Reader, kube kubernetes.Interface, logger logr.Logger,
-	extProcImage string, extProcImagePullPolicy corev1.PullPolicy, extProcLogLevel string, extProcEnableRedaction bool,
-	udsPath string, requestHeaderAttributes, spanRequestHeaderAttributes, metricsRequestHeaderAttributes, logRequestHeaderAttributes *string, rootPrefix, endpointPrefixes, extProcExtraEnvVars, extProcImagePullSecrets string, extProcMaxRecvMsgSize int,
-	extProcAsSideCar bool,
-	mcpSessionEncryptionSeed string, mcpSessionEncryptionIterations int, mcpFallbackSessionEncryptionSeed string, mcpFallbackSessionEncryptionIterations int,
+	builder *extProcBuilder,
 ) *gatewayMutator {
-	var parsedEnvVars []corev1.EnvVar
-	if extProcExtraEnvVars != "" {
-		var err error
-		parsedEnvVars, err = ParseExtraEnvVars(extProcExtraEnvVars)
-		if err != nil {
-			logger.Error(err, "failed to parse extProc extra env vars, skipping",
-				"envVars", extProcExtraEnvVars)
-		}
-	}
-
-	var parsedImagePullSecrets []corev1.LocalObjectReference
-	if extProcImagePullSecrets != "" {
-		var err error
-		parsedImagePullSecrets, err = ParseImagePullSecrets(extProcImagePullSecrets)
-		if err != nil {
-			logger.Error(err, "failed to parse extProc image pull secrets, skipping",
-				"imagePullSecrets", extProcImagePullSecrets)
-		}
-	}
-
 	return &gatewayMutator{
-		c: c, codec: serializer.NewCodecFactory(Scheme),
-		noCacheReader:                          noCacheReader,
-		kube:                                   kube,
-		extProcImage:                           extProcImage,
-		extProcImagePullPolicy:                 extProcImagePullPolicy,
-		extProcLogLevel:                        extProcLogLevel,
-		extProcEnableRedaction:                 extProcEnableRedaction,
-		logger:                                 logger,
-		udsPath:                                udsPath,
-		requestHeaderAttributes:                requestHeaderAttributes,
-		spanRequestHeaderAttributes:            spanRequestHeaderAttributes,
-		metricsRequestHeaderAttributes:         metricsRequestHeaderAttributes,
-		logRequestHeaderAttributes:             logRequestHeaderAttributes,
-		rootPrefix:                             rootPrefix,
-		endpointPrefixes:                       endpointPrefixes,
-		extProcExtraEnvVars:                    parsedEnvVars,
-		extProcImagePullSecrets:                parsedImagePullSecrets,
-		extProcMaxRecvMsgSize:                  extProcMaxRecvMsgSize,
-		extProcAsSideCar:                       extProcAsSideCar,
-		mcpSessionEncryptionSeed:               mcpSessionEncryptionSeed,
-		mcpSessionEncryptionIterations:         mcpSessionEncryptionIterations,
-		mcpFallbackSessionEncryptionSeed:       mcpFallbackSessionEncryptionSeed,
-		mcpFallbackSessionEncryptionIterations: mcpFallbackSessionEncryptionIterations,
+		c:              c,
+		codec:          serializer.NewCodecFactory(Scheme),
+		noCacheReader:  noCacheReader,
+		kube:           kube,
+		logger:         logger,
+		extProcBuilder: builder,
 	}
 }
 
@@ -139,63 +72,6 @@ func (g *gatewayMutator) Default(ctx context.Context, obj runtime.Object) error 
 		return err
 	}
 	return nil
-}
-
-// buildExtProcArgs builds all command line arguments for the extproc container.
-func (g *gatewayMutator) buildExtProcArgs(filterConfigFullPath, configBundlePath string, extProcAdminPort int, needMCP bool) []string {
-	args := []string{}
-	if filterConfigFullPath != "" {
-		args = append(args, "-configPath", filterConfigFullPath)
-	}
-	if configBundlePath != "" {
-		args = append(args, "-configBundlePath", configBundlePath)
-	}
-	args = append(args,
-		"-logLevel", g.extProcLogLevel,
-		"-extProcAddr", "unix://"+g.udsPath,
-		"-adminPort", fmt.Sprintf("%d", extProcAdminPort),
-		"-rootPrefix", g.rootPrefix,
-		"-maxRecvMsgSize", fmt.Sprintf("%d", g.extProcMaxRecvMsgSize),
-	)
-	if needMCP {
-		args = append(args,
-			"-mcpAddr", ":"+strconv.Itoa(internalapi.MCPProxyPort),
-			"-mcpSessionEncryptionSeed", g.mcpSessionEncryptionSeed,
-			"-mcpSessionEncryptionIterations", strconv.Itoa(g.mcpSessionEncryptionIterations),
-		)
-		if g.mcpFallbackSessionEncryptionSeed != "" {
-			args = append(args,
-				"-mcpFallbackSessionEncryptionSeed", g.mcpFallbackSessionEncryptionSeed,
-				"-mcpFallbackSessionEncryptionIterations", strconv.Itoa(g.mcpFallbackSessionEncryptionIterations),
-			)
-		}
-	}
-
-	if g.requestHeaderAttributes != nil {
-		args = append(args, "-requestHeaderAttributes", *g.requestHeaderAttributes)
-	}
-
-	if g.spanRequestHeaderAttributes != nil {
-		args = append(args, "-spanRequestHeaderAttributes", *g.spanRequestHeaderAttributes)
-	}
-
-	if g.metricsRequestHeaderAttributes != nil {
-		args = append(args, "-metricsRequestHeaderAttributes", *g.metricsRequestHeaderAttributes)
-	}
-
-	if g.logRequestHeaderAttributes != nil {
-		args = append(args, "-logRequestHeaderAttributes", *g.logRequestHeaderAttributes)
-	}
-
-	if g.endpointPrefixes != "" {
-		args = append(args, "-endpointPrefixes", g.endpointPrefixes)
-	}
-
-	if g.extProcEnableRedaction {
-		args = append(args, "-enableRedaction")
-	}
-
-	return args
 }
 
 const (
@@ -390,21 +266,10 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 	if err != nil {
 		return fmt.Errorf("failed to fetch GatewayConfig: %w", err)
 	}
-	var (
-		extProcSpec       *aigv1b1.GatewayConfigExtProc
-		kubernetesExtProc *egv1a1.KubernetesContainerSpec
-	)
-	if gatewayConfig != nil {
-		extProcSpec = gatewayConfig.Spec.ExtProc
-		if extProcSpec != nil {
-			kubernetesExtProc = extProcSpec.Kubernetes
-		}
-	}
 
 	// Now we construct the AI Gateway managed containers and volumes.
 	filterConfigVolumeName := legacyFilterConfigVolumeName(gatewayName, gatewayNamespace)
 	filterConfigBundleVolumeName := filterConfigBundleVolumeName(gatewayName, gatewayNamespace)
-	const extProcUDSVolumeName = mutationNamePrefix + "extproc-uds"
 	volumes := []corev1.Volume{
 		{
 			Name: extProcUDSVolumeName,
@@ -464,92 +329,46 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 	podspec.Volumes = append(podspec.Volumes, volumes...)
 
 	// Add imagePullSecrets for extProc if configured
-	if len(g.extProcImagePullSecrets) > 0 {
-		podspec.ImagePullSecrets = append(podspec.ImagePullSecrets, g.extProcImagePullSecrets...)
+	if len(g.imagePullSecrets) > 0 {
+		podspec.ImagePullSecrets = append(podspec.ImagePullSecrets, g.imagePullSecrets...)
 	}
-
-	// Use resources from GatewayConfig if present.
-	var resources corev1.ResourceRequirements
-	if kubernetesExtProc != nil && kubernetesExtProc.Resources != nil {
-		resources = *kubernetesExtProc.Resources
-		g.logger.Info("using resources from GatewayConfig",
-			"gateway_name", gatewayName, "gatewayconfig_name", gatewayConfig.Name)
-	}
-
-	// Merge env vars with GatewayConfig overriding global.
-	envVars := g.mergeEnvVars(gatewayConfig)
-	image := g.resolveExtProcImage(extProcSpec)
 
 	const (
-		extProcAdminPort            = 1064
 		filterConfigMountPath       = "/etc/filter-config"
 		filterConfigFullPath        = filterConfigMountPath + "/" + FilterConfigKeyInSecret
 		filterConfigBundleMountPath = "/etc/filter-config-bundle"
 	)
 	udsMountPath := filepath.Dir(g.udsPath)
-	securityContext := &corev1.SecurityContext{
-		AllowPrivilegeEscalation: ptr.To(false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
-		Privileged:   ptr.To(false),
-		RunAsGroup:   ptr.To(int64(65532)),
-		RunAsNonRoot: ptr.To(true),
-		RunAsUser:    ptr.To(int64(65532)),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-	if kubernetesExtProc != nil && kubernetesExtProc.SecurityContext != nil {
-		securityContext = kubernetesExtProc.SecurityContext
-	}
 
-	container := corev1.Container{
-		Name:            extProcContainerName,
-		Image:           image,
-		ImagePullPolicy: g.extProcImagePullPolicy,
-		Ports: []corev1.ContainerPort{
-			{Name: "aigw-admin", ContainerPort: extProcAdminPort},
-		},
-		Args: func() []string {
-			bundlePath := ""
-			if hasBundleConfig {
-				bundlePath = filterConfigBundleMountPath
-			}
-			configPath := ""
-			if !hasBundleConfig { // for backward compatibility when upgrade from the previous version and the secret is created by the previous version
-				configPath = filterConfigFullPath
-			}
-			return g.buildExtProcArgs(configPath, bundlePath, extProcAdminPort, len(mcpRoutes.Items) > 0)
-		}(),
-		Env: envVars,
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      extProcUDSVolumeName,
-				MountPath: udsMountPath,
-				ReadOnly:  false,
-			},
-		},
-		SecurityContext: securityContext,
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Port:   intstr.FromInt32(extProcAdminPort),
-					Path:   "/health",
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			InitialDelaySeconds: 2,
-			TimeoutSeconds:      5,
-			PeriodSeconds:       10,
-			SuccessThreshold:    1,
-			FailureThreshold:    1,
-		},
-		Resources: resources,
-	}
+	// Build the extproc container via the shared builder. The builder produces the
+	// base container (image, env, base args, UDS mount, resources, securityContext,
+	// GatewayConfig volumeMounts, readiness probe); the secret-presence-driven parts
+	// (-configPath / -configBundlePath args and the legacy/bundle volumeMounts) are
+	// added below, since they depend on which filter-config secrets exist at pod
+	// creation time and must stay out of the drift hash.
+	input := extProcContainerInput{gatewayConfig: gatewayConfig, needMCP: len(mcpRoutes.Items) > 0}
+	container := g.buildExtProcContainer(input)
 
-	if kubernetesExtProc != nil && len(kubernetesExtProc.VolumeMounts) > 0 {
-		container.VolumeMounts = append(container.VolumeMounts, kubernetesExtProc.VolumeMounts...)
+	// Stamp the config hash so the reconciler can detect drift on later
+	// controller restarts. Computed on the base container, before the
+	// secret-presence-driven args/mounts below are added — exactly what the
+	// reconciler recomputes.
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[extProcConfigHashAnnotationKey] = g.extProcContainerHash(input)
+
+	// Prepend the config-routing flags so the arg order matches what extproc
+	// expects (configPath/bundlePath first, then base args).
+	configArgs := []string{}
+	if !hasBundleConfig { // for backward compatibility when upgrading from the previous version and the secret is created by the previous version
+		configArgs = append(configArgs, "-configPath", filterConfigFullPath)
+	}
+	if hasBundleConfig {
+		configArgs = append(configArgs, "-configBundlePath", filterConfigBundleMountPath)
+	}
+	if len(configArgs) > 0 {
+		container.Args = append(configArgs, container.Args...)
 	}
 
 	if hasLegacyConfig {
@@ -569,8 +388,7 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 	}
 
 	if g.extProcAsSideCar {
-		// When running as a sidecar, we want to ensure the extProc container is shutdown last after Envoy is shutdown.
-		container.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+		// RestartPolicy is set by the builder for the sidecar case.
 		podspec.InitContainers = append(podspec.InitContainers, container)
 	} else {
 		podspec.Containers = append(podspec.Containers, container)
@@ -626,77 +444,4 @@ func (g *gatewayMutator) fetchGatewayConfig(ctx context.Context, gatewayName, ga
 	g.logger.Info("found GatewayConfig for Gateway",
 		"gateway_name", gatewayName, "gatewayconfig_name", configName)
 	return &gatewayConfig, nil
-}
-
-// mergeEnvVars merges env vars; GatewayConfig overrides global while preserving order.
-func (g *gatewayMutator) mergeEnvVars(gatewayConfig *aigv1b1.GatewayConfig) []corev1.EnvVar {
-	result := make([]corev1.EnvVar, 0, len(g.extProcExtraEnvVars))
-	index := make(map[string]int, len(g.extProcExtraEnvVars))
-
-	// Add global env vars first (lowest precedence) preserving input order.
-	for _, env := range g.extProcExtraEnvVars {
-		result = append(result, env)
-		index[env.Name] = len(result) - 1
-	}
-
-	// Add GatewayConfig env vars (highest precedence) overriding in-place when names collide,
-	// otherwise append in the order they are defined.
-	if gatewayConfig != nil && gatewayConfig.Spec.ExtProc != nil && gatewayConfig.Spec.ExtProc.Kubernetes != nil {
-		for _, env := range gatewayConfig.Spec.ExtProc.Kubernetes.Env {
-			if i, ok := index[env.Name]; ok {
-				result[i] = env
-			} else {
-				result = append(result, env)
-				index[env.Name] = len(result) - 1
-			}
-		}
-	}
-
-	return result
-}
-
-// resolveExtProcImage chooses the extProc image honoring GatewayConfig overrides.
-func (g *gatewayMutator) resolveExtProcImage(extProc *aigv1b1.GatewayConfigExtProc) string {
-	if extProc == nil || extProc.Kubernetes == nil {
-		return g.extProcImage
-	}
-
-	kubernetesExtProc := extProc.Kubernetes
-	switch {
-	case kubernetesExtProc.Image != nil:
-		return *kubernetesExtProc.Image
-	case kubernetesExtProc.ImageRepository != nil:
-		return mergeImageWithRepository(g.extProcImage, *kubernetesExtProc.ImageRepository)
-	default:
-		return g.extProcImage
-	}
-}
-
-// mergeImageWithRepository reuses the tag or digest from baseImage when a repository override is provided.
-func mergeImageWithRepository(baseImage, repository string) string {
-	if repository == "" {
-		return baseImage
-	}
-
-	suffix := imageTagOrDigest(baseImage)
-	if suffix == "" {
-		return repository
-	}
-	return repository + suffix
-}
-
-// imageTagOrDigest extracts the tag (":vX") or digest ("@sha256:...") from an image reference.
-func imageTagOrDigest(image string) string {
-	if image == "" {
-		return ""
-	}
-	if idx := strings.Index(image, "@"); idx != -1 {
-		return image[idx:]
-	}
-	lastSlash := strings.LastIndex(image, "/")
-	lastColon := strings.LastIndex(image, ":")
-	if lastColon != -1 && lastColon > lastSlash {
-		return image[lastColon:]
-	}
-	return ""
 }

--- a/internal/controller/gateway_mutator_test.go
+++ b/internal/controller/gateway_mutator_test.go
@@ -995,7 +995,6 @@ func TestGatewayMutator_mutatePod_UsesNoCacheReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pod.Spec.Containers, 2)
 	require.Equal(t, extProcContainerName, pod.Spec.Containers[1].Name)
-	require.Equal(t, g.extProcContainerHash(extProcContainerInput{}), pod.Annotations[extProcConfigHashAnnotationKey])
 }
 
 func TestGatewayMutator_listAIGatewayRoutesForGateway_NoCacheReaderFallback(t *testing.T) {

--- a/internal/controller/gateway_mutator_test.go
+++ b/internal/controller/gateway_mutator_test.go
@@ -995,6 +995,7 @@ func TestGatewayMutator_mutatePod_UsesNoCacheReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pod.Spec.Containers, 2)
 	require.Equal(t, extProcContainerName, pod.Spec.Containers[1].Name)
+	require.Equal(t, g.extProcContainerHash(extProcContainerInput{}), pod.Annotations[extProcConfigHashAnnotationKey])
 }
 
 func TestGatewayMutator_listAIGatewayRoutesForGateway_NoCacheReaderFallback(t *testing.T) {

--- a/internal/controller/gateway_mutator_test.go
+++ b/internal/controller/gateway_mutator_test.go
@@ -589,11 +589,47 @@ func strPtr(value string) *string {
 
 func newTestGatewayMutator(fakeClient client.Client, fakeKube *fake2.Clientset, requestHeaderAttributes, spanRequestHeaderAttributes, metricsRequestHeaderAttributes, logRequestHeaderAttributes *string, endpointPrefixes, extProcExtraEnvVars, extProcImagePullSecrets string, sidecar bool) *gatewayMutator {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	return newGatewayMutator(
-		fakeClient, fakeClient, fakeKube, ctrl.Log, "docker.io/envoyproxy/ai-gateway-extproc:latest", corev1.PullIfNotPresent,
-		"info", false, "/tmp/extproc.sock", requestHeaderAttributes, spanRequestHeaderAttributes, metricsRequestHeaderAttributes, logRequestHeaderAttributes, "/v1", endpointPrefixes, extProcExtraEnvVars, extProcImagePullSecrets, 512*1024*1024,
-		sidecar, "seed", 100, "fallback", 200,
-	)
+	opts := &Options{
+		ExtProcImage:                           "docker.io/envoyproxy/ai-gateway-extproc:latest",
+		ExtProcImagePullPolicy:                 corev1.PullIfNotPresent,
+		ExtProcLogLevel:                        "info",
+		ExtProcEnableRedaction:                 false,
+		UDSPath:                                "/tmp/extproc.sock",
+		RequestHeaderAttributes:                requestHeaderAttributes,
+		TracingRequestHeaderAttributes:         spanRequestHeaderAttributes,
+		MetricsRequestHeaderAttributes:         metricsRequestHeaderAttributes,
+		LogRequestHeaderAttributes:             logRequestHeaderAttributes,
+		RootPrefix:                             "/v1",
+		EndpointPrefixes:                       endpointPrefixes,
+		ExtProcExtraEnvVars:                    extProcExtraEnvVars,
+		ExtProcImagePullSecrets:                extProcImagePullSecrets,
+		ExtProcMaxRecvMsgSize:                  512 * 1024 * 1024,
+		MCPSessionEncryptionSeed:               "seed",
+		MCPSessionEncryptionIterations:         100,
+		MCPFallbackSessionEncryptionSeed:       "fallback",
+		MCPFallbackSessionEncryptionIterations: 200,
+	}
+	return newGatewayMutator(fakeClient, fakeClient, fakeKube, ctrl.Log, newExtProcBuilder(opts, sidecar, ctrl.Log))
+}
+
+// defaultTestExtProcBuilder returns an extProcBuilder with the standard test
+// defaults used by the no-cache-reader mutator tests (which need a distinct
+// noCacheReader and therefore call newGatewayMutator directly).
+func defaultTestExtProcBuilder() *extProcBuilder {
+	opts := &Options{
+		ExtProcImage:                           "docker.io/envoyproxy/ai-gateway-extproc:latest",
+		ExtProcImagePullPolicy:                 corev1.PullIfNotPresent,
+		ExtProcLogLevel:                        "info",
+		ExtProcEnableRedaction:                 false,
+		UDSPath:                                "/tmp/extproc.sock",
+		RootPrefix:                             "/v1",
+		ExtProcMaxRecvMsgSize:                  512 * 1024 * 1024,
+		MCPSessionEncryptionSeed:               "seed",
+		MCPSessionEncryptionIterations:         100,
+		MCPFallbackSessionEncryptionSeed:       "fallback",
+		MCPFallbackSessionEncryptionIterations: 200,
+	}
+	return newExtProcBuilder(opts, false, ctrl.Log)
 }
 
 func TestParseExtraEnvVars(t *testing.T) {
@@ -910,7 +946,7 @@ func TestGatewayMutator_resolveExtProcImage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := &gatewayMutator{extProcImage: tt.base}
+			g := &gatewayMutator{extProcBuilder: &extProcBuilder{image: tt.base}}
 			require.Equal(t, tt.expected, g.resolveExtProcImage(tt.extProc))
 		})
 	}
@@ -920,12 +956,7 @@ func TestGatewayMutator_mutatePod_UsesNoCacheReader(t *testing.T) {
 	cacheClient := requireNewFakeClientWithIndexes(t)
 	noCacheReader := requireNewFakeClientWithIndexes(t)
 	fakeKube := fake2.NewClientset()
-	g := newGatewayMutator(
-		cacheClient, noCacheReader, fakeKube, ctrl.Log,
-		"docker.io/envoyproxy/ai-gateway-extproc:latest", corev1.PullIfNotPresent,
-		"info", false, "/tmp/extproc.sock", nil, nil, nil, nil, "/v1", "", "", "", 512*1024*1024,
-		false, "seed", 100, "fallback", 200,
-	)
+	g := newGatewayMutator(cacheClient, noCacheReader, fakeKube, ctrl.Log, defaultTestExtProcBuilder())
 
 	const gwName, gwNamespace = "test-gateway", "test-namespace"
 	// Route only in noCacheReader, not in cacheClient — simulates cache not yet synced.
@@ -970,12 +1001,7 @@ func TestGatewayMutator_listAIGatewayRoutesForGateway_NoCacheReaderFallback(t *t
 	cacheClient := requireNewFakeClientWithIndexes(t)
 	noCacheReader := requireNewFakeClientWithIndexes(t)
 	fakeKube := fake2.NewClientset()
-	g := newGatewayMutator(
-		cacheClient, noCacheReader, fakeKube, ctrl.Log,
-		"docker.io/envoyproxy/ai-gateway-extproc:latest", corev1.PullIfNotPresent,
-		"info", false, "/tmp/extproc.sock", nil, nil, nil, nil, "/v1", "", "", "", 512*1024*1024,
-		false, "seed", 100, "fallback", 200,
-	)
+	g := newGatewayMutator(cacheClient, noCacheReader, fakeKube, ctrl.Log, defaultTestExtProcBuilder())
 
 	const gwName, gwNamespace = "test-gateway", "test-namespace"
 
@@ -1014,12 +1040,7 @@ func TestGatewayMutator_listMCPRoutesForGateway_NoCacheReaderFallback(t *testing
 	cacheClient := requireNewFakeClientWithIndexes(t)
 	noCacheReader := requireNewFakeClientWithIndexes(t)
 	fakeKube := fake2.NewClientset()
-	g := newGatewayMutator(
-		cacheClient, noCacheReader, fakeKube, ctrl.Log,
-		"docker.io/envoyproxy/ai-gateway-extproc:latest", corev1.PullIfNotPresent,
-		"info", false, "/tmp/extproc.sock", nil, nil, nil, nil, "/v1", "", "", "", 512*1024*1024,
-		false, "seed", 100, "fallback", 200,
-	)
+	g := newGatewayMutator(cacheClient, noCacheReader, fakeKube, ctrl.Log, defaultTestExtProcBuilder())
 
 	const gwName, gwNamespace = "test-gateway", "test-namespace"
 

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -231,6 +231,83 @@ func TestGatewayController_Reconcile(t *testing.T) {
 	require.NotNil(t, secret)
 }
 
+func TestGatewayController_listAIGatewayRoutesForGateway_NoCacheReaderFallback(t *testing.T) {
+	cacheClient := requireNewFakeClientWithIndexes(t)
+	noCacheReader := requireNewFakeClientWithIndexes(t)
+	c := NewGatewayControllerWithAPIReader(cacheClient, noCacheReader, fake2.NewClientset(), ctrl.Log,
+		"envoy-gateway-system", false, nil, newTestExtProcOptions("docker.io/envoyproxy/ai-gateway-extproc:latest", "info"), true)
+
+	const gwName, gwNamespace = "test-gateway", "test-namespace"
+
+	err := noCacheReader.Create(t.Context(), &aigv1b1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-matching", Namespace: gwNamespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			ParentRefs: []gwapiv1.ParentReference{
+				{Name: gwapiv1.ObjectName(gwName)},
+			},
+			Rules: []aigv1b1.AIGatewayRouteRule{{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "backend"}}}},
+		},
+	})
+	require.NoError(t, err)
+
+	otherNamespace := gwapiv1.Namespace("other")
+	err = noCacheReader.Create(t.Context(), &aigv1b1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-non-matching", Namespace: gwNamespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			ParentRefs: []gwapiv1.ParentReference{
+				{Name: gwapiv1.ObjectName(gwName), Namespace: &otherNamespace},
+			},
+			Rules: []aigv1b1.AIGatewayRouteRule{{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "backend"}}}},
+		},
+	})
+	require.NoError(t, err)
+
+	routes, err := c.listAIGatewayRoutesForGateway(t.Context(), gwName, gwNamespace)
+	require.NoError(t, err)
+	require.Len(t, routes.Items, 1)
+	require.Equal(t, "route-matching", routes.Items[0].Name)
+}
+
+func TestGatewayController_listMCPRoutesForGateway_NoCacheReaderFallback(t *testing.T) {
+	cacheClient := requireNewFakeClientWithIndexes(t)
+	noCacheReader := requireNewFakeClientWithIndexes(t)
+	c := NewGatewayControllerWithAPIReader(cacheClient, noCacheReader, fake2.NewClientset(), ctrl.Log,
+		"envoy-gateway-system", false, nil, newTestExtProcOptions("docker.io/envoyproxy/ai-gateway-extproc:latest", "info"), true)
+
+	const gwName, gwNamespace = "test-gateway", "test-namespace"
+
+	err := noCacheReader.Create(t.Context(), &aigv1b1.MCPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcp-matching", Namespace: gwNamespace},
+		Spec: aigv1b1.MCPRouteSpec{
+			ParentRefs: []gwapiv1.ParentReference{
+				{Name: gwapiv1.ObjectName(gwName)},
+			},
+			BackendRefs: []aigv1b1.MCPRouteBackendRef{
+				{BackendObjectReference: gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName("server")}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	err = noCacheReader.Create(t.Context(), &aigv1b1.MCPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcp-non-matching", Namespace: gwNamespace},
+		Spec: aigv1b1.MCPRouteSpec{
+			ParentRefs: []gwapiv1.ParentReference{
+				{Name: gwapiv1.ObjectName("other-gw")},
+			},
+			BackendRefs: []aigv1b1.MCPRouteBackendRef{
+				{BackendObjectReference: gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName("other")}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	routes, err := c.listMCPRoutesForGateway(t.Context(), gwName, gwNamespace)
+	require.NoError(t, err)
+	require.Len(t, routes.Items, 1)
+	require.Equal(t, "mcp-matching", routes.Items[0].Name)
+}
+
 func TestGatewayController_reconcileFilterConfigSecret(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -231,83 +231,6 @@ func TestGatewayController_Reconcile(t *testing.T) {
 	require.NotNil(t, secret)
 }
 
-func TestGatewayController_listAIGatewayRoutesForGateway_NoCacheReaderFallback(t *testing.T) {
-	cacheClient := requireNewFakeClientWithIndexes(t)
-	noCacheReader := requireNewFakeClientWithIndexes(t)
-	c := NewGatewayControllerWithAPIReader(cacheClient, noCacheReader, fake2.NewClientset(), ctrl.Log,
-		"envoy-gateway-system", false, nil, newTestExtProcOptions("docker.io/envoyproxy/ai-gateway-extproc:latest", "info"), true)
-
-	const gwName, gwNamespace = "test-gateway", "test-namespace"
-
-	err := noCacheReader.Create(t.Context(), &aigv1b1.AIGatewayRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: "route-matching", Namespace: gwNamespace},
-		Spec: aigv1b1.AIGatewayRouteSpec{
-			ParentRefs: []gwapiv1.ParentReference{
-				{Name: gwapiv1.ObjectName(gwName)},
-			},
-			Rules: []aigv1b1.AIGatewayRouteRule{{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "backend"}}}},
-		},
-	})
-	require.NoError(t, err)
-
-	otherNamespace := gwapiv1.Namespace("other")
-	err = noCacheReader.Create(t.Context(), &aigv1b1.AIGatewayRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: "route-non-matching", Namespace: gwNamespace},
-		Spec: aigv1b1.AIGatewayRouteSpec{
-			ParentRefs: []gwapiv1.ParentReference{
-				{Name: gwapiv1.ObjectName(gwName), Namespace: &otherNamespace},
-			},
-			Rules: []aigv1b1.AIGatewayRouteRule{{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "backend"}}}},
-		},
-	})
-	require.NoError(t, err)
-
-	routes, err := c.listAIGatewayRoutesForGateway(t.Context(), gwName, gwNamespace)
-	require.NoError(t, err)
-	require.Len(t, routes.Items, 1)
-	require.Equal(t, "route-matching", routes.Items[0].Name)
-}
-
-func TestGatewayController_listMCPRoutesForGateway_NoCacheReaderFallback(t *testing.T) {
-	cacheClient := requireNewFakeClientWithIndexes(t)
-	noCacheReader := requireNewFakeClientWithIndexes(t)
-	c := NewGatewayControllerWithAPIReader(cacheClient, noCacheReader, fake2.NewClientset(), ctrl.Log,
-		"envoy-gateway-system", false, nil, newTestExtProcOptions("docker.io/envoyproxy/ai-gateway-extproc:latest", "info"), true)
-
-	const gwName, gwNamespace = "test-gateway", "test-namespace"
-
-	err := noCacheReader.Create(t.Context(), &aigv1b1.MCPRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: "mcp-matching", Namespace: gwNamespace},
-		Spec: aigv1b1.MCPRouteSpec{
-			ParentRefs: []gwapiv1.ParentReference{
-				{Name: gwapiv1.ObjectName(gwName)},
-			},
-			BackendRefs: []aigv1b1.MCPRouteBackendRef{
-				{BackendObjectReference: gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName("server")}},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	err = noCacheReader.Create(t.Context(), &aigv1b1.MCPRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: "mcp-non-matching", Namespace: gwNamespace},
-		Spec: aigv1b1.MCPRouteSpec{
-			ParentRefs: []gwapiv1.ParentReference{
-				{Name: gwapiv1.ObjectName("other-gw")},
-			},
-			BackendRefs: []aigv1b1.MCPRouteBackendRef{
-				{BackendObjectReference: gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName("other")}},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	routes, err := c.listMCPRoutesForGateway(t.Context(), gwName, gwNamespace)
-	require.NoError(t, err)
-	require.Len(t, routes.Items, 1)
-	require.Equal(t, "mcp-matching", routes.Items[0].Name)
-}
-
 func TestGatewayController_reconcileFilterConfigSecret(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
@@ -1401,7 +1324,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 		hasEffectiveRoute := true
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, nil, "some-uuid", hasEffectiveRoute, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, nil, "some-uuid", hasEffectiveRoute, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1431,7 +1354,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 
 		// Since it has already a sidecar container, passing the hasEffectiveRoute=false should result in adding an annotation to the deployment.
 		hasEffectiveRoute = false
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", hasEffectiveRoute, false, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", hasEffectiveRoute, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1474,7 +1397,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 
 		// When there's no effective route, this should not add the annotation to the deployment.
 		hasEffectiveRoute := false
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 		deployment, err = kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "deployment1", metav1.GetOptions{})
@@ -1484,7 +1407,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 
 		// When there's an effective route, this should add the annotation to the deployment.
 		hasEffectiveRoute = true
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1529,7 +1452,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1544,7 +1467,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1588,7 +1511,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1603,7 +1526,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1646,7 +1569,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call with needMCP=true - should trigger rollout due to missing -mcpAddr
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, true, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, true, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1661,7 +1584,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again - should NOT trigger another rollout
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", true, true, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", true, true, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1727,7 +1650,8 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 			nil,
 			"some-uuid",
 			true,
-			false, "")
+			false,
+			c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 
@@ -1788,7 +1712,8 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 			nil,
 			"force-rollout-uuid",
 			true,
-			false, "")
+			false,
+			c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1851,7 +1776,8 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 			nil,
 			"ignore-terminating-uuid",
 			false,
-			false, "")
+			false,
+			c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1964,7 +1890,7 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{extProcConfigHashAnnotationKey: stamp}},
 			Spec:       corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
 		}
-		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, stamp)
+		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, c.image, stamp)
 		require.True(t, hasSideCar)
 		require.False(t, needsRollout)
 	})
@@ -1972,20 +1898,21 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 	t.Run("sidecar mode: logLevel mismatch triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", "debug")}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, false, "")
+		hasSideCar, _ := c.checkPodHasSideCar(pod, false, c.image, "")
 		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
 	})
 
 	t.Run("sidecar mode: uses GatewayConfig resolved image", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
-		desiredImage := "gcr.io/custom/extproc:v2"
+		input := extProcContainerInput{gatewayConfig: testGatewayConfig}
+		desiredImage := c.extProcImage(input)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{
 			{Name: extProcContainerName, Image: desiredImage, Args: []string{"-logLevel", logLevel}},
 		}}}
-		hasSideCar, _ := c.checkPodHasSideCarWithImage(pod, false, desiredImage, "")
+		hasSideCar, _ := c.checkPodHasSideCar(pod, false, desiredImage, "")
 		require.True(t, hasSideCar)
 
-		hasSideCar, _ = c.checkPodHasSideCarWithImage(pod, false, image, "")
+		hasSideCar, _ = c.checkPodHasSideCar(pod, false, image, "")
 		require.False(t, hasSideCar, "global image must not be used when GatewayConfig resolves a different image")
 	})
 
@@ -1998,11 +1925,11 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 			Spec:       corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
 		}
 		// Matching hash: no rollout.
-		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, stamp)
+		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, c.image, stamp)
 		require.True(t, hasSideCar)
 		require.False(t, needsRollout)
 		// Drifted desired hash: rollout needed (controller side stayed; pod's stamp differs).
-		hasSideCar, needsRollout = c.checkPodHasSideCar(pod, false, "different-desired-hash")
+		hasSideCar, needsRollout = c.checkPodHasSideCar(pod, false, c.image, "different-desired-hash")
 		require.True(t, hasSideCar)
 		require.True(t, needsRollout, "hash mismatch must flag rollout")
 	})
@@ -2010,7 +1937,7 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 	t.Run("container mode: needMCP without -mcpAddr triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, true, "")
+		hasSideCar, _ := c.checkPodHasSideCar(pod, true, c.image, "")
 		require.False(t, hasSideCar, "missing -mcpAddr when MCP is needed must trigger rollout")
 	})
 
@@ -2019,14 +1946,14 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
 			extProcContainer("-logLevel", logLevel, "-mcpAddr", ":808"),
 		}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, true, "")
+		hasSideCar, _ := c.checkPodHasSideCar(pod, true, c.image, "")
 		require.True(t, hasSideCar, "with -mcpAddr present the sidecar is up to date")
 	})
 
 	t.Run("container mode: logLevel mismatch triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", "debug")}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, false, "")
+		hasSideCar, _ := c.checkPodHasSideCar(pod, false, c.image, "")
 		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
 	})
 }
@@ -2077,7 +2004,7 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	require.NoError(t, err)
 
 	// desiredHash matches the pod's stamped hash ⇒ no rollout.
-	result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-1", true, false, stampedHash)
+	result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-1", true, false, c.image, stampedHash)
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
 	dep, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
@@ -2093,7 +2020,7 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	desiredHash := changedBuilder.extProcContainerHash(extProcContainerInput{})
 	require.NotEqual(t, stampedHash, desiredHash)
 
-	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-2", true, false, desiredHash)
+	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-2", true, false, c.image, desiredHash)
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
 	dep, err = kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
@@ -2121,7 +2048,7 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	}
 	_, err = kube.AppsV1().Deployments(egNamespace).Create(t.Context(), deployment2, metav1.CreateOptions{})
 	require.NoError(t, err)
-	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*podNoHash}, []appsv1.Deployment{*deployment2}, nil, "uuid-3", true, false, desiredHash)
+	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*podNoHash}, []appsv1.Deployment{*deployment2}, nil, "uuid-3", true, false, c.image, desiredHash)
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
 	dep2, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-legacy", metav1.GetOptions{})
@@ -2153,6 +2080,7 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 		"uuid-4",
 		true,
 		false,
+		c.image,
 		desiredHash,
 	)
 	require.NoError(t, err)
@@ -2219,7 +2147,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2255,7 +2183,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2270,7 +2198,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again, but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2305,7 +2233,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2320,7 +2248,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again, but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2374,7 +2302,8 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 			[]appsv1.DaemonSet{*dss},
 			"uuid-requeue",
 			true,
-			false, "")
+			false,
+			c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 	})
@@ -2420,7 +2349,8 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 			[]appsv1.DaemonSet{*dss},
 			"uuid-force",
 			true,
-			false, "")
+			false,
+			c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2472,7 +2402,8 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 			[]appsv1.DaemonSet{*dss},
 			"uuid-ignore-terminating",
 			false,
-			false, "")
+			false,
+			c.image, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -1860,16 +1860,10 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 	})
 }
 
-// TestGatewayController_annotateGatewayPods_ConfigHashDrift verifies the
-// #2395 fix: when the injected extproc config drifts (e.g. --extProcExtraEnvVars
-// changed after the pod was created), the reconciler detects the config-hash
-// mismatch and rolls the deployment so the webhook re-injects the current
-// config. A pod with a matching hash, or with no hash (pre-upgrade pod), must
-// not trigger a rollout.
 // TestGatewayController_checkPodHasSideCar exercises both the init-container
 // (extProcAsSideCar=true) and the regular-container (extProcAsSideCar=false)
 // branches of checkPodHasSideCar, plus the logLevel mismatch, missing -mcpAddr,
-// and config-hash drift signals.
+// and GatewayConfig-resolved image signals.
 func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 	egNamespace := "envoy-gateway-system"
 	fakeClient := requireNewFakeClientWithIndexes(t)
@@ -1882,23 +1876,19 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 		return corev1.Container{Name: extProcContainerName, Image: image, Args: args}
 	}
 
-	t.Run("sidecar mode: matches and hash matches", func(t *testing.T) {
+	t.Run("sidecar mode: matches", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
-		opts := newTestExtProcOptions(image, logLevel)
-		stamp := newExtProcBuilder(opts, true, ctrl.Log).extProcContainerHash(extProcContainerInput{})
 		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{extProcConfigHashAnnotationKey: stamp}},
-			Spec:       corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
+			Spec: corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
 		}
-		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, c.image, stamp)
+		hasSideCar := c.checkPodHasSideCar(pod, false, c.image)
 		require.True(t, hasSideCar)
-		require.False(t, needsRollout)
 	})
 
 	t.Run("sidecar mode: logLevel mismatch triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", "debug")}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, false, c.image, "")
+		hasSideCar := c.checkPodHasSideCar(pod, false, c.image)
 		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
 	})
 
@@ -1909,35 +1899,26 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 		pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{
 			{Name: extProcContainerName, Image: desiredImage, Args: []string{"-logLevel", logLevel}},
 		}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, false, desiredImage, "")
+		hasSideCar := c.checkPodHasSideCar(pod, false, desiredImage)
 		require.True(t, hasSideCar)
 
-		hasSideCar, _ = c.checkPodHasSideCar(pod, false, image, "")
+		hasSideCar = c.checkPodHasSideCar(pod, false, image)
 		require.False(t, hasSideCar, "global image must not be used when GatewayConfig resolves a different image")
 	})
 
-	t.Run("container mode: matches and hash drift triggers rollout", func(t *testing.T) {
+	t.Run("container mode: matches", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
-		opts := newTestExtProcOptions(image, logLevel)
-		stamp := newExtProcBuilder(opts, false, ctrl.Log).extProcContainerHash(extProcContainerInput{})
 		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{extProcConfigHashAnnotationKey: stamp}},
-			Spec:       corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
 		}
-		// Matching hash: no rollout.
-		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, c.image, stamp)
+		hasSideCar := c.checkPodHasSideCar(pod, false, c.image)
 		require.True(t, hasSideCar)
-		require.False(t, needsRollout)
-		// Drifted desired hash: rollout needed (controller side stayed; pod's stamp differs).
-		hasSideCar, needsRollout = c.checkPodHasSideCar(pod, false, c.image, "different-desired-hash")
-		require.True(t, hasSideCar)
-		require.True(t, needsRollout, "hash mismatch must flag rollout")
 	})
 
 	t.Run("container mode: needMCP without -mcpAddr triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, true, c.image, "")
+		hasSideCar := c.checkPodHasSideCar(pod, true, c.image)
 		require.False(t, hasSideCar, "missing -mcpAddr when MCP is needed must trigger rollout")
 	})
 
@@ -1946,14 +1927,14 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
 			extProcContainer("-logLevel", logLevel, "-mcpAddr", ":808"),
 		}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, true, c.image, "")
+		hasSideCar := c.checkPodHasSideCar(pod, true, c.image)
 		require.True(t, hasSideCar, "with -mcpAddr present the sidecar is up to date")
 	})
 
 	t.Run("container mode: logLevel mismatch triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
 		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", "debug")}}}
-		hasSideCar, _ := c.checkPodHasSideCar(pod, false, c.image, "")
+		hasSideCar := c.checkPodHasSideCar(pod, false, c.image)
 		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
 	})
 }
@@ -1971,19 +1952,14 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
 
 	const image = "docker.io/envoyproxy/ai-gateway-extproc:latest"
-	// The controller and the webhook share one config: the controller builds its
-	// extProcBuilder from these options inside NewGatewayController, and here we
-	// build the matching builder the webhook would use to stamp the pod.
 	opts := newTestExtProcOptions(image, "info")
-	stampBuilder := newExtProcBuilder(opts, true, ctrl.Log)
+	baseBuilder := newExtProcBuilder(opts, true, ctrl.Log)
 	c := NewGatewayController(fakeClient, kube, ctrl.Log, egNamespace, false, func() string { return "test-uuid" }, opts, true)
+	baseHash := baseBuilder.extProcContainerHash(extProcContainerInput{})
 
-	// A pod with the sidecar and a hash stamped by the webhook (current config).
-	stampedHash := stampBuilder.extProcContainerHash(extProcContainerInput{})
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pod-current", Namespace: egNamespace, Labels: labels,
-			Annotations: map[string]string{extProcConfigHashAnnotationKey: stampedHash},
 		},
 		Spec: corev1.PodSpec{InitContainers: []corev1.Container{
 			{Name: extProcContainerName, Image: image, Args: []string{"-logLevel", "info"}},
@@ -2003,58 +1979,44 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	_, err = kube.AppsV1().Deployments(egNamespace).Create(t.Context(), deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// desiredHash matches the pod's stamped hash ⇒ no rollout.
-	result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-1", true, false, c.image, stampedHash)
+	// The reconciler writes the desired hash to the pod template so Kubernetes
+	// rolls the workload when injected extproc config changes.
+	result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-1", true, false, c.image, baseHash)
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
 	dep, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
 	require.NoError(t, err)
+	require.Equal(t, baseHash, dep.Spec.Template.Annotations[extProcConfigHashAnnotationKey])
 	_, rolled := dep.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
-	require.False(t, rolled, "no rollout when hash matches")
+	require.False(t, rolled, "hash-only rollout should not update the UUID rollout trigger")
 
-	// Simulate a controller restart with a changed flag: the builder now holds a
-	// different config, so the desired hash diverges from the pod's stamped hash.
-	changedOpts := newTestExtProcOptions(image, "info")
-	changedOpts.ExtProcExtraEnvVars = "OTEL_SERVICE_NAME=ai-gateway"
-	changedBuilder := newExtProcBuilder(changedOpts, true, ctrl.Log)
-	desiredHash := changedBuilder.extProcContainerHash(extProcContainerInput{})
-	require.NotEqual(t, stampedHash, desiredHash)
-
-	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-2", true, false, c.image, desiredHash)
+	// A current template hash should not trigger another template update.
+	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*dep}, nil, "uuid-2", true, false, c.image, baseHash)
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
 	dep, err = kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, "uuid-2", dep.Spec.Template.Annotations[aigatewayUUIDAnnotationKey],
-		"hash mismatch must trigger a rollout so the webhook re-injects the current config")
+	require.Equal(t, baseHash, dep.Spec.Template.Annotations[extProcConfigHashAnnotationKey])
+	_, rolled = dep.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
+	require.False(t, rolled, "current template hash must not trigger UUID rollout")
 
-	// A pre-upgrade pod with NO hash annotation must not be rolled by the hash
-	// signal (missing ⇒ fall back to legacy image/logLevel check).
-	podNoHash := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "pod-legacy", Namespace: egNamespace, Labels: labels},
-		Spec: corev1.PodSpec{InitContainers: []corev1.Container{
-			{Name: extProcContainerName, Image: image, Args: []string{"-logLevel", "info"}},
-		}},
-	}
-	_, err = kube.CoreV1().Pods(egNamespace).Create(t.Context(), podNoHash, metav1.CreateOptions{})
-	require.NoError(t, err)
-	deployment2 := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "dep-legacy", Namespace: egNamespace, Labels: labels},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To(int32(1)),
-			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
-		},
-		Status: appsv1.DeploymentStatus{ObservedGeneration: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, Replicas: 1},
-	}
-	_, err = kube.AppsV1().Deployments(egNamespace).Create(t.Context(), deployment2, metav1.CreateOptions{})
-	require.NoError(t, err)
-	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*podNoHash}, []appsv1.Deployment{*deployment2}, nil, "uuid-3", true, false, c.image, desiredHash)
+	// Simulate a controller restart with a changed flag: the desired hash now
+	// differs from the workload template hash.
+	changedOpts := newTestExtProcOptions(image, "info")
+	changedOpts.ExtProcExtraEnvVars = "OTEL_SERVICE_NAME=ai-gateway"
+	changedBuilder := newExtProcBuilder(changedOpts, true, ctrl.Log)
+	desiredHash := changedBuilder.extProcContainerHash(extProcContainerInput{})
+	require.NotEqual(t, baseHash, desiredHash)
+
+	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*dep}, nil, "uuid-3", true, false, c.image, desiredHash)
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
-	dep2, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-legacy", metav1.GetOptions{})
+	dep, err = kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
 	require.NoError(t, err)
-	_, rolled = dep2.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
-	require.False(t, rolled, "missing hash annotation must not trigger a rollout")
+	require.Equal(t, desiredHash, dep.Spec.Template.Annotations[extProcConfigHashAnnotationKey],
+		"hash drift must update the template hash so Kubernetes rolls the workload")
+	_, rolled = dep.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
+	require.False(t, rolled, "hash drift is handled by the template hash, not the UUID rollout trigger")
 
 	podWithoutSidecar := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "pod-no-sidecar", Namespace: egNamespace, Labels: labels},
@@ -2066,7 +2028,9 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "dep-mixed-drift", Namespace: egNamespace, Labels: labels},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.To(int32(1)),
-			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{extProcConfigHashAnnotationKey: baseHash},
+			}},
 		},
 		Status: appsv1.DeploymentStatus{ObservedGeneration: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, Replicas: 1},
 	}
@@ -2074,7 +2038,7 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	require.NoError(t, err)
 
 	result, err = c.annotateGatewayPods(t.Context(),
-		[]corev1.Pod{*podNoHash, *podWithoutSidecar, *pod},
+		[]corev1.Pod{*podWithoutSidecar, *pod},
 		[]appsv1.Deployment{*deployment3},
 		nil,
 		"uuid-4",
@@ -2088,13 +2052,14 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	dep3, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-mixed-drift", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "uuid-4", dep3.Spec.Template.Annotations[aigatewayUUIDAnnotationKey],
-		"mixed pod state plus hash drift must trigger rollout")
+		"mixed pod state must keep using the UUID rollout trigger")
+	require.Equal(t, desiredHash, dep3.Spec.Template.Annotations[extProcConfigHashAnnotationKey],
+		"mixed pod state plus hash drift should update both template rollout annotations")
 }
 
 // newTestExtProcOptions returns the Options the gateway controller tests use to
-// build a GatewayController (and, via newExtProcBuilder, the matching builder the
-// webhook would use to stamp a pod). Keeping one Options source makes the
-// controller's internal hash and the test's stamped hash identical.
+// build a GatewayController. Keeping one Options source makes the controller's
+// internal hash and the test's desired hash identical.
 func newTestExtProcOptions(image, logLevel string) *Options {
 	return &Options{
 		ExtProcImage:                           image,

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -231,6 +231,99 @@ func TestGatewayController_Reconcile(t *testing.T) {
 	require.NotNil(t, secret)
 }
 
+func TestGatewayController_Reconcile_GatewayConfigImageOverrideNoWorkloadPatch(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	fakeKube := fake2.NewClientset()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
+
+	const (
+		gwName      = "gc-image-gw"
+		namespace   = "ns"
+		egNamespace = "envoy-gateway-system"
+		globalImage = "docker.io/envoyproxy/ai-gateway-extproc:latest"
+	)
+	opts := newTestExtProcOptions(globalImage, "info")
+	c := NewGatewayController(fakeClient, fakeKube, ctrl.Log, egNamespace, false, func() string { return "uuid" }, opts, true)
+
+	gatewayConfig := testGatewayConfig.DeepCopy()
+	gatewayConfig.Namespace = namespace
+	require.NoError(t, fakeClient.Create(t.Context(), gatewayConfig))
+
+	require.NoError(t, fakeClient.Create(t.Context(), &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gwName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				GatewayConfigAnnotationKey: gatewayConfig.Name,
+			},
+		},
+	}))
+
+	parentRefs := []gwapiv1a2.ParentReference{{Name: gwName}}
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: namespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			ParentRefs: parentRefs,
+			Rules: []aigv1b1.AIGatewayRouteRule{
+				{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "backend"}}},
+			},
+		},
+	}))
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: namespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "service", Namespace: ptr.To[gwapiv1.Namespace](namespace)},
+		},
+	}))
+
+	input := extProcContainerInput{gatewayConfig: gatewayConfig}
+	desiredImage := c.extProcImage(input)
+	desiredHash := c.extProcContainerHash(input)
+	labels := map[string]string{
+		egOwningGatewayNameLabel:      gwName,
+		egOwningGatewayNamespaceLabel: namespace,
+	}
+	_, err := fakeKube.CoreV1().Pods(egNamespace).Create(t.Context(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-pod", Namespace: egNamespace, Labels: labels},
+		Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+			{Name: extProcContainerName, Image: desiredImage, Args: []string{"-logLevel", "info"}},
+		}},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = fakeKube.AppsV1().Deployments(egNamespace).Create(t.Context(), &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-deployment", Namespace: egNamespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{extProcConfigHashAnnotationKey: desiredHash},
+			}},
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			ReadyReplicas:      1,
+			AvailableReplicas:  1,
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	beforeActions := len(fakeKube.Actions())
+	res, err := c.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: gwName, Namespace: namespace}})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, res)
+
+	for _, action := range fakeKube.Actions()[beforeActions:] {
+		require.Falsef(t, action.GetVerb() == "patch" && action.GetResource().Resource == "deployments",
+			"reconcile should not patch workload when GatewayConfig image and template hash are current: %#v", action)
+	}
+	deployment, err := fakeKube.AppsV1().Deployments(egNamespace).Get(t.Context(), "gw-deployment", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, desiredHash, deployment.Spec.Template.Annotations[extProcConfigHashAnnotationKey])
+	_, exists := deployment.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
+	require.False(t, exists)
+}
+
 func TestGatewayController_reconcileFilterConfigSecret(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
@@ -2120,6 +2213,46 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		deployment, err := kube.AppsV1().DaemonSets(egNamespace).Get(t.Context(), "deployment1", metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Equal(t, "some-uuid", deployment.Spec.Template.Annotations[aigatewayUUIDAnnotationKey])
+	})
+
+	t.Run("current sidecar with desired hash patches daemonset template hash only", func(t *testing.T) {
+		pod, err := kube.CoreV1().Pods(egNamespace).Create(t.Context(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-ds-current-hash",
+				Namespace: egNamespace,
+				Labels:    labels,
+			},
+			Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+				{Name: extProcContainerName, Image: c.image, Args: []string{"-logLevel", logLevel}},
+			}},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		dss, err := kube.AppsV1().DaemonSets(egNamespace).Create(t.Context(), &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "daemonset-current-hash",
+				Namespace: egNamespace,
+				Labels:    labels,
+			},
+			Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}}},
+			Status: appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				CurrentNumberScheduled: 1,
+				UpdatedNumberScheduled: 1,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		const desiredHash = "daemonset-desired-hash"
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "uuid-hash", true, false, c.image, desiredHash)
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		dss, err = kube.AppsV1().DaemonSets(egNamespace).Get(t.Context(), "daemonset-current-hash", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, desiredHash, dss.Spec.Template.Annotations[extProcConfigHashAnnotationKey])
+		_, exists := dss.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
+		require.False(t, exists)
 	})
 
 	t.Run("pod with extproc but old version", func(t *testing.T) {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,25 @@ func requireLLMRequestCostsEqual(t *testing.T, want, got []filterapi.LLMRequestC
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
 		t.Fatalf("LLMRequestCosts not equal (-want +got):\n%s", diff)
 	}
+}
+
+// newTestGatewayController builds a GatewayController for tests, deriving the
+// extproc builder from the given image/logLevel/sidecar via the same
+// newExtProcBuilder NewGatewayController uses. It mirrors the pre-refactor
+// NewGatewayController signature so existing tests read cleanly.
+func newTestGatewayController(c client.Client, kube kubernetes.Interface, logger logr.Logger, ns, extProcImage, extProcLogLevel string, standAlone bool, uuidFn func() string, extProcAsSideCar bool) *GatewayController {
+	opts := &Options{
+		ExtProcImage:                           extProcImage,
+		ExtProcLogLevel:                        extProcLogLevel,
+		UDSPath:                                "/tmp/extproc.sock",
+		RootPrefix:                             "/",
+		ExtProcMaxRecvMsgSize:                  512 * 1024 * 1024,
+		MCPSessionEncryptionSeed:               "seed",
+		MCPSessionEncryptionIterations:         100,
+		MCPFallbackSessionEncryptionSeed:       "fallback",
+		MCPFallbackSessionEncryptionIterations: 200,
+	}
+	return NewGatewayController(c, kube, logger, ns, standAlone, uuidFn, opts, extProcAsSideCar)
 }
 
 func requireFilterConfigFromBundle(t *testing.T, kube kubernetes.Interface, namespace, gatewayName, gatewayNamespace string) filterapi.Config {
@@ -93,7 +113,7 @@ func TestGatewayController_Reconcile(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	fakeKube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, fakeKube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, fakeKube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const namespace = "ns"
@@ -215,7 +235,7 @@ func TestGatewayController_reconcileFilterConfigSecret(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -392,7 +412,7 @@ func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *t
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -482,7 +502,7 @@ func TestGatewayController_reconcileFilterConfigSecret_AllUnscopedRoutesLeaveUns
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -532,7 +552,7 @@ func TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostA
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -627,7 +647,7 @@ func TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostA
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -677,7 +697,7 @@ func TestGatewayController_reconcileFilterConfigSecret_InvalidCELExpression(t *t
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -715,7 +735,7 @@ func TestGatewayController_reconcileFilterConfigSecret_SkipsDeletedRoutes(t *tes
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -848,7 +868,7 @@ func TestGatewayController_bspToFilterAPIBackendAuth(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const namespace = "ns"
@@ -1048,7 +1068,7 @@ func TestGatewayController_bspToFilterAPIBackendAuth(t *testing.T) {
 
 func TestGatewayController_bspToFilterAPIBackendAuth_ErrorCases(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
-	c := NewGatewayController(fakeClient, fake2.NewClientset(), ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, fake2.NewClientset(), ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	ctx := context.Background()
@@ -1225,7 +1245,7 @@ func TestResolveCredentialOverride(t *testing.T) {
 func TestGatewayController_bspToFilterAPIBackendAuth_WithOverride(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const namespace = "ns"
@@ -1263,7 +1283,7 @@ func TestGatewayController_bspToFilterAPIBackendAuth_WithOverride(t *testing.T) 
 
 func TestGatewayController_GetSecretData_ErrorCases(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
-	c := NewGatewayController(fakeClient, fake2.NewClientset(), ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, fake2.NewClientset(), ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	ctx := context.Background()
@@ -1289,7 +1309,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
 	const v2Container = "ai-gateway-extproc:v2"
 	const logLevel = "info"
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		v2Container, logLevel, false, nil, true)
 	t.Run("pod with extproc", func(t *testing.T) {
 		pod, err := kube.CoreV1().Pods(egNamespace).Create(t.Context(), &corev1.Pod{
@@ -1299,12 +1319,12 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 				Labels:    labels,
 			},
 			Spec: corev1.PodSpec{InitContainers: []corev1.Container{
-				{Name: extProcContainerName, Image: c.extProcImage},
+				{Name: extProcContainerName, Image: c.image},
 			}},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 		hasEffectiveRoute := true
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, nil, "some-uuid", hasEffectiveRoute, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, nil, "some-uuid", hasEffectiveRoute, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1334,7 +1354,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 
 		// Since it has already a sidecar container, passing the hasEffectiveRoute=false should result in adding an annotation to the deployment.
 		hasEffectiveRoute = false
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", hasEffectiveRoute, false)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", hasEffectiveRoute, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1377,7 +1397,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 
 		// When there's no effective route, this should not add the annotation to the deployment.
 		hasEffectiveRoute := false
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 		deployment, err = kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "deployment1", metav1.GetOptions{})
@@ -1387,7 +1407,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 
 		// When there's an effective route, this should add the annotation to the deployment.
 		hasEffectiveRoute = true
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", hasEffectiveRoute, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1432,7 +1452,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1447,7 +1467,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1491,7 +1511,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1506,7 +1526,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1549,7 +1569,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call with needMCP=true - should trigger rollout due to missing -mcpAddr
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, true)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "some-uuid", true, true, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1564,7 +1584,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again - should NOT trigger another rollout
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", true, true)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "another-uuid", true, true, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1630,7 +1650,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 			nil,
 			"some-uuid",
 			true,
-			false)
+			false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 
@@ -1691,7 +1711,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 			nil,
 			"force-rollout-uuid",
 			true,
-			false)
+			false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1754,7 +1774,7 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 			nil,
 			"ignore-terminating-uuid",
 			false,
-			false)
+			false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1837,6 +1857,207 @@ func TestGatewayController_annotateGatewayPods(t *testing.T) {
 	})
 }
 
+// TestGatewayController_annotateGatewayPods_ConfigHashDrift verifies the
+// #2395 fix: when the injected extproc config drifts (e.g. --extProcExtraEnvVars
+// changed after the pod was created), the reconciler detects the config-hash
+// mismatch and rolls the deployment so the webhook re-injects the current
+// config. A pod with a matching hash, or with no hash (pre-upgrade pod), must
+// not trigger a rollout.
+// TestGatewayController_checkPodHasSideCar exercises both the init-container
+// (extProcAsSideCar=true) and the regular-container (extProcAsSideCar=false)
+// branches of checkPodHasSideCar, plus the logLevel mismatch, missing -mcpAddr,
+// and config-hash drift signals.
+func TestGatewayController_checkPodHasSideCar(t *testing.T) {
+	egNamespace := "envoy-gateway-system"
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+
+	const image = "docker.io/envoyproxy/ai-gateway-extproc:latest"
+	const logLevel = "info"
+
+	extProcContainer := func(args ...string) corev1.Container {
+		return corev1.Container{Name: extProcContainerName, Image: image, Args: args}
+	}
+
+	t.Run("sidecar mode: matches and hash matches", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
+		opts := newTestExtProcOptions(image, logLevel)
+		stamp := newExtProcBuilder(opts, true, ctrl.Log).extProcContainerHash(extProcContainerInput{})
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{extProcConfigHashAnnotationKey: stamp}},
+			Spec:       corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
+		}
+		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, stamp)
+		require.True(t, hasSideCar)
+		require.False(t, needsRollout)
+	})
+
+	t.Run("sidecar mode: logLevel mismatch triggers rollout", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
+		pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{extProcContainer("-logLevel", "debug")}}}
+		hasSideCar, _ := c.checkPodHasSideCar(pod, false, "")
+		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
+	})
+
+	t.Run("container mode: matches and hash drift triggers rollout", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
+		opts := newTestExtProcOptions(image, logLevel)
+		stamp := newExtProcBuilder(opts, false, ctrl.Log).extProcContainerHash(extProcContainerInput{})
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{extProcConfigHashAnnotationKey: stamp}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}},
+		}
+		// Matching hash: no rollout.
+		hasSideCar, needsRollout := c.checkPodHasSideCar(pod, false, stamp)
+		require.True(t, hasSideCar)
+		require.False(t, needsRollout)
+		// Drifted desired hash: rollout needed (controller side stayed; pod's stamp differs).
+		hasSideCar, needsRollout = c.checkPodHasSideCar(pod, false, "different-desired-hash")
+		require.True(t, hasSideCar)
+		require.True(t, needsRollout, "hash mismatch must flag rollout")
+	})
+
+	t.Run("container mode: needMCP without -mcpAddr triggers rollout", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
+		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", logLevel)}}}
+		hasSideCar, _ := c.checkPodHasSideCar(pod, true, "")
+		require.False(t, hasSideCar, "missing -mcpAddr when MCP is needed must trigger rollout")
+	})
+
+	t.Run("container mode: needMCP with -mcpAddr keeps sidecar", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
+		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+			extProcContainer("-logLevel", logLevel, "-mcpAddr", ":808"),
+		}}}
+		hasSideCar, _ := c.checkPodHasSideCar(pod, true, "")
+		require.True(t, hasSideCar, "with -mcpAddr present the sidecar is up to date")
+	})
+
+	t.Run("container mode: logLevel mismatch triggers rollout", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
+		pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{extProcContainer("-logLevel", "debug")}}}
+		hasSideCar, _ := c.checkPodHasSideCar(pod, false, "")
+		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
+	})
+}
+
+func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
+	egNamespace := "envoy-gateway-system"
+	gwName, gwNamespace := "gw", "ns"
+	labels := map[string]string{
+		egOwningGatewayNameLabel:      gwName,
+		egOwningGatewayNamespaceLabel: gwNamespace,
+	}
+
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
+
+	const image = "docker.io/envoyproxy/ai-gateway-extproc:latest"
+	// The controller and the webhook share one config: the controller builds its
+	// extProcBuilder from these options inside NewGatewayController, and here we
+	// build the matching builder the webhook would use to stamp the pod.
+	opts := newTestExtProcOptions(image, "info")
+	stampBuilder := newExtProcBuilder(opts, true, ctrl.Log)
+	c := NewGatewayController(fakeClient, kube, ctrl.Log, egNamespace, false, func() string { return "test-uuid" }, opts, true)
+
+	// A pod with the sidecar and a hash stamped by the webhook (current config).
+	stampedHash := stampBuilder.extProcContainerHash(extProcContainerInput{})
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-current", Namespace: egNamespace, Labels: labels,
+			Annotations: map[string]string{extProcConfigHashAnnotationKey: stampedHash},
+		},
+		Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+			{Name: extProcContainerName, Image: image, Args: []string{"-logLevel", "info"}},
+		}},
+	}
+	_, err := kube.CoreV1().Pods(egNamespace).Create(t.Context(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dep-current", Namespace: egNamespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
+		},
+		Status: appsv1.DeploymentStatus{ObservedGeneration: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, Replicas: 1},
+	}
+	_, err = kube.AppsV1().Deployments(egNamespace).Create(t.Context(), deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// desiredHash matches the pod's stamped hash ⇒ no rollout.
+	result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-1", true, false, stampedHash)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	dep, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, rolled := dep.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
+	require.False(t, rolled, "no rollout when hash matches")
+
+	// Simulate a controller restart with a changed flag: the builder now holds a
+	// different config, so the desired hash diverges from the pod's stamped hash.
+	changedOpts := newTestExtProcOptions(image, "info")
+	changedOpts.ExtProcExtraEnvVars = "OTEL_SERVICE_NAME=ai-gateway"
+	changedBuilder := newExtProcBuilder(changedOpts, true, ctrl.Log)
+	desiredHash := changedBuilder.extProcContainerHash(extProcContainerInput{})
+	require.NotEqual(t, stampedHash, desiredHash)
+
+	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, []appsv1.Deployment{*deployment}, nil, "uuid-2", true, false, desiredHash)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	dep, err = kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-current", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "uuid-2", dep.Spec.Template.Annotations[aigatewayUUIDAnnotationKey],
+		"hash mismatch must trigger a rollout so the webhook re-injects the current config")
+
+	// A pre-upgrade pod with NO hash annotation must not be rolled by the hash
+	// signal (missing ⇒ fall back to legacy image/logLevel check).
+	podNoHash := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-legacy", Namespace: egNamespace, Labels: labels},
+		Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+			{Name: extProcContainerName, Image: image, Args: []string{"-logLevel", "info"}},
+		}},
+	}
+	_, err = kube.CoreV1().Pods(egNamespace).Create(t.Context(), podNoHash, metav1.CreateOptions{})
+	require.NoError(t, err)
+	deployment2 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dep-legacy", Namespace: egNamespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
+		},
+		Status: appsv1.DeploymentStatus{ObservedGeneration: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, Replicas: 1},
+	}
+	_, err = kube.AppsV1().Deployments(egNamespace).Create(t.Context(), deployment2, metav1.CreateOptions{})
+	require.NoError(t, err)
+	result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*podNoHash}, []appsv1.Deployment{*deployment2}, nil, "uuid-3", true, false, desiredHash)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	dep2, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-legacy", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, rolled = dep2.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
+	require.False(t, rolled, "missing hash annotation must not trigger a rollout")
+}
+
+// newTestExtProcOptions returns the Options the gateway controller tests use to
+// build a GatewayController (and, via newExtProcBuilder, the matching builder the
+// webhook would use to stamp a pod). Keeping one Options source makes the
+// controller's internal hash and the test's stamped hash identical.
+func newTestExtProcOptions(image, logLevel string) *Options {
+	return &Options{
+		ExtProcImage:                           image,
+		ExtProcLogLevel:                        logLevel,
+		UDSPath:                                "/tmp/extproc.sock",
+		RootPrefix:                             "/",
+		ExtProcMaxRecvMsgSize:                  512 * 1024 * 1024,
+		MCPSessionEncryptionSeed:               "seed",
+		MCPSessionEncryptionIterations:         100,
+		MCPFallbackSessionEncryptionSeed:       "fallback",
+		MCPFallbackSessionEncryptionIterations: 200,
+	}
+}
+
 func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 	egNamespace := "envoy-gateway-system"
 	gwName, gwNamepsace := "gw", "ns"
@@ -1850,7 +2071,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
 	const v2Container = "ai-gateway-extproc:v2"
 	const logLevel = "info"
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		v2Container, logLevel, false, nil, true)
 
 	t.Run("pod without extproc", func(t *testing.T) {
@@ -1875,7 +2096,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1911,7 +2132,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1926,7 +2147,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again, but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1961,7 +2182,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false)
+		result, err := c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -1976,7 +2197,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call annotateGatewayPods again, but the deployment's pod template should not be updated again.
-		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false)
+		result, err = c.annotateGatewayPods(t.Context(), []corev1.Pod{*pod}, nil, []appsv1.DaemonSet{*dss}, "some-uuid", true, false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2030,7 +2251,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 			[]appsv1.DaemonSet{*dss},
 			"uuid-requeue",
 			true,
-			false)
+			false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 	})
@@ -2076,7 +2297,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 			[]appsv1.DaemonSet{*dss},
 			"uuid-force",
 			true,
-			false)
+			false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2128,7 +2349,7 @@ func TestGatewayController_annotateDaemonSetGatewayPods(t *testing.T) {
 			[]appsv1.DaemonSet{*dss},
 			"uuid-ignore-terminating",
 			false,
-			false)
+			false, "")
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
@@ -2263,7 +2484,7 @@ func TestGatewayController_backendWithMaybeBSP(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
 	const v2Container = "ai-gateway-extproc:v2"
 	const logLevel = "info"
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system", v2Container, logLevel, false, nil, true)
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system", v2Container, logLevel, false, nil, true)
 
 	_, _, err := c.backendWithMaybeBSP(t.Context(), "foo", "bar")
 	require.ErrorContains(t, err, `aiservicebackends.aigateway.envoyproxy.io "bar" not found`)
@@ -2322,7 +2543,7 @@ func TestGatewayController_reconcileFilterMCPConfigSecret(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	const gwNamespace = "ns"
@@ -2406,7 +2627,7 @@ func TestGatewayController_writeFilterConfigBundleShards(t *testing.T) {
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	namespace := "ns"
@@ -2453,7 +2674,7 @@ func TestGatewayController_writeFilterConfigBundleShards_Overflow(t *testing.T) 
 	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	payload := []byte(strings.Repeat("x", filterConfigBundlePartSizeBytes*(maxFilterConfigBundleSlots+1)))
@@ -2895,7 +3116,7 @@ func TestGatewayController_reconcileFilterConfigSecret_GlobalDefaults(t *testing
 			fakeClient := requireNewFakeClientWithIndexes(t)
 			kube := fake2.NewClientset()
 			ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
-			c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+			c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 				"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 			const gwNamespace = "ns"
@@ -3111,7 +3332,7 @@ func TestGatewayController_getObjectsForGatewayNamespaceInconsistency(t *testing
 	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNamespace}}
 
 	kube := fake2.NewClientset()
-	c := NewGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, egNamespace,
+	c := newTestGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, egNamespace,
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	// Place a pod in the gateway namespace and a pod in the envoy-gateway namespace so that
@@ -3137,7 +3358,7 @@ func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
 	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
 
 	kube := fake2.NewClientset()
-	c := NewGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, ns,
+	c := newTestGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, ns,
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
 	_, err := kube.CoreV1().Pods(ns).Create(t.Context(), &corev1.Pod{

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -1976,6 +1976,19 @@ func TestGatewayController_checkPodHasSideCar(t *testing.T) {
 		require.False(t, hasSideCar, "logLevel mismatch must clear hasSideCar")
 	})
 
+	t.Run("sidecar mode: uses GatewayConfig resolved image", func(t *testing.T) {
+		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, true)
+		desiredImage := "gcr.io/custom/extproc:v2"
+		pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+			{Name: extProcContainerName, Image: desiredImage, Args: []string{"-logLevel", logLevel}},
+		}}}
+		hasSideCar, _ := c.checkPodHasSideCarWithImage(pod, false, desiredImage, "")
+		require.True(t, hasSideCar)
+
+		hasSideCar, _ = c.checkPodHasSideCarWithImage(pod, false, image, "")
+		require.False(t, hasSideCar, "global image must not be used when GatewayConfig resolves a different image")
+	})
+
 	t.Run("container mode: matches and hash drift triggers rollout", func(t *testing.T) {
 		c := newTestGatewayController(fakeClient, kube, ctrl.Log, egNamespace, image, logLevel, false, nil, false)
 		opts := newTestExtProcOptions(image, logLevel)

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -2038,6 +2038,39 @@ func TestGatewayController_annotateGatewayPods_ConfigHashDrift(t *testing.T) {
 	require.NoError(t, err)
 	_, rolled = dep2.Spec.Template.Annotations[aigatewayUUIDAnnotationKey]
 	require.False(t, rolled, "missing hash annotation must not trigger a rollout")
+
+	podWithoutSidecar := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-no-sidecar", Namespace: egNamespace, Labels: labels},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "envoy", Image: "envoyproxy/envoy"}}},
+	}
+	_, err = kube.CoreV1().Pods(egNamespace).Create(t.Context(), podWithoutSidecar, metav1.CreateOptions{})
+	require.NoError(t, err)
+	deployment3 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dep-mixed-drift", Namespace: egNamespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
+		},
+		Status: appsv1.DeploymentStatus{ObservedGeneration: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, Replicas: 1},
+	}
+	_, err = kube.AppsV1().Deployments(egNamespace).Create(t.Context(), deployment3, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	result, err = c.annotateGatewayPods(t.Context(),
+		[]corev1.Pod{*podNoHash, *podWithoutSidecar, *pod},
+		[]appsv1.Deployment{*deployment3},
+		nil,
+		"uuid-4",
+		true,
+		false,
+		desiredHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	dep3, err := kube.AppsV1().Deployments(egNamespace).Get(t.Context(), "dep-mixed-drift", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "uuid-4", dep3.Spec.Template.Annotations[aigatewayUUIDAnnotationKey],
+		"mixed pod state plus hash drift must trigger rollout")
 }
 
 // newTestExtProcOptions returns the Options the gateway controller tests use to


### PR DESCRIPTION
**Description**

The mutating webhook injects the extproc container config only at pod creation time, but the previous drift check only compared the container image, `-logLevel`, and `-mcpAddr` presence. Restarting the controller with changed extproc settings, or editing `GatewayConfig.spec.extProc.kubernetes`, could leave existing pods running stale injected config until they were recreated for some unrelated reason.

This PR computes a stable desired hash from the extproc injection inputs and writes it to the Deployment/DaemonSet pod template annotation `aigateway.envoyproxy.io/extproc-config-hash`. Kubernetes then owns the rollout whenever injected extproc config changes.

Upgrade behavior: workloads created before this annotation existed will not have the desired hash on their pod template. On the next Gateway reconcile, Deployments/DaemonSets with effective routes get the template hash annotation and Kubernetes performs one rollout to converge pods onto the current injected extproc config. After that first convergence rollout, reconciles are no-op unless the desired hash changes again.

The existing direct pod UUID annotation path remains for filter-config Secret refresh because it speeds projected-volume updates without restarting pods. Workload pod template patching is limited to cases where pod template state must change: sidecar add/remove, inconsistent pod state self-heal, or extproc config hash drift.

To avoid rollout loops from Kubernetes API shape/defaulting changes, the hash serializes an explicit digest of the inputs that affect extproc injection instead of hashing a full `corev1.Container`. The hash covers controller flags, GatewayConfig extproc settings, image pull secrets, and MCP input. It intentionally excludes secret-presence-driven `-configPath` / `-configBundlePath` args and legacy/bundle volume mounts.

**Related Issues/PRs (if applicable)**

Fixes #2395

**Special notes for reviewers (if applicable)**

- The shared builder in `internal/controller/extproc_builder.go` is the single source of truth for the injected container and the desired template hash.
- `GatewayConfig.spec.extProc.kubernetes.image` / `imageRepository` are used when checking whether an existing extproc sidecar is current.
- The reconciler uses the cached route-list path; the no-cache fallback remains only on the admission webhook path.
- Tests cover deterministic hashing, drift-relevant inputs, GatewayConfig-resolved image checks, and Deployment/DaemonSet template hash rollout behavior.