### PR TITLE
fix: sign AWS Bedrock SigV4 over the backend endpoint host

### DIFF
--- a/internal/backendauth/aws.go
+++ b/internal/backendauth/aws.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -29,6 +30,9 @@ type awsHandler struct {
 	credentialsProvider aws.CredentialsProvider
 	signer              *v4.Signer
 	region              string
+	// hostname is the upstream endpoint host to sign over. Empty falls back to the
+	// region-default bedrock-runtime.<region>.amazonaws.com.
+	hostname string
 }
 
 func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.BackendAuthHandler, error) {
@@ -38,6 +42,15 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 
 	var cfg aws.Config
 	var err error
+
+	// The SigV4 credential scope and the STS region must be the region the request
+	// actually reaches. When the endpoint is a Bedrock host (canonical or an
+	// interface VPC endpoint), take the region from it so a wrong/typo'd configured
+	// region (e.g. "us-east1") can't break signing or STS.
+	region := awsAuth.Region
+	if r := regionFromBedrockHost(awsAuth.Hostname); r != "" {
+		region = r
+	}
 
 	// If credentials file is provided, use it; otherwise use default credential chain
 	// which automatically handles IRSA, EKS Pod Identity, instance roles, etc.
@@ -57,7 +70,7 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 		cfg, err = config.LoadDefaultConfig(
 			ctx,
 			config.WithSharedCredentialsFiles([]string{name}),
-			config.WithRegion(awsAuth.Region),
+			config.WithRegion(region),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot load from credentials file: %w", err)
@@ -66,7 +79,7 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 		// Use default credential chain (supports IRSA, EKS Pod Identity, etc.)
 		cfg, err = config.LoadDefaultConfig(
 			ctx,
-			config.WithRegion(awsAuth.Region),
+			config.WithRegion(region),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot load AWS config: %w", err)
@@ -75,7 +88,37 @@ func newAWSHandler(ctx context.Context, awsAuth *filterapi.AWSAuth) (filterapi.B
 
 	signer := v4.NewSigner()
 
-	return &awsHandler{credentialsProvider: cfg.Credentials, signer: signer, region: awsAuth.Region}, nil
+	return &awsHandler{credentialsProvider: cfg.Credentials, signer: signer, region: region, hostname: awsAuth.Hostname}, nil
+}
+
+// bedrockHostRE matches a Bedrock endpoint host and captures its region label:
+//
+//	bedrock-runtime.<region>.amazonaws.com                         (canonical)
+//	vpce-<id>-<hash>.bedrock-runtime.<region>.vpce.amazonaws.com   (interface VPC endpoint)
+var bedrockHostRE = regexp.MustCompile(`(?:^|\.)bedrock-runtime\.([a-z0-9-]+)\.(?:vpce\.)?amazonaws\.com$`)
+
+// regionFromBedrockHost returns the AWS region embedded in a Bedrock endpoint
+// host, or "" for any non-Bedrock host (e.g. a private proxy). The endpoint's
+// region is authoritative for SigV4 -- the request physically goes there -- so it
+// is preferred over the configured region, which also guards against an invalid
+// configured region string.
+func regionFromBedrockHost(hostname string) string {
+	if m := bedrockHostRE.FindStringSubmatch(hostname); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// bedrockHost returns the host SigV4 is signed over: the configured upstream
+// endpoint hostname when set (e.g. a Bedrock interface VPC endpoint FQDN), else
+// the region-default public Bedrock host. Signing over the actual upstream host
+// is required because Bedrock recomputes the signature over the Host it receives
+// (which Envoy's Backend host-rewrite sets to the endpoint FQDN).
+func (a *awsHandler) bedrockHost() string {
+	if a.hostname != "" {
+		return a.hostname
+	}
+	return fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", a.region)
 }
 
 // Do implements [Handler.Do].
@@ -93,7 +136,7 @@ func (a *awsHandler) Do(ctx context.Context, requestHeaders map[string]string, m
 
 	payloadHash := sha256.Sum256(body)
 	req, err := http.NewRequest(method,
-		fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com%s", a.region, path),
+		fmt.Sprintf("https://%s%s", a.bedrockHost(), path),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)

--- a/internal/backendauth/aws_hostname_test.go
+++ b/internal/backendauth/aws_hostname_test.go
@@ -1,0 +1,121 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package backendauth
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"testing"
+	"time"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
+)
+
+func TestAWSHandler_bedrockHost(t *testing.T) {
+	t.Run("defaults to region host when hostname empty", func(t *testing.T) {
+		a := &awsHandler{region: "us-east-1"}
+		require.Equal(t, "bedrock-runtime.us-east-1.amazonaws.com", a.bedrockHost())
+	})
+	t.Run("uses configured hostname (vpc endpoint)", func(t *testing.T) {
+		vpce := "vpce-0123456789abcdef0-1a2b3c4d.bedrock-runtime.us-east-1.vpce.amazonaws.com"
+		a := &awsHandler{region: "us-east-1", hostname: vpce}
+		require.Equal(t, vpce, a.bedrockHost())
+	})
+}
+
+// TestAWSHandler_Do_signsOverConfiguredHost proves the SigV4 signature is computed
+// over the configured endpoint host (a Bedrock interface VPC endpoint FQDN), not the
+// region-default public host. Envoy's Backend host-rewrite puts the vpce FQDN on the
+// wire as Host, and Bedrock recomputes the signature over that Host, so the signer
+// must sign over it too. This is the assertion that would have caught the earlier
+// hardcoded-host regression.
+func TestAWSHandler_Do_signsOverConfiguredHost(t *testing.T) {
+	const (
+		region = "us-east-1"
+		path   = "/model/us.anthropic.claude-haiku-4-5-20251001-v1%3A0/converse-stream"
+		vpce   = "vpce-0123456789abcdef0-1a2b3c4d.bedrock-runtime.us-east-1.vpce.amazonaws.com"
+	)
+	body := []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
+	awsFileBody := "[default]\naws_access_key_id=AKIDEXAMPLE\naws_secret_access_key=SECRETEXAMPLE\n"
+
+	handler, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+		CredentialFileLiteral: awsFileBody,
+		Region:                region,
+		Hostname:              vpce,
+	})
+	require.NoError(t, err)
+	awsH := handler.(*awsHandler)
+	require.Equal(t, vpce, awsH.hostname)
+
+	hdrs, err := handler.Do(t.Context(), map[string]string{":method": "POST", ":path": path}, body)
+	require.NoError(t, err)
+	got := stringPairsToMap(hdrs)
+	require.Contains(t, got, "Authorization")
+	require.Contains(t, got, "X-Amz-Date")
+
+	// Recompute the expected Authorization independently, at the exact timestamp the
+	// handler emitted, over the vpce host vs the region-default host.
+	signTime, err := time.Parse("20060102T150405Z", got["X-Amz-Date"])
+	require.NoError(t, err)
+	creds, err := awsH.credentialsProvider.Retrieve(t.Context())
+	require.NoError(t, err)
+
+	sign := func(host string) string {
+		payloadHash := sha256.Sum256(body)
+		r, err := http.NewRequest("POST", "https://"+host+path, bytes.NewReader(body))
+		require.NoError(t, err)
+		r.ContentLength = -1
+		require.NoError(t, v4.NewSigner().SignHTTP(t.Context(), creds, r,
+			hex.EncodeToString(payloadHash[:]), "bedrock", region, signTime))
+		return r.Header.Get("Authorization")
+	}
+
+	require.Equal(t, sign(vpce), got["Authorization"],
+		"handler must sign over the configured vpce host")
+	require.NotEqual(t, sign("bedrock-runtime."+region+".amazonaws.com"), got["Authorization"],
+		"handler must NOT sign over the region-default host when a vpce endpoint is configured")
+}
+
+func TestRegionFromBedrockHost(t *testing.T) {
+	for _, tc := range []struct{ host, want string }{
+		{"vpce-0123456789abcdef0-1a2b3c4d.bedrock-runtime.us-east-1.vpce.amazonaws.com", "us-east-1"},
+		{"bedrock-runtime.us-west-2.amazonaws.com", "us-west-2"},
+		{"bedrock-runtime.ap-southeast-1.amazonaws.com", "ap-southeast-1"},
+		{"bedrock-runtime.us-gov-west-1.amazonaws.com", "us-gov-west-1"},
+		{"my-proxy.internal.corp", ""},                       // non-Bedrock host -> use configured region
+		{"", ""},                                             // empty -> use configured region
+		{"bedrock.us-east-1.amazonaws.com", ""},              // control-plane host, not bedrock-runtime
+		{"bedrock-runtime-fips.us-east-1.amazonaws.com", ""}, // FIPS host -> use configured region
+		{"bedrock-runtime.cn-north-1.amazonaws.com.cn", ""},  // China partition -> use configured region
+	} {
+		require.Equal(t, tc.want, regionFromBedrockHost(tc.host), tc.host)
+	}
+}
+
+// TestAWSHandler_signsWithRegionDerivedFromHost proves that a malformed/mismatched
+// configured region (here GCP-style "us-east1") is overridden by the region embedded
+// in the Bedrock endpoint host, so the SigV4 credential scope is valid.
+func TestAWSHandler_signsWithRegionDerivedFromHost(t *testing.T) {
+	const vpce = "vpce-0123456789abcdef0-1a2b3c4d.bedrock-runtime.us-east-1.vpce.amazonaws.com"
+	h, err := newAWSHandler(t.Context(), &filterapi.AWSAuth{
+		CredentialFileLiteral: "[default]\naws_access_key_id=AKIDEXAMPLE\naws_secret_access_key=SECRETEXAMPLE\n",
+		Region:                "us-east1", // malformed -- must be ignored in favor of the host's region
+		Hostname:              vpce,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "us-east-1", h.(*awsHandler).region, "region must be derived from the vpce host")
+
+	hdrs, err := h.Do(t.Context(), map[string]string{":method": "POST", ":path": "/model/m/converse"}, []byte(`{}`))
+	require.NoError(t, err)
+	auth := stringPairsToMap(hdrs)["Authorization"]
+	require.Contains(t, auth, "/us-east-1/bedrock/aws4_request", "credential scope must use the derived region")
+	require.NotContains(t, auth, "/us-east1/bedrock/", "malformed configured region must not reach the scope")
+}

--- a/internal/controller/ai_service_backend.go
+++ b/internal/controller/ai_service_backend.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"fmt"
 
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -116,4 +118,43 @@ func (c *AIBackendController) updateAIServiceBackendStatus(ctx context.Context, 
 		c.logger.Error(err, "failed to update AIServiceBackend status",
 			"namespace", backend.Namespace, "name", backend.Name)
 	}
+}
+
+// backendToAIServiceBackends maps an Envoy Gateway Backend change to reconcile
+// requests for every AIServiceBackend that references it, so a Backend create or
+// FQDN edit regenerates the extproc config (the Backend FQDN is the AWS SigV4
+// signing host -- see gateway.go awsBackendHostname). Reconciling those
+// AIServiceBackends cascades to the referencing routes and gateways via the
+// existing event chain.
+func (c *AIBackendController) backendToAIServiceBackends(ctx context.Context, obj client.Object) []reconcile.Request {
+	be, ok := obj.(*egv1a1.Backend)
+	if !ok {
+		return nil
+	}
+	var list aigv1b1.AIServiceBackendList
+	if err := c.client.List(ctx, &list); err != nil {
+		c.logger.Error(err, "failed to list AIServiceBackends for Backend event",
+			"backend", be.Name, "namespace", be.Namespace)
+		return nil
+	}
+	var reqs []reconcile.Request
+	for i := range list.Items {
+		ref := list.Items[i].Spec.BackendRef
+		if ref.Kind == nil || string(*ref.Kind) != "Backend" ||
+			ref.Group == nil || string(*ref.Group) != "gateway.envoyproxy.io" ||
+			string(ref.Name) != be.Name {
+			continue
+		}
+		ns := list.Items[i].Namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		if ns != be.Namespace {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: list.Items[i].Namespace, Name: list.Items[i].Name,
+		}})
+	}
+	return reqs
 }

--- a/internal/controller/ai_service_backend_watch_test.go
+++ b/internal/controller/ai_service_backend_watch_test.go
@@ -1,0 +1,65 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package controller
+
+import (
+	"testing"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake2 "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
+)
+
+// TestAIBackendController_backendToAIServiceBackends covers the egv1a1.Backend ->
+// AIServiceBackend requeue mapping, so a Backend FQDN edit regenerates the extproc
+// config (the signing host).
+func TestAIBackendController_backendToAIServiceBackends(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	eventChan := internaltesting.NewControllerEventChan[*aigv1b1.AIGatewayRoute]()
+	c := NewAIServiceBackendController(fakeClient, fake2.NewClientset(), ctrl.Log, eventChan.Ch)
+
+	beRef := func(name string) gwapiv1.BackendObjectReference {
+		return gwapiv1.BackendObjectReference{
+			Group: ptr.To(gwapiv1.Group("gateway.envoyproxy.io")),
+			Kind:  ptr.To(gwapiv1.Kind("Backend")),
+			Name:  gwapiv1.ObjectName(name),
+		}
+	}
+	mkASB := func(name, ns string, ref gwapiv1.BackendObjectReference) *aigv1b1.AIServiceBackend {
+		return &aigv1b1.AIServiceBackend{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       aigv1b1.AIServiceBackendSpec{BackendRef: ref},
+		}
+	}
+	require.NoError(t, fakeClient.Create(t.Context(), mkASB("asb1", "a", beRef("bedrock"))))
+	require.NoError(t, fakeClient.Create(t.Context(), mkASB("asb2", "a", beRef("bedrock"))))
+	require.NoError(t, fakeClient.Create(t.Context(), mkASB("other", "a", beRef("openai"))))      // different Backend
+	require.NoError(t, fakeClient.Create(t.Context(), mkASB("elsewhere", "b", beRef("bedrock")))) // different ns
+
+	reqs := c.backendToAIServiceBackends(t.Context(),
+		&egv1a1.Backend{ObjectMeta: metav1.ObjectMeta{Name: "bedrock", Namespace: "a"}})
+	names := map[string]bool{}
+	for _, r := range reqs {
+		require.Equal(t, "a", r.Namespace)
+		names[r.Name] = true
+	}
+	require.Len(t, reqs, 2, "only the two ns=a AIServiceBackends referencing Backend bedrock")
+	require.True(t, names["asb1"] && names["asb2"])
+	require.False(t, names["other"] || names["elsewhere"])
+
+	// A Backend nobody references -> no requeue.
+	require.Empty(t, c.backendToAIServiceBackends(t.Context(),
+		&egv1a1.Backend{ObjectMeta: metav1.ObjectMeta{Name: "ghost", Namespace: "a"}}))
+	// Non-Backend object -> nil.
+	require.Nil(t, c.backendToAIServiceBackends(t.Context(), &aigv1b1.AIServiceBackend{}))
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -163,6 +163,11 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 			aiServiceBackendEventChan,
 			&handler.EnqueueRequestForObject{},
 		)).
+		// Watch the referenced Envoy Gateway Backends: their FQDN is baked into the
+		// AWS SigV4 signing host (see gateway.go awsBackendHostname), so a Backend
+		// create or FQDN edit must requeue the AIServiceBackends that reference it to
+		// regenerate the extproc config.
+		Watches(&egv1a1.Backend{}, handler.EnqueueRequestsFromMapFunc(backendC.backendToAIServiceBackends)).
 		Complete(backendC); err != nil {
 		return fmt.Errorf("failed to create controller for AIServiceBackend: %w", err)
 	}

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -428,6 +428,7 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 				b.ModelNameOverride = backendRef.ModelNameOverride
 
 				var bsp *aigv1b1.BackendSecurityPolicy
+				var backendObj *aigv1b1.AIServiceBackend
 				backendNamespace := backendRef.GetNamespace(aiGatewayRoute.Namespace)
 
 				if backendRef.IsInferencePool() {
@@ -446,7 +447,6 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 						continue
 					}
 				} else {
-					var backendObj *aigv1b1.AIServiceBackend
 					backendObj, bsp, err = c.backendWithMaybeBSP(ctx, backendNamespace, backendRef.Name)
 					if err != nil {
 						c.logger.Error(err, "failed to get backend or backend security policy. Skipping this backend.",
@@ -491,6 +491,18 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 							b.HeaderMutation = &filterapi.HTTPHeaderMutation{}
 						}
 						b.HeaderMutation.Remove = append(b.HeaderMutation.Remove, b.Auth.CredentialOverride.InputHeaderToRemove)
+					}
+				}
+
+				// For AWS backends, sign SigV4 over the host Envoy actually sends
+				// upstream -- the referenced Backend's FQDN (e.g. a Bedrock interface VPC
+				// endpoint) -- not the default bedrock-runtime.<region>. bspToFilterAPIBackendAuth
+				// allocates a fresh BackendAuth per backendRef, so stamping the per-backend
+				// host in place is safe; if that ever becomes a shared/cached pointer this
+				// must copy before writing.
+				if backendObj != nil && b.Auth != nil && b.Auth.AWSAuth != nil {
+					if host := c.awsBackendHostname(ctx, backendNamespace, backendObj.Spec.BackendRef); host != "" {
+						b.Auth.AWSAuth.Hostname = host
 					}
 				}
 
@@ -984,6 +996,51 @@ func (c *GatewayController) injectQuotaPolicyCostExpressions(
 // is active per request, and ext_proc filters cost entries by Model before
 // writing to this key.
 const QuotaCostMetadataKey = "quota_cost"
+
+// awsBackendHostname resolves the FQDN hostname of the Envoy Gateway Backend
+// referenced by an AIServiceBackend. It is used so AWS SigV4 is signed over the
+// actual upstream host (e.g. a Bedrock interface VPC endpoint FQDN
+// vpce-xxxx.bedrock-runtime.<region>.vpce.amazonaws.com) rather than the default
+// bedrock-runtime.<region>.amazonaws.com, matching the Host that Envoy's Backend
+// host-rewrite sends upstream. Returns "" when the Backend cannot be read or has
+// no FQDN endpoint, in which case the signer keeps its region-default host. Only
+// FQDN endpoints are meaningful for signing (IP/Service endpoints have no name to
+// sign over).
+func (c *GatewayController) awsBackendHostname(ctx context.Context, namespace string, ref gwapiv1.BackendObjectReference) string {
+	// Only an Envoy Gateway Backend carries a signable FQDN. The default
+	// BackendObjectReference kind is Service, so guard against Getting an unrelated
+	// Backend CR that merely shares the ref's name.
+	if ref.Group == nil || string(*ref.Group) != "gateway.envoyproxy.io" ||
+		ref.Kind == nil || string(*ref.Kind) != "Backend" {
+		return ""
+	}
+	name := string(ref.Name)
+	if name == "" {
+		return ""
+	}
+	ns := namespace
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+	var be egv1a1.Backend
+	if err := c.client.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &be); err != nil {
+		// Don't silently drop the signing host: config regenerated without it makes
+		// every AWS request 403. NotFound is benign -- the egv1a1.Backend watch
+		// (StartControllers) requeues the referencing AIServiceBackend when the
+		// Backend appears or its FQDN changes; log anything else so it's visible.
+		if client.IgnoreNotFound(err) != nil {
+			c.logger.Error(err, "resolving Backend FQDN for AWS signing host",
+				"backend", name, "namespace", ns)
+		}
+		return ""
+	}
+	for i := range be.Spec.Endpoints {
+		if fqdn := be.Spec.Endpoints[i].FQDN; fqdn != nil {
+			return fqdn.Hostname
+		}
+	}
+	return ""
+}
 
 // backendWithMaybeBSP retrieves the AIServiceBackend and its associated BackendSecurityPolicy if it exists.
 func (c *GatewayController) backendWithMaybeBSP(ctx context.Context, namespace, name string) (backend *aigv1b1.AIServiceBackend, bsp *aigv1b1.BackendSecurityPolicy, err error) {

--- a/internal/controller/gateway_aws_hostname_test.go
+++ b/internal/controller/gateway_aws_hostname_test.go
@@ -1,0 +1,145 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package controller
+
+import (
+	"testing"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake2 "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+)
+
+// TestGatewayController_awsBackendHostname covers the Backend-FQDN resolution used
+// to sign AWS SigV4 over the real upstream host: FQDN resolution, the
+// Backend/gateway.envoyproxy.io kind guard (a Service ref must not pick up a
+// same-named Backend CR), no-FQDN endpoints, and a missing Backend.
+func TestGatewayController_awsBackendHostname(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	backendRef := func(name string) gwapiv1.BackendObjectReference {
+		return gwapiv1.BackendObjectReference{
+			Group: ptr.To(gwapiv1.Group("gateway.envoyproxy.io")),
+			Kind:  ptr.To(gwapiv1.Kind("Backend")),
+			Name:  gwapiv1.ObjectName(name),
+		}
+	}
+
+	const vpce = "vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com"
+	require.NoError(t, fakeClient.Create(t.Context(), &egv1a1.Backend{
+		ObjectMeta: metav1.ObjectMeta{Name: "bedrock-vpce", Namespace: "ns"},
+		Spec: egv1a1.BackendSpec{Endpoints: []egv1a1.BackendEndpoint{
+			{FQDN: &egv1a1.FQDNEndpoint{Hostname: vpce, Port: 443}},
+		}},
+	}))
+	// A Backend with no FQDN endpoint (e.g. IP/Unix) has no signable host.
+	require.NoError(t, fakeClient.Create(t.Context(), &egv1a1.Backend{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-fqdn", Namespace: "ns"},
+		Spec:       egv1a1.BackendSpec{Endpoints: []egv1a1.BackendEndpoint{}},
+	}))
+
+	t.Run("resolves FQDN", func(t *testing.T) {
+		require.Equal(t, vpce, c.awsBackendHostname(t.Context(), "ns", backendRef("bedrock-vpce")))
+	})
+	t.Run("no FQDN endpoint -> empty", func(t *testing.T) {
+		require.Equal(t, "", c.awsBackendHostname(t.Context(), "ns", backendRef("no-fqdn")))
+	})
+	t.Run("missing Backend -> empty", func(t *testing.T) {
+		require.Equal(t, "", c.awsBackendHostname(t.Context(), "ns", backendRef("missing")))
+	})
+	t.Run("non-Backend (Service) ref -> empty even if a same-named Backend exists", func(t *testing.T) {
+		// Default BackendObjectReference kind is Service; must NOT resolve to the
+		// same-named egv1a1.Backend created above.
+		svcRef := gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName("bedrock-vpce")}
+		require.Equal(t, "", c.awsBackendHostname(t.Context(), "ns", svcRef))
+	})
+	t.Run("ref namespace overrides the passed namespace", func(t *testing.T) {
+		ref := backendRef("bedrock-vpce")
+		ref.Namespace = ptr.To(gwapiv1.Namespace("ns"))
+		require.Equal(t, vpce, c.awsBackendHostname(t.Context(), "other", ref))
+	})
+}
+
+// TestGatewayController_reconcileFilterConfigSecret_AWSSigningHostname is the
+// end-to-end wiring proof (credential-free): a reconcile over an AWS-backed route
+// whose AIServiceBackend references an Envoy Gateway Backend with a vpce FQDN must
+// emit a filter config whose AWSAuth.Hostname is that FQDN. Combined with the
+// backendauth handler unit test (which proves SigV4 is signed over AWSAuth.Hostname),
+// this covers the whole controller -> filterapi -> signer chain.
+func TestGatewayController_reconcileFilterConfigSecret_AWSSigningHostname(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	const (
+		gwNamespace = "ns"
+		vpce        = "vpce-0123456789abcdef0-1a2b3c4d.bedrock-runtime.us-east-1.vpce.amazonaws.com"
+	)
+
+	// The Envoy Gateway Backend whose FQDN Envoy host-rewrites onto the wire.
+	require.NoError(t, fakeClient.Create(t.Context(), &egv1a1.Backend{
+		ObjectMeta: metav1.ObjectMeta{Name: "bedrock-be", Namespace: gwNamespace},
+		Spec: egv1a1.BackendSpec{Endpoints: []egv1a1.BackendEndpoint{
+			{FQDN: &egv1a1.FQDNEndpoint{Hostname: vpce, Port: 443}},
+		}},
+	}))
+	// The AIServiceBackend referencing that Backend by kind=Backend/group=gateway.envoyproxy.io.
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "aws-be", Namespace: gwNamespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{
+				Group: ptr.To(gwapiv1.Group("gateway.envoyproxy.io")),
+				Kind:  ptr.To(gwapiv1.Kind("Backend")),
+				Name:  "bedrock-be",
+			},
+		},
+	}))
+	// An AWS BSP with only a region uses the default credential chain, so no secret
+	// is needed -- bspToFilterAPIBackendAuth returns AWSAuth directly, credential-free.
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "aws-bsp", Namespace: gwNamespace},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			Type:           aigv1b1.BackendSecurityPolicyTypeAWSCredentials,
+			AWSCredentials: &aigv1b1.BackendSecurityPolicyAWSCredentials{Region: "us-east-1"},
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{
+				{Group: "aigateway.envoyproxy.io", Kind: "AIServiceBackend", Name: "aws-be"},
+			},
+		},
+	}))
+
+	routes := []aigv1b1.AIGatewayRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "aws-route", Namespace: gwNamespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			Rules: []aigv1b1.AIGatewayRouteRule{{
+				BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "aws-be"}},
+			}},
+		},
+	}}
+
+	const someNamespace = "some-namespace"
+	effective, err := c.reconcileFilterConfigSecret(t.Context(), "gw", gwNamespace, someNamespace, routes, nil, "foouuid", nil)
+	require.NoError(t, err)
+	require.True(t, effective)
+
+	fc := requireFilterConfigFromBundle(t, kube, someNamespace, "gw", gwNamespace)
+	require.Len(t, fc.Backends, 1)
+	require.NotNil(t, fc.Backends[0].Auth)
+	require.NotNil(t, fc.Backends[0].Auth.AWSAuth)
+	require.Equal(t, vpce, fc.Backends[0].Auth.AWSAuth.Hostname,
+		"the emitted AWS signing host must be the referenced Backend's FQDN")
+	require.Equal(t, "us-east-1", fc.Backends[0].Auth.AWSAuth.Region)
+}

--- a/internal/filterapi/filterconfig.go
+++ b/internal/filterapi/filterconfig.go
@@ -246,6 +246,14 @@ type AWSAuth struct {
 	// [default]\naws_access_key_id = <access-key-id>\naws_secret_access_key = <secret-access-key>\naws_session_token = <session-token>.
 	CredentialFileLiteral string `json:"credentialFileLiteral,omitempty"`
 	Region                string `json:"region"`
+	// Hostname is the upstream endpoint host that SigV4 is computed over. When set
+	// (e.g. a Bedrock interface VPC endpoint FQDN such as
+	// vpce-xxxx.bedrock-runtime.<region>.vpce.amazonaws.com), the signer signs the
+	// request over this host instead of the default
+	// bedrock-runtime.<region>.amazonaws.com, so the signature matches the Host that
+	// Envoy's Backend host-rewrite actually sends upstream. Empty preserves the
+	// region-default behavior.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // LogValue implements slog.LogValuer for AWSAuth to redact sensitive information.


### PR DESCRIPTION
**Description**

AWS Bedrock backends whose endpoint is an interface VPC endpoint (`vpce-….bedrock-runtime.<region>.vpce.amazonaws.com`) or any custom host return `403 InvalidSignatureException` on every request. The extproc SigV4 signer builds the request it signs from the hardcoded `bedrock-runtime.<region>.amazonaws.com`, but Envoy's Backend host-rewrite puts the endpoint FQDN on the wire as `Host`. Bedrock recomputes the signature over the `Host` it receives, so it never matches.

This signs over the host Envoy actually sends upstream — the referenced Backend's FQDN:

- The controller resolves the Envoy Gateway `Backend` referenced by the AIServiceBackend and plumbs its FQDN via a new `filterapi.AWSAuth.Hostname`. The signer signs over that host, falling back to the region default when it's empty (so existing deployments are unchanged).
- The SigV4/STS region is derived from the Bedrock host when it is one, so a typo'd configured region (e.g. `us-east1`) can't break signing.
- The AIServiceBackend controller now watches `egv1a1.Backend`, so a Backend create or FQDN edit regenerates the extproc config instead of leaving the signing host stale.

**Related Issues/PRs**

This is an alternative to #2413, which addresses the same bug. Both change the same signing line; the difference is where the signing host comes from. #2413 reads it from request headers (`x-ai-eg-aws-signing-host`, then `:authority`, then `host`) gated by a `.amazonaws.com` suffix check. Those headers are client-reachable and not stripped at ingress, and at signing time `:authority` is the downstream gateway host rather than the upstream host — which is also why the earlier attempt (#2296, reverted in #2298) signed the wrong host.

| | #2413 | this PR |
|---|---|---|
| Signing host source | request headers (`x-ai-eg-aws-signing-host` / `:authority` / `host`) | controller-resolved Backend FQDN |
| Client can influence it | yes (headers not stripped at ingress) | no (control-plane only) |
| Guard | `.amazonaws.com` suffix check | none needed |
| AWS China / custom proxy | rejected by suffix check | works |
| Stale on FQDN edit | n/a | Backend watch requeues config |
| Region on typo'd config | unchanged | derived from the Bedrock host |
| Covered by fork-PR CI | no (asserts headers exist only) | yes (credential-free, recomputes SigV4) |

**Special notes for reviewers**

- Empty `Hostname` preserves the current behavior, so non-vpce deployments are unaffected.
- `bspToFilterAPIBackendAuth` allocates a fresh `BackendAuth` per backendRef, so the per-backend host is stamped in place; there's a comment noting this must copy-on-write if that ever becomes shared.
- Controller RBAC already grants `gateway.envoyproxy.io` access, so the Backend watch needs no RBAC change.
- Tests are credential-free so fork PRs actually exercise them (#2296 broke on main precisely because the credentialed e2e is skipped on forks): a backendauth test recomputes SigV4 independently and asserts the signature is over the vpce host and not the region default; a controller test asserts the reconciled filter config carries the Backend FQDN as the signing host; plus Backend-FQDN resolution and the Backend→AIServiceBackend requeue mapping.
