### PR TITLE
extproc: always redact credential header mutations in debug log

### DIFF
--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -289,16 +289,16 @@ func (s *Server) processMsg(ctx context.Context, p Processor, req *extprocv3.Pro
 			}
 		}
 		if s.debugLogEnabled && resp != nil && resp.Response != nil {
+			// Header mutations always carry injected backend credentials (e.g. the
+			// upstream Authorization), so they are redacted whenever debug logging
+			// is on — independent of enableRedaction, which only controls body
+			// content. This mirrors redactRequestBodyResponse above.
 			var logContent any
-			if s.enableRedaction {
-				switch val := resp.Response.(type) {
-				case *extprocv3.ProcessingResponse_RequestHeaders:
-					logContent = redactProcessingResponseRequestHeaders(val, s.logger, sensitiveHeaderKeys)
-				case *extprocv3.ProcessingResponse_ImmediateResponse:
-					logContent = val
-				}
-			} else {
-				logContent = resp
+			switch val := resp.Response.(type) {
+			case *extprocv3.ProcessingResponse_RequestHeaders:
+				logContent = redactProcessingResponseRequestHeaders(val, s.logger, sensitiveHeaderKeys, s.enableRedaction)
+			case *extprocv3.ProcessingResponse_ImmediateResponse:
+				logContent = val
 			}
 			l.Debug("request headers processed", slog.Any("response", logContent))
 		}
@@ -484,15 +484,29 @@ func filterSensitiveHeadersForLogging(headers *corev3.HeaderMap, sensitiveKeys [
 
 // redactProcessingResponseRequestHeaders creates a safe-to-log copy of the request headers processing response.
 // Used exclusively for debug logging without modifying the actual response sent to Envoy.
-// Redacts sensitive header values (API keys, authorization tokens) while preserving header names for debugging.
-func redactProcessingResponseRequestHeaders(resp *extprocv3.ProcessingResponse_RequestHeaders, logger *slog.Logger, sensitiveKeys []string) *extprocv3.ProcessingResponse_RequestHeaders {
+//
+// Header mutations are always redacted (API keys, authorization tokens) — a backend
+// credential injected here must never reach the debug log, regardless of the
+// [Server.enableRedaction] flag, which only governs the more expensive body-content
+// redaction. When redactBody is false, the body mutation is logged as-is (mirroring
+// [redactRequestBodyResponse]); when true, it is redacted too.
+func redactProcessingResponseRequestHeaders(resp *extprocv3.ProcessingResponse_RequestHeaders, logger *slog.Logger, sensitiveKeys []string, redactBody bool) *extprocv3.ProcessingResponse_RequestHeaders {
+	if resp == nil || resp.RequestHeaders == nil || resp.RequestHeaders.Response == nil {
+		return &extprocv3.ProcessingResponse_RequestHeaders{}
+	}
 	originalHeaderMutation := resp.RequestHeaders.GetResponse().GetHeaderMutation()
+	var bodyMutation *extprocv3.BodyMutation
+	if redactBody {
+		bodyMutation = redactBodyMutation(resp.RequestHeaders.Response.GetBodyMutation())
+	} else {
+		bodyMutation = resp.RequestHeaders.Response.GetBodyMutation()
+	}
 
 	return &extprocv3.ProcessingResponse_RequestHeaders{
 		RequestHeaders: &extprocv3.HeadersResponse{
 			Response: &extprocv3.CommonResponse{
 				HeaderMutation:  redactHeaderMutation(originalHeaderMutation, logger, sensitiveKeys),
-				BodyMutation:    redactBodyMutation(resp.RequestHeaders.Response.GetBodyMutation()),
+				BodyMutation:    bodyMutation,
 				ClearRouteCache: resp.RequestHeaders.Response.GetClearRouteCache(),
 			},
 		},

--- a/internal/extproc/server_test.go
+++ b/internal/extproc/server_test.go
@@ -573,6 +573,142 @@ func Test_filterRequestBodyResponseHeaders(t *testing.T) {
 	})
 }
 
+func Test_redactProcessingResponseRequestHeaders(t *testing.T) {
+	buf := internaltesting.CaptureOutput("test")[0]
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	resp := &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extprocv3.HeadersResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: &extprocv3.HeaderMutation{
+						SetHeaders: []*corev3.HeaderValueOption{
+							{Header: &corev3.HeaderValue{
+								Key:      ":path",
+								RawValue: []byte("/v1/chat/completions"),
+							}},
+							{Header: &corev3.HeaderValue{
+								Key:      "Authorization",
+								RawValue: []byte("Bearer secret-backend-key"),
+							}},
+						},
+						RemoveHeaders: []string{"x-envoy-original-path"},
+					},
+					BodyMutation: &extprocv3.BodyMutation{
+						Mutation: &extprocv3.BodyMutation_Body{
+							Body: []byte(`{"prompt":"secret prompt"}`),
+						},
+					},
+					ClearRouteCache: true,
+				},
+			},
+		},
+	}
+	rh := resp.Response.(*extprocv3.ProcessingResponse_RequestHeaders)
+
+	t.Run("redactBody=false redacts headers only", func(t *testing.T) {
+		filtered := redactProcessingResponseRequestHeaders(rh, logger, []string{"authorization"}, false)
+		require.NotNil(t, filtered)
+		filteredMutation := filtered.RequestHeaders.Response.GetHeaderMutation()
+		require.Equal(t, []string{"x-envoy-original-path"}, filteredMutation.GetRemoveHeaders())
+		// The injected backend credential must be redacted even with redactBody off.
+		require.Equal(t, []*corev3.HeaderValueOption{
+			{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/v1/chat/completions")}},
+			{Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte("[REDACTED]")}},
+		}, filteredMutation.GetSetHeaders())
+		require.NotContains(t, buf.String(), "secret-backend-key")
+
+		// Body stays raw when redactBody is false.
+		require.JSONEq(t, `{"prompt":"secret prompt"}`, string(filtered.RequestHeaders.Response.GetBodyMutation().GetBody()))
+		// ClearRouteCache is preserved.
+		require.True(t, filtered.RequestHeaders.Response.GetClearRouteCache())
+
+		// Original response is not modified.
+		originalMutation := rh.RequestHeaders.Response.GetHeaderMutation()
+		require.Equal(t, []*corev3.HeaderValueOption{
+			{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/v1/chat/completions")}},
+			{Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte("Bearer secret-backend-key")}},
+		}, originalMutation.GetSetHeaders())
+	})
+
+	t.Run("redactBody=true redacts headers and body", func(t *testing.T) {
+		filtered := redactProcessingResponseRequestHeaders(rh, logger, []string{"authorization"}, true)
+		require.NotNil(t, filtered)
+		filteredMutation := filtered.RequestHeaders.Response.GetHeaderMutation()
+		require.Equal(t, []*corev3.HeaderValueOption{
+			{Header: &corev3.HeaderValue{Key: ":path", RawValue: []byte("/v1/chat/completions")}},
+			{Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte("[REDACTED]")}},
+		}, filteredMutation.GetSetHeaders())
+
+		bodyStr := string(filtered.RequestHeaders.Response.GetBodyMutation().GetBody())
+		require.Contains(t, bodyStr, "[REDACTED LENGTH=")
+		require.NotContains(t, bodyStr, "secret prompt")
+
+		// Original body still unmodified.
+		require.JSONEq(t, `{"prompt":"secret prompt"}`, string(rh.RequestHeaders.Response.GetBodyMutation().GetBody()))
+	})
+
+	t.Run("handle nil response", func(t *testing.T) {
+		filtered := redactProcessingResponseRequestHeaders(nil, logger, []string{"authorization"}, false)
+		require.NotNil(t, filtered)
+		require.Equal(t, &extprocv3.ProcessingResponse_RequestHeaders{}, filtered)
+	})
+}
+
+// TestServer_processMsg_RedactsCredentialMutation asserts that a backend
+// credential injected via the request-headers header mutation is redacted in the
+// "request headers processed" debug log even when enableRedaction is false —
+// header/credential redaction must be independent of the body-content redaction
+// flag.
+func TestServer_processMsg_RedactsCredentialMutation(t *testing.T) {
+	buf := internaltesting.CaptureOutput("test")[0]
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	s, err := NewServer(logger, false) // enableRedaction=false, debug on
+	require.NoError(t, err)
+	s.config = &filterapi.RuntimeConfig{}
+	m := newMockProcessor(s.config, s.logger).(*mockProcessor)
+	s.Register("/", func(*filterapi.RuntimeConfig, map[string]string, *slog.Logger, bool, bool) (Processor, error) {
+		return m, nil
+	})
+
+	hm := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}}}
+	expResponse := &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extprocv3.HeadersResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: &extprocv3.HeaderMutation{
+						SetHeaders: []*corev3.HeaderValueOption{{
+							Header: &corev3.HeaderValue{Key: "Authorization", RawValue: []byte("Bearer secret-backend-key")},
+						}},
+					},
+				},
+			},
+		},
+	}
+	m.t = t
+	m.expHeaderMap = hm
+	m.retProcessingResponse = expResponse
+
+	ctx := context.WithValue(t.Context(), loggerContextKey, logger)
+	req := &extprocv3.ProcessingRequest{
+		Request: &extprocv3.ProcessingRequest_RequestHeaders{RequestHeaders: &extprocv3.HttpHeaders{Headers: hm}},
+	}
+	// Upstream filter path is where the backend Authorization is injected.
+	resp, err := s.processMsg(ctx, m, req, "test-req-id", true)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The actual response sent to Envoy is unchanged.
+	require.Equal(t, []byte("Bearer secret-backend-key"),
+		resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()[0].Header.RawValue)
+	// But the debug log must not leak the credential.
+	require.Contains(t, buf.String(), "[REDACTED]")
+	require.NotContains(t, buf.String(), "secret-backend-key")
+}
+
 func Test_redactRequestBodyResponseFull(t *testing.T) {
 	buf := internaltesting.CaptureOutput("test")[0]
 	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{


### PR DESCRIPTION
**Description**

The "request headers processed" debug log only ran header-mutation redaction when Server.enableRedaction was on. With debug logging on but redaction off (the aigw run default), the upstream filter's injected Authorization (the backend API key) was logged in cleartext, even though the incoming authorization header was already redacted by filterSensitiveHeadersForLogging.

This was inconsistent with the RequestBody phase, whose redactRequestBodyResponse always redacts header mutations and only gates body-content redaction on the flag. This change aligns the RequestHeaders phase to the same pattern: redact header mutations whenever debug logging is on, independent of enableRedaction, and gate only body content on the flag via a new redactBody parameter on redactProcessingResponseRequestHeaders.

A nil-response guard is added matching redactRequestBodyResponse.

**Special notes for reviewers (if applicable)**

- No behavior change to the response sent to Envoy; redaction only touches the logContent copy used for the debug log. Process-level tests assert on the returned resp, not log content, so they are unaffected.
- Verified live: with AIGW_DEBUG=true and enableRedaction off, the upstream Authorization mutation now logs as [REDACTED] while the actual response sent upstream still carries the real key.
- Out of scope: Envoy's own [http] and [ext_proc] debug logs still emit the raw Authorization header / proto and are outside extproc's control; those require Envoy log-level tuning, not addressed here.

**Related Issues/PRs (if applicable)**

Adjacent to but distinct from #2428 (which covers request body content redaction for the 7 passthrough endpoints). This PR covers a different leak surface: the backend credential injected into the request-headers header mutation by the extproc upstream filter.

Co-Authored-By: Claude <noreply@anthropic.com>


Partially addresses #2436 (extproc Go side; Envoy-side leak points remain).
