### PR TITLE
fix: surface reasoning_tokens in the access log

### DIFF
--- a/examples/access-log/basic.yaml
+++ b/examples/access-log/basic.yaml
@@ -55,6 +55,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -93,6 +94,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
     - metadataKey: llm_total_token
       type: TotalToken
   rules:

--- a/examples/aigw/ollama.yaml
+++ b/examples/aigw/ollama.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/examples/mcp/openai-github.yaml
+++ b/examples/mcp/openai-github.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -145,6 +146,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/config.yaml.tmpl
+++ b/internal/autoconfig/config.yaml.tmpl
@@ -10,6 +10,7 @@
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
 {{- end }}
 
@@ -127,7 +128,7 @@ spec:
 {{- end }}
 {{- end }}
           format:
-            text: "[%START_TIME%] %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% model=%REQ(X-AI-EG-MODEL)% %RESPONSE_CODE% llm_input_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)% llm_output_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)% %DURATION%ms"
+            text: "[%START_TIME%] %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% model=%REQ(X-AI-EG-MODEL)% %RESPONSE_CODE% llm_input_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)% llm_output_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)% llm_reasoning_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)% %DURATION%ms"
             json:
 {{ template "aigw.llmAccessLogFields" . }}
 {{ template "aigw.commonAccessLogFields" . }}
@@ -215,6 +216,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 {{- end }}
 {{- if .Anthropic }}
@@ -246,6 +249,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 {{- end }}
 {{- if .MCPBackendRefs }}

--- a/internal/autoconfig/testdata/anthropic.yaml
+++ b/internal/autoconfig/testdata/anthropic.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/azure-openai-with-org-and-project.yaml
+++ b/internal/autoconfig/testdata/azure-openai-with-org-and-project.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/azure-openai.yaml
+++ b/internal/autoconfig/testdata/azure-openai.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/debug.yaml
+++ b/internal/autoconfig/testdata/debug.yaml
@@ -63,6 +63,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -150,6 +151,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/kiwi.yaml
+++ b/internal/autoconfig/testdata/kiwi.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"

--- a/internal/autoconfig/testdata/llamastack.yaml
+++ b/internal/autoconfig/testdata/llamastack.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai-github.yaml
+++ b/internal/autoconfig/testdata/openai-github.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: aigateway.envoyproxy.io/v1alpha1
 kind: MCPRoute

--- a/internal/autoconfig/testdata/openai-ip.yaml
+++ b/internal/autoconfig/testdata/openai-ip.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai-otel-ip.yaml
+++ b/internal/autoconfig/testdata/openai-otel-ip.yaml
@@ -52,7 +52,7 @@ spec:
                     kind: Backend
                     name: otel
           format:
-            text: "[%START_TIME%] %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% model=%REQ(X-AI-EG-MODEL)% %RESPONSE_CODE% llm_input_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)% llm_output_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)% %DURATION%ms"
+            text: "[%START_TIME%] %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% model=%REQ(X-AI-EG-MODEL)% %RESPONSE_CODE% llm_input_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)% llm_output_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)% llm_reasoning_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)% %DURATION%ms"
             json:
               # LLM specific fields. Dynamic metadata expressions must match
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
@@ -62,6 +62,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -152,6 +153,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai-otel.yaml
+++ b/internal/autoconfig/testdata/openai-otel.yaml
@@ -59,7 +59,7 @@ spec:
                   service.name: "ai-gateway-service"
                   service.version: "1.2.3"
           format:
-            text: "[%START_TIME%] %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% model=%REQ(X-AI-EG-MODEL)% %RESPONSE_CODE% llm_input_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)% llm_output_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)% %DURATION%ms"
+            text: "[%START_TIME%] %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% model=%REQ(X-AI-EG-MODEL)% %RESPONSE_CODE% llm_input_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)% llm_output_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)% llm_reasoning_token=%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)% %DURATION%ms"
             json:
               # LLM specific fields. Dynamic metadata expressions must match
               # the ones defined in the AIGatewayRoute llmRequestCosts field or
@@ -69,6 +69,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -166,6 +167,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai-with-org-and-project.yaml
+++ b/internal/autoconfig/testdata/openai-with-org-and-project.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai-with-org.yaml
+++ b/internal/autoconfig/testdata/openai-with-org.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai-with-project.yaml
+++ b/internal/autoconfig/testdata/openai-with-project.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openai.yaml
+++ b/internal/autoconfig/testdata/openai.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/openrouter.yaml
+++ b/internal/autoconfig/testdata/openrouter.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend

--- a/internal/autoconfig/testdata/tars.yaml
+++ b/internal/autoconfig/testdata/tars.yaml
@@ -59,6 +59,7 @@ spec:
               gen_ai.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
               gen_ai.usage.input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               gen_ai.usage.output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              gen_ai.usage.reasoning_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_reasoning_token)%"
               session.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:session.id)%"
               # Common fields
               start_time: "%START_TIME%"
@@ -146,6 +147,8 @@ spec:
       type: InputToken
     - metadataKey: llm_output_token
       type: OutputToken
+    - metadataKey: llm_reasoning_token
+      type: ReasoningToken
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend


### PR DESCRIPTION
**Description**

The autoconfig emitted `llmRequestCosts` for `InputToken` and `OutputToken` only, so even though every translator already parses `reasoning_tokens` (`TokenUsage.SetReasoningTokens`, from OpenAI `completion_tokens_details.reasoning_tokens`, Anthropic `output_tokens_details.thinking_tokens`, Gemini `thoughtsTokenCount`) and `evalCost` already supports the `ReasoningToken` cost type, reasoning tokens never reached extproc dynamic metadata and never reached the access log. For reasoning models (gpt-5.x, o-series) where `completion_tokens` includes a large reasoning component, operators could not split reasoning vs visible output tokens from access logs — a billing/observability blind spot.

This adds a `ReasoningToken` cost rule (`metadataKey: llm_reasoning_token`) alongside the existing input/output rules in both the OpenAI and Anthropic `llmRequestCosts` blocks of `internal/autoconfig/config.yaml.tmpl`, and surfaces it in the access log: `gen_ai.usage.reasoning_tokens` in the shared `aigw.llmAccessLogFields` template (JSON log) and `llm_reasoning_token` in the text access log.

No extproc/translator change is needed — the value is already computed; this only wires it into the access-log metadata path that was already wired for input/output.

**Special notes for reviewers (if applicable)**

- Pure autoconfig/template plumbing. The `evalCost` `ReasoningToken` branch and the translators' `SetReasoningTokens` already exist and are tested; this only adds the missing cost rule + log field.
- The testdata goldens (and `examples/aigw/ollama.yaml`, which the Ollama test compares against) are regenerated from the template. `testdata/openai-ip.yaml` is not exercised by any test (it is not embedded and no case maps to it) but is updated by hand for consistency; the two hand-maintained examples `examples/access-log/basic.yaml` and `examples/mcp/openai-github.yaml` get the same additions.
- Non-reasoning backends: when a backend doesn't report reasoning tokens, the metadata key is unset and the access-log field renders empty (same as `input_tokens` on an error response) — no special-casing.
- Verified live: a reasoning-model call returning `completion_tokens_details.reasoning_tokens=35` now produces an access log with `gen_ai.usage.input_tokens=39, output_tokens=137, reasoning_tokens=35` (previously reasoning was absent).
- Out of scope: the metrics (`internal/metrics`) and tracing (`internal/tracing/openinference`) paths already surface reasoning tokens; this closes the Envoy access-log path specifically. Token-ratelimit / CRD-CEL / e2e fixtures that reference `llm_input_token` for other purposes are intentionally untouched.

Fixes #2437

Co-Authored-By: Claude <noreply@anthropic.com>
