### PR TITLE
fix: emit dynamic metadata on error responses for access-log attribution

### DIFF
--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -521,7 +521,7 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) ProcessRespo
 		}
 		// Mark so the deferred handler records failure.
 		recordRequestCompletionErr = true
-		return &extprocv3.ProcessingResponse{
+		resp := &extprocv3.ProcessingResponse{
 			Response: &extprocv3.ProcessingResponse_ResponseBody{
 				ResponseBody: &extprocv3.BodyResponse{
 					Response: &extprocv3.CommonResponse{
@@ -530,7 +530,34 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) ProcessRespo
 					},
 				},
 			},
-		}, nil
+		}
+		// Emit dynamic metadata at end of stream so failed requests still carry
+		// backend_name / model_name_override / route_name / token costs (0) in the
+		// access log. backend_name and model_name_override are known from the request
+		// phase (SetBackend), so unlike token usage they do not depend on a successful
+		// response body. Token costs are 0 on errors (no tokens consumed), so the
+		// rate-limit stream-done hits_addend stays 0 — observability only, no token
+		// quota charge (verified by an e2e in tests/e2e/backend_quota_ratelimit_test.go).
+		// responseModel is empty because error responses carry no model.
+		//
+		// If a CEL cost expression fails to evaluate here, skip emitting metadata
+		// and log rather than failing the response: the access log simply stays
+		// null for this request, same as for any failed request without costs.
+		// (Note: llmcostcel.NewProgram sanity-checks each expression at all-zero
+		// token counts — the exact state of a failed request — so division-by-zero
+		// on zero tokens is already rejected at program creation; this guard is
+		// defensive against any other CEL runtime error.)
+		if body.EndOfStream && u.parent.config != nil &&
+			(len(u.parent.config.GlobalRequestCosts) > 0 || len(u.parent.config.RequestCosts) > 0) {
+			metadata, mdErr := buildDynamicMetadata(u.parent.config.GlobalRequestCosts, u.parent.config.RequestCosts, &u.costs, u.requestHeaders, u.backendName, u.routeName, internalapi.ResponseModel(""))
+			if mdErr != nil {
+				u.logger.Warn("failed to build dynamic metadata for error response, skipping access-log metadata",
+					slog.Any("error", mdErr))
+			} else {
+				resp.DynamicMetadata = metadata
+			}
+		}
+		return resp, nil
 	}
 
 	newHeaders, newBody, tokenUsage, responseModel, err := u.translator.ResponseBody(u.responseHeaders, decodingResult.reader, body.EndOfStream, u.parent.span)
@@ -816,9 +843,12 @@ func evalRuntimeRequestCost(rc *filterapi.RuntimeRequestCost, costs *metrics.Tok
 }
 
 // buildDynamicMetadata creates metadata for rate limiting and cost tracking.
-// This function is called by the upstream filter only at the end of the stream (body.EndOfStream=true)
-// when the response is successfully completed. It is not called for failed requests or partial responses.
-// The metadata includes token usage costs and model information for downstream processing.
+// This function is called by the upstream filter only at the end of the stream
+// (body.EndOfStream=true), on both successful and failed responses. For failed
+// responses (non-2xx), token costs are 0 (no tokens were consumed) and
+// responseModel is empty, but backend_name / model_name_override / route_name
+// are still emitted so the access log can attribute failed requests. The metadata
+// includes token usage costs and model information for downstream processing.
 // Two-tier precedence: for each metadataKey, check route-scoped requestCosts first (matching RouteName == routeName).
 // If found, use it. Otherwise, fall back to globalRequestCosts. If neither exists, the key is not emitted.
 func buildDynamicMetadata(globalRequestCosts []filterapi.RuntimeGlobalRequestCost, requestCosts []filterapi.RuntimeRequestCost, costs *metrics.TokenUsage, requestHeaders map[string]string, backendName, routeName, responseModel string) (*structpb.Struct, error) {

--- a/internal/extproc/processor_impl_test.go
+++ b/internal/extproc/processor_impl_test.go
@@ -399,6 +399,168 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 		mm.RequireRequestFailure(t)
 	})
 
+	// Verify failed (non-2xx) responses still emit dynamic metadata at end of
+	// stream so the access log can attribute them to backend/model/route. Token
+	// costs are 0 since no tokens were consumed. See issue #2440.
+	t.Run("non-2xx status emits dynamic metadata at end of stream", func(t *testing.T) {
+		inBody := &extprocv3.HttpBody{Body: []byte("error-body"), EndOfStream: true}
+		mm := &mockMetrics{}
+		mt := &mockTranslator{
+			t: t, expResponseBody: inBody,
+			retHeaderMutation: []internalapi.Header{{"foo", "bar"}},
+			retBodyMutation:   []byte("error-body"),
+		}
+		p := &chatCompletionProcessorUpstreamFilter{
+			translator: mt,
+			metrics:    mm,
+			parent: &chatCompletionProcessorRouterFilter{
+				config: &filterapi.RuntimeConfig{
+					RequestCosts: []filterapi.RuntimeRequestCost{
+						{LLMRequestCost: &filterapi.LLMRequestCost{RouteName: "some_route", Type: filterapi.LLMRequestCostTypeInputToken, MetadataKey: "input_token_usage"}},
+						{LLMRequestCost: &filterapi.LLMRequestCost{RouteName: "some_route", Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "output_token_usage"}},
+						{LLMRequestCost: &filterapi.LLMRequestCost{RouteName: "some_route", Type: filterapi.LLMRequestCostTypeReasoningToken, MetadataKey: "reasoning_token_usage"}},
+					},
+				},
+			},
+			requestHeaders:    map[string]string{internalapi.ModelNameHeaderKeyDefault: "ai_gateway_llm"},
+			responseHeaders:   map[string]string{":status": "500"},
+			backendName:       "some_backend",
+			routeName:         "some_route",
+			modelNameOverride: "ai_gateway_llm",
+		}
+		res, err := p.ProcessResponseBody(t.Context(), inBody)
+		require.NoError(t, err)
+		md := res.DynamicMetadata
+		require.NotNil(t, md, "error responses must emit dynamic metadata for access-log attribution")
+		fields := md.Fields[internalapi.AIGatewayFilterMetadataNamespace].GetStructValue().Fields
+		// backend/model/route are known from the request phase and must be present.
+		require.Equal(t, "some_backend", fields["backend_name"].GetStringValue())
+		require.Equal(t, "some_backend", fields["ai_service_backend_name"].GetStringValue())
+		require.Equal(t, "ai_gateway_llm", fields["model_name_override"].GetStringValue())
+		require.Equal(t, "some_route", fields["route_name"].GetStringValue())
+		// Token costs are 0 on errors (no tokens consumed), but the keys exist so
+		// the access log reads 0 instead of null.
+		require.Equal(t, float64(0), fields["input_token_usage"].GetNumberValue())
+		require.Equal(t, float64(0), fields["output_token_usage"].GetNumberValue())
+		require.Equal(t, float64(0), fields["reasoning_token_usage"].GetNumberValue())
+		// Error responses carry no model; response_model must be absent (not "").
+		_, ok := fields["response_model"]
+		require.False(t, ok)
+		mm.RequireRequestFailure(t)
+	})
+
+	// Metadata is only emitted at end of stream; a partial error chunk must not
+	// populate dynamic metadata yet.
+	t.Run("non-2xx status does not emit metadata before end of stream", func(t *testing.T) {
+		inBody := &extprocv3.HttpBody{Body: []byte("error-body"), EndOfStream: false}
+		mm := &mockMetrics{}
+		mt := &mockTranslator{
+			t: t, expResponseBody: inBody,
+			retHeaderMutation: []internalapi.Header{{"foo", "bar"}},
+			retBodyMutation:   []byte("error-body"),
+		}
+		p := &chatCompletionProcessorUpstreamFilter{
+			translator: mt,
+			metrics:    mm,
+			parent: &chatCompletionProcessorRouterFilter{
+				config: &filterapi.RuntimeConfig{
+					RequestCosts: []filterapi.RuntimeRequestCost{
+						{LLMRequestCost: &filterapi.LLMRequestCost{RouteName: "some_route", Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "output_token_usage"}},
+					},
+				},
+			},
+			requestHeaders:    map[string]string{internalapi.ModelNameHeaderKeyDefault: "ai_gateway_llm"},
+			responseHeaders:   map[string]string{":status": "500"},
+			backendName:       "some_backend",
+			routeName:         "some_route",
+			modelNameOverride: "ai_gateway_llm",
+		}
+		res, err := p.ProcessResponseBody(t.Context(), inBody)
+		require.NoError(t, err)
+		require.Nil(t, res.DynamicMetadata)
+	})
+
+	// GlobalRequestCosts (route-unscoped) are also emitted on error responses.
+	t.Run("non-2xx status emits global request costs", func(t *testing.T) {
+		inBody := &extprocv3.HttpBody{Body: []byte("error-body"), EndOfStream: true}
+		mm := &mockMetrics{}
+		mt := &mockTranslator{
+			t: t, expResponseBody: inBody,
+			retHeaderMutation: []internalapi.Header{{"foo", "bar"}},
+			retBodyMutation:   []byte("error-body"),
+		}
+		p := &chatCompletionProcessorUpstreamFilter{
+			translator: mt,
+			metrics:    mm,
+			parent: &chatCompletionProcessorRouterFilter{
+				config: &filterapi.RuntimeConfig{
+					GlobalRequestCosts: []filterapi.RuntimeGlobalRequestCost{
+						{GlobalLLMRequestCost: &filterapi.GlobalLLMRequestCost{Type: filterapi.LLMRequestCostTypeOutputToken, MetadataKey: "g_output_token"}},
+						{GlobalLLMRequestCost: &filterapi.GlobalLLMRequestCost{Type: filterapi.LLMRequestCostTypeTotalToken, MetadataKey: "g_total_token"}},
+					},
+				},
+			},
+			requestHeaders:    map[string]string{internalapi.ModelNameHeaderKeyDefault: "ai_gateway_llm"},
+			responseHeaders:   map[string]string{":status": "500"},
+			backendName:       "some_backend",
+			routeName:         "some_route",
+			modelNameOverride: "ai_gateway_llm",
+		}
+		res, err := p.ProcessResponseBody(t.Context(), inBody)
+		require.NoError(t, err)
+		md := res.DynamicMetadata
+		require.NotNil(t, md)
+		fields := md.Fields[internalapi.AIGatewayFilterMetadataNamespace].GetStructValue().Fields
+		require.Equal(t, float64(0), fields["g_output_token"].GetNumberValue())
+		require.Equal(t, float64(0), fields["g_total_token"].GetNumberValue())
+		require.Equal(t, "some_backend", fields["backend_name"].GetStringValue())
+		mm.RequireRequestFailure(t)
+	})
+
+	// If buildDynamicMetadata errors on the error path (e.g. a CEL cost expression
+	// that fails), the response must still succeed: metadata is skipped and a
+	// warning logged, rather than the error propagating and failing the response.
+	// On real error responses token costs are 0, but we pre-set non-zero costs
+	// here so the CEL unsigned-subtraction overflows and exercises the guard.
+	t.Run("non-2xx status skips metadata on CEL error", func(t *testing.T) {
+		inBody := &extprocv3.HttpBody{Body: []byte("error-body"), EndOfStream: true}
+		mm := &mockMetrics{}
+		mt := &mockTranslator{
+			t: t, expResponseBody: inBody,
+			retHeaderMutation: []internalapi.Header{{"foo", "bar"}},
+			retBodyMutation:   []byte("error-body"),
+		}
+		// input_tokens - output_tokens overflows (uint) when input < output.
+		// NewProgram sanity-checks at all-zero (0-0 = 0, OK), so this compiles.
+		celProg, err := llmcostcel.NewProgram("input_tokens - output_tokens")
+		require.NoError(t, err)
+		var costs metrics.TokenUsage
+		costs.SetInputTokens(1)
+		costs.SetOutputTokens(5) // 1 - 5 => unsigned overflow => CEL error
+		p := &chatCompletionProcessorUpstreamFilter{
+			translator: mt,
+			metrics:    mm,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			parent: &chatCompletionProcessorRouterFilter{
+				config: &filterapi.RuntimeConfig{
+					RequestCosts: []filterapi.RuntimeRequestCost{
+						{CELProg: celProg, LLMRequestCost: &filterapi.LLMRequestCost{RouteName: "some_route", Type: filterapi.LLMRequestCostTypeCEL, MetadataKey: "cel_diff"}},
+					},
+				},
+			},
+			requestHeaders:    map[string]string{internalapi.ModelNameHeaderKeyDefault: "ai_gateway_llm"},
+			responseHeaders:   map[string]string{":status": "500"},
+			backendName:       "some_backend",
+			routeName:         "some_route",
+			modelNameOverride: "ai_gateway_llm",
+			costs:             costs,
+		}
+		res, procErr := p.ProcessResponseBody(t.Context(), inBody)
+		require.NoError(t, procErr, "CEL error must not fail the error response")
+		require.Nil(t, res.DynamicMetadata, "metadata is skipped when CEL evaluation errors")
+		mm.RequireRequestFailure(t)
+	})
+
 	// Verify streaming only records completion on EndOfStream.
 	t.Run("streaming completion only at end", func(t *testing.T) {
 		mm := &mockMetrics{}

--- a/tests/e2e/backend_quota_ratelimit_test.go
+++ b/tests/e2e/backend_quota_ratelimit_test.go
@@ -93,6 +93,22 @@ func Test_Examples_BackendQuotaRateLimit(t *testing.T) {
 		makeRequest("quota-test-model", 5, http.StatusTooManyRequests)
 		requireQuotaUsage(t, "quota-test-model", 22)
 	})
+
+	// A non-2xx (failed) response must not charge token quota. The extproc
+	// error path emits token costs of 0 (no tokens were consumed), so even though
+	// the stream-done rate-limit descriptor now fires on failed requests, its
+	// hits_addend is 0. If the failed request's 100 total_tokens were charged,
+	// the 10-token limit would be exceeded and the next request would 429.
+	t.Run("non-2xx response does not charge token quota", func(t *testing.T) {
+		flushQuotaKeys(t)
+		// Upstream returns 500 with a body claiming 100 total_tokens.
+		errHdr := http.Header{}
+		errHdr.Set(testupstreamlib.ResponseStatusKey, "500")
+		makeRequest("quota-test-model", 100, http.StatusInternalServerError, errHdr)
+		// The subsequent request must succeed: the failed request's 0 tokens
+		// did not count against the 10-token-per-hour quota.
+		makeRequest("quota-test-model", 2, http.StatusOK)
+	})
 }
 
 // redisExec runs a redis-cli command on the Redis pod and returns the output.


### PR DESCRIPTION
**Description**

When an upstream LLM returns a non-2xx response, ProcessResponseBody returns
early after translator.ResponseError and never calls buildDynamicMetadata.
resp.DynamicMetadata stays nil, so the access log reads every LLM dimension as
null for failed requests: gen_ai.provider.name, gen_ai.response.model, and all
gen_ai.usage.* token fields (input/output/total/reasoning), even though the
request was routed to a backend (upstream_host is populated).

This defeats the access log for exactly the requests operators most need to
debug, and nullifies gen_ai.usage.reasoning_tokens for failed reasoning-model
calls.

backend_name and model_name_override are known at request time (SetBackend) and
do not depend on a successful response body, so withholding them on errors is
unjustified.

## Fix

On the error branch of ProcessResponseBody, when body.EndOfStream and request
costs are configured, call buildDynamicMetadata with responseModel empty and
attach it to resp.DynamicMetadata, mirroring the success path. Updated the
buildDynamicMetadata doc comment accordingly.

- Token costs are 0 on errors (no tokens consumed), so the rate-limit
  stream-done hits_addend (which reads the cost via quotaHitsAddend) stays 0:
  observability only, no quota behavioral change.
- response_model stays absent on errors because error responses carry no model
  (buildDynamicMetadata only emits it when non-empty).

## Test

Added a subtest "non-2xx status emits dynamic metadata at end of stream"
asserting backend_name, ai_service_backend_name, model_name_override, route_name
are present and token costs are 0, response_model absent, on a 500 response.

go test ./internal/extproc/... passes.

## Verified live

aigw run against an OpenAI-compatible backend, sending a request the upstream
rejects (gpt-4o-mini, 400):

Before: gen_ai.provider.name=null, gen_ai.usage.input_tokens=null,
gen_ai.usage.output_tokens=null, gen_ai.usage.reasoning_tokens=null
(upstream_host present).

After: gen_ai.provider.name="default/openai/route/aigw-run/rule/0/ref/0",
gen_ai.usage.input_tokens=0, gen_ai.usage.output_tokens=0.

reasoning_tokens is null on this branch only because the reasoning cost rule
itself is added by a separate change (#2438); once configured, it follows the
same path and will read 0 on errors instead of null.

Fixes #2440
