### PR TITLE
extproc: scope /v1/models by non-model exact-match headers

### DIFF
--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -375,6 +375,10 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 	// ec.UnscopedModels (and merge them into ec.ModelsByHost) when at least one route
 	// IS hostname-scoped; otherwise the existing ec.Models list already covers them.
 	var unscopedModels []filterapi.Model
+	// Models contributed by rules with no non-model exact-match headers. Promoted to
+	// UnscopedHeaderModels when at least one header-scoped rule is also present.
+	var unscopedHeaderModels []filterapi.Model
+	var hasHeaderScopedRules bool
 
 	for i := range aiGatewayRoutes {
 		aiGatewayRoute := &aiGatewayRoutes[i]
@@ -392,33 +396,66 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		for ruleIndex := range spec.Rules {
 			rule := &spec.Rules[ruleIndex]
 			for _, m := range rule.Matches {
-				for _, h := range m.Headers {
+				var modelHeader *gwapiv1.HTTPHeaderMatch
+				var scopeHeaders []gwapiv1.HTTPHeaderMatch
+				for headerIndex, h := range m.Headers {
 					// If explicitly set to something that is not an exact match, skip.
 					// If not set, we assume it's an exact match.
-					//
-					// Also, we only care about the AIModel header to declare models.
-					if (h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact) || string(h.Name) != internalapi.ModelNameHeaderKeyDefault {
+					if h.Type != nil && *h.Type != gwapiv1.HeaderMatchExact {
 						continue
 					}
-					model := filterapi.Model{
-						Name:      h.Value,
-						CreatedAt: ptr.Deref[metav1.Time](rule.ModelsCreatedAt, aiGatewayRoute.CreationTimestamp).UTC(),
-						OwnedBy:   ptr.Deref(rule.ModelsOwnedBy, defaultOwnedBy),
+					if string(h.Name) == internalapi.ModelNameHeaderKeyDefault {
+						modelHeader = &m.Headers[headerIndex]
+						continue
 					}
-					ec.Models = append(ec.Models, model)
-					if len(hostnames) > 0 {
-						if ec.ModelsByHost == nil {
-							ec.ModelsByHost = make(map[string][]filterapi.Model)
-						}
-						for _, hn := range hostnames {
-							ec.ModelsByHost[string(hn)] = append(ec.ModelsByHost[string(hn)], model)
-						}
-					} else {
-						// Routes without hostnames are "unscoped": they apply to every host.
-						// Tracked in unscopedModels for now; only promoted to ec.UnscopedModels
-						// after the loop if at least one scoped route is also present.
-						unscopedModels = append(unscopedModels, model)
+					scopeHeaders = append(scopeHeaders, h)
+				}
+				if modelHeader == nil {
+					continue
+				}
+				model := filterapi.Model{
+					Name:      modelHeader.Value,
+					CreatedAt: ptr.Deref[metav1.Time](rule.ModelsCreatedAt, aiGatewayRoute.CreationTimestamp).UTC(),
+					OwnedBy:   ptr.Deref(rule.ModelsOwnedBy, defaultOwnedBy),
+				}
+				ec.Models = append(ec.Models, model)
+				if len(hostnames) > 0 {
+					if ec.ModelsByHost == nil {
+						ec.ModelsByHost = make(map[string][]filterapi.Model)
 					}
+					for _, hn := range hostnames {
+						ec.ModelsByHost[string(hn)] = append(ec.ModelsByHost[string(hn)], model)
+					}
+				} else {
+					// Routes without hostnames are "unscoped": they apply to every host.
+					// Tracked in unscopedModels for now; only promoted to ec.UnscopedModels
+					// after the loop if at least one scoped route is also present.
+					unscopedModels = append(unscopedModels, model)
+				}
+				scopeKey := canonicalHeaderScopeKey(scopeHeaders)
+				if scopeKey == "" {
+					unscopedHeaderModels = append(unscopedHeaderModels, model)
+					continue
+				}
+				hasHeaderScopedRules = true
+				if ec.ModelsByHostAndScope == nil {
+					ec.ModelsByHostAndScope = make(map[string]filterapi.HeaderScopedModels)
+				}
+				hostKeys := make([]string, 0, max(1, len(hostnames)))
+				if len(hostnames) > 0 {
+					for _, hn := range hostnames {
+						hostKeys = append(hostKeys, string(hn))
+					}
+				} else {
+					hostKeys = append(hostKeys, "")
+				}
+				for _, hostKey := range hostKeys {
+					hsm := ec.ModelsByHostAndScope[hostKey]
+					if hsm.ModelsByHeaderScope == nil {
+						hsm.ModelsByHeaderScope = make(map[string][]filterapi.Model)
+					}
+					hsm.ModelsByHeaderScope[scopeKey] = append(hsm.ModelsByHeaderScope[scopeKey], model)
+					ec.ModelsByHostAndScope[hostKey] = hsm
 				}
 			}
 			for backendRefIndex := range rule.BackendRefs {
@@ -531,6 +568,18 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		ec.UnscopedModels = unscopedModels
 		for hn := range ec.ModelsByHost {
 			ec.ModelsByHost[hn] = append(ec.ModelsByHost[hn], unscopedModels...)
+		}
+	}
+
+	// If at least one rule is header-scoped, promote unscoped-header models so every scope bucket
+	// (and the unmatched-scope fallback) still sees models from rules without scope headers.
+	if hasHeaderScopedRules && len(unscopedHeaderModels) > 0 {
+		for hostKey, hsm := range ec.ModelsByHostAndScope {
+			hsm.UnscopedHeaderModels = unscopedHeaderModels
+			for scopeKey := range hsm.ModelsByHeaderScope {
+				hsm.ModelsByHeaderScope[scopeKey] = append(hsm.ModelsByHeaderScope[scopeKey], unscopedHeaderModels...)
+			}
+			ec.ModelsByHostAndScope[hostKey] = hsm
 		}
 	}
 
@@ -1343,4 +1392,17 @@ func (c *GatewayController) fetchGatewayConfig(ctx context.Context, gw *gwapiv1.
 	c.logger.Info("found GatewayConfig for Gateway",
 		"gateway_name", gw.Name, "gateway_namespace", gw.Namespace, "gatewayconfig_name", configName)
 	return &gatewayConfig, nil
+}
+
+// canonicalHeaderScopeKey returns a stable key for exact-match scope headers, excluding x-ai-eg-model.
+// An empty string means the rule has no header scope.
+func canonicalHeaderScopeKey(headers []gwapiv1.HTTPHeaderMatch) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	pairs := make(map[string]string, len(headers))
+	for _, h := range headers {
+		pairs[strings.ToLower(string(h.Name))] = h.Value
+	}
+	return filterapi.CanonicalHeaderScopeKey(pairs)
 }

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -526,6 +526,165 @@ func TestGatewayController_reconcileFilterConfigSecret_AllUnscopedRoutesLeaveUns
 	require.Nil(t, fc.UnscopedModels)
 }
 
+// TestGatewayController_reconcileFilterConfigSecret_HeaderScopedModels verifies that rules with
+// non-model exact-match headers produce separate ModelsByHeaderScope entries and that unscoped
+// header models are promoted without leaking scoped models to other scopes.
+func TestGatewayController_reconcileFilterConfigSecret_HeaderScopedModels(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
+	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	const gwNamespace = "ns"
+	routes := []aigv1b1.AIGatewayRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "client-a-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: "x-jwt-sub", Value: "client-a"},
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "model-a"},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "client-b-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "orange"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: "x-jwt-sub", Value: "client-b"},
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "model-b"},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "unscoped-header-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "banana"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "shared-model"},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, b := range []*aigv1b1.AIServiceBackend{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: gwNamespace},
+			Spec: aigv1b1.AIServiceBackendSpec{
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "orange", Namespace: gwNamespace},
+			Spec: aigv1b1.AIServiceBackendSpec{
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "banana", Namespace: gwNamespace},
+			Spec: aigv1b1.AIServiceBackendSpec{
+				BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+			},
+		},
+	} {
+		require.NoError(t, fakeClient.Create(t.Context(), b))
+	}
+
+	const someNamespace = "some-namespace"
+	effective, err := c.reconcileFilterConfigSecret(t.Context(), "gw-header-scope", gwNamespace, someNamespace, routes, nil, "foouuid", nil)
+	require.NoError(t, err)
+	require.True(t, effective)
+
+	fc := requireFilterConfigFromBundle(t, kube, someNamespace, "gw-header-scope", gwNamespace)
+
+	require.Contains(t, fc.ModelsByHostAndScope, "")
+	hsm := fc.ModelsByHostAndScope[""]
+	require.Contains(t, hsm.ModelsByHeaderScope, "x-jwt-sub=client-a")
+	require.Contains(t, hsm.ModelsByHeaderScope, "x-jwt-sub=client-b")
+	require.Len(t, hsm.UnscopedHeaderModels, 1)
+	require.Equal(t, "shared-model", hsm.UnscopedHeaderModels[0].Name)
+
+	clientAModels := modelNames(hsm.ModelsByHeaderScope["x-jwt-sub=client-a"])
+	require.ElementsMatch(t, []string{"model-a", "shared-model"}, clientAModels)
+	clientBModels := modelNames(hsm.ModelsByHeaderScope["x-jwt-sub=client-b"])
+	require.ElementsMatch(t, []string{"model-b", "shared-model"}, clientBModels)
+}
+
+// TestGatewayController_reconcileFilterConfigSecret_HostnameAndHeaderScopedModels verifies that
+// hostname and header scoping compose: models land in the correct host bucket and scope key.
+func TestGatewayController_reconcileFilterConfigSecret_HostnameAndHeaderScopedModels(t *testing.T) {
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: zapcore.DebugLevel})))
+	c := NewGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	const gwNamespace = "ns"
+	routes := []aigv1b1.AIGatewayRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "scoped-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Hostnames: []gwapiv1.Hostname{"api.example.com"},
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}},
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: "x-jwt-sub", Value: "client-a"},
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "host-scoped-model"},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: gwNamespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+		},
+	}))
+
+	const someNamespace = "some-namespace"
+	effective, err := c.reconcileFilterConfigSecret(t.Context(), "gw-host-header", gwNamespace, someNamespace, routes, nil, "foouuid", nil)
+	require.NoError(t, err)
+	require.True(t, effective)
+
+	fc := requireFilterConfigFromBundle(t, kube, someNamespace, "gw-host-header", gwNamespace)
+	require.Contains(t, fc.ModelsByHostAndScope, "api.example.com")
+	hsm := fc.ModelsByHostAndScope["api.example.com"]
+	require.Contains(t, hsm.ModelsByHeaderScope, "x-jwt-sub=client-a")
+	require.Equal(t, []string{"host-scoped-model"}, modelNames(hsm.ModelsByHeaderScope["x-jwt-sub=client-a"]))
+}
+
+func modelNames(models []filterapi.Model) []string {
+	names := make([]string, 0, len(models))
+	for _, m := range models {
+		names = append(names, m.Name)
+	}
+	return names
+}
+
 // TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostAggregation verifies that
 // routes sharing the same metadataKey each get their own filter-config row (scoped by routeName).
 func TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostAggregation(t *testing.T) {

--- a/internal/extproc/models_processor.go
+++ b/internal/extproc/models_processor.go
@@ -42,7 +42,7 @@ func NewModelsProcessor(config *filterapi.RuntimeConfig, requestHeaders map[stri
 	}
 
 	host := requestHost(requestHeaders)
-	selectedModels := selectModelsForHost(host, config)
+	selectedModels := selectModels(requestHeaders, host, config)
 
 	modelList := openai.ModelList{
 		Object: "list",
@@ -104,6 +104,88 @@ func requestHost(headers map[string]string) string {
 		host = h
 	}
 	return strings.ToLower(host)
+}
+
+// selectModels returns the models for the request, applying hostname and header scoping when configured.
+func selectModels(requestHeaders map[string]string, host string, cfg *filterapi.RuntimeConfig) []filterapi.Model {
+	if len(cfg.ModelsByHostAndScope) == 0 {
+		return selectModelsForHost(host, cfg)
+	}
+	hsm := lookupHeaderScopedModels(host, cfg)
+	return selectModelsForHeaderScope(requestHeaders, hsm)
+}
+
+// lookupHeaderScopedModels resolves the header-scoped model group for the request host.
+func lookupHeaderScopedModels(host string, cfg *filterapi.RuntimeConfig) filterapi.HeaderScopedModels {
+	if len(cfg.ModelsByHostAndScope) == 0 {
+		return filterapi.HeaderScopedModels{}
+	}
+	if len(cfg.ModelsByHost) == 0 {
+		return cfg.ModelsByHostAndScope[""]
+	}
+	if hsm, ok := cfg.ModelsByHostAndScope[host]; ok {
+		return hsm
+	}
+	if bestMatch := wildcardHostScopedModels(host, cfg.ModelsByHostAndScope); bestMatch != nil {
+		return *bestMatch
+	}
+	return cfg.ModelsByHostAndScope[""]
+}
+
+func wildcardHostScopedModels(host string, modelsByHostAndScope map[string]filterapi.HeaderScopedModels) *filterapi.HeaderScopedModels {
+	bestMatchLength := -1
+	var bestMatch *filterapi.HeaderScopedModels
+	for pattern, hsm := range modelsByHostAndScope {
+		if !strings.HasPrefix(pattern, "*.") {
+			continue
+		}
+		suffix := strings.TrimPrefix(pattern, "*.")
+		if !strings.HasSuffix(host, "."+suffix) {
+			continue
+		}
+		prefix := strings.TrimSuffix(host, "."+suffix)
+		if strings.Contains(prefix, ".") {
+			continue
+		}
+		if len(suffix) > bestMatchLength {
+			bestMatchLength = len(suffix)
+			match := hsm
+			bestMatch = &match
+		}
+	}
+	return bestMatch
+}
+
+// selectModelsForHeaderScope returns models for the request's header scope within a host bucket.
+func selectModelsForHeaderScope(requestHeaders map[string]string, hsm filterapi.HeaderScopedModels) []filterapi.Model {
+	if len(hsm.ModelsByHeaderScope) == 0 {
+		return hsm.UnscopedHeaderModels
+	}
+	scopeKey := filterapi.RequestHeaderScopeKey(hsm.ModelsByHeaderScope, requestHeaders)
+	var selected []filterapi.Model
+	if scopeKey != "" {
+		if models, ok := hsm.ModelsByHeaderScope[scopeKey]; ok {
+			selected = append(selected, models...)
+		}
+	}
+	selected = append(selected, hsm.UnscopedHeaderModels...)
+	return dedupeModelsByName(selected)
+}
+
+func dedupeModelsByName(models []filterapi.Model) []filterapi.Model {
+	if len(models) == 0 {
+		return models
+	}
+	seen := make(map[string]struct{}, len(models))
+	result := make([]filterapi.Model, 0, len(models))
+	for _, model := range models {
+		if _, ok := seen[model.Name]; ok {
+			continue
+		}
+		seen[model.Name] = struct{}{}
+		result = append(result, model)
+	}
+	return result
 }
 
 // selectModelsForHost returns the models for the given host, falling back to the global list.

--- a/internal/extproc/models_processor_test.go
+++ b/internal/extproc/models_processor_test.go
@@ -213,3 +213,68 @@ func Test_selectModelsForHost(t *testing.T) {
 		require.Nil(t, selectModelsForHost("localhost", scopedOnly))
 	})
 }
+
+func Test_selectModelsForHeaderScope(t *testing.T) {
+	clientAModels := []filterapi.Model{{Name: "model-a"}}
+	clientBModels := []filterapi.Model{{Name: "model-b"}}
+	sharedModels := []filterapi.Model{{Name: "shared-model"}}
+
+	hsm := filterapi.HeaderScopedModels{
+		ModelsByHeaderScope: map[string][]filterapi.Model{
+			"x-jwt-sub=client-a": clientAModels,
+			"x-jwt-sub=client-b": clientBModels,
+		},
+		UnscopedHeaderModels: sharedModels,
+	}
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    []filterapi.Model
+	}{
+		{
+			name:    "matching scope returns scoped and shared models",
+			headers: map[string]string{"x-jwt-sub": "client-a"},
+			want:    append(append([]filterapi.Model{}, clientAModels...), sharedModels...),
+		},
+		{
+			name:    "unknown scope returns shared models only",
+			headers: map[string]string{"x-jwt-sub": "client-c"},
+			want:    sharedModels,
+		},
+		{
+			name:    "missing scope header returns shared models only",
+			headers: map[string]string{},
+			want:    sharedModels,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, selectModelsForHeaderScope(tt.headers, hsm))
+		})
+	}
+}
+
+func Test_selectModels(t *testing.T) {
+	cfg := &filterapi.RuntimeConfig{
+		DeclaredModels: []filterapi.Model{{Name: "legacy-model"}},
+		ModelsByHostAndScope: map[string]filterapi.HeaderScopedModels{
+			"": {
+				ModelsByHeaderScope: map[string][]filterapi.Model{
+					"x-jwt-sub=client-a": {{Name: "scoped-model"}},
+				},
+			},
+		},
+	}
+
+	require.Equal(t, []filterapi.Model{{Name: "scoped-model"}}, selectModels(map[string]string{
+		"x-jwt-sub": "client-a",
+	}, "", cfg))
+	require.Equal(t, []filterapi.Model(nil), selectModels(map[string]string{
+		"x-jwt-sub": "client-b",
+	}, "", cfg))
+	require.Equal(t, cfg.DeclaredModels, selectModels(nil, "", &filterapi.RuntimeConfig{
+		DeclaredModels: cfg.DeclaredModels,
+	}))
+}

--- a/internal/filterapi/filterconfig.go
+++ b/internal/filterapi/filterconfig.go
@@ -50,8 +50,22 @@ type Config struct {
 	// configured, requests to a host that doesn't match any entry fall back to this list (rather than to Models, which
 	// would leak host-scoped models to unknown hosts).
 	UnscopedModels []Model `json:"unscopedModels,omitempty"`
+	// ModelsByHostAndScope maps hostname to header-scoped model groups. When a route has no hostnames, use "" as the
+	// host key. Header scoping composes with hostname scoping: a rule with both hostnames and scope headers contributes
+	// only when both match.
+	ModelsByHostAndScope map[string]HeaderScopedModels `json:"modelsByHostAndScope,omitempty"`
 	// MCPConfig is the configuration for the MCPRoute implementations.
 	MCPConfig *MCPConfig `json:"mcpConfig,omitempty"`
+}
+
+// HeaderScopedModels groups models by header scope within a host (or globally when the host key is "").
+type HeaderScopedModels struct {
+	// ModelsByHeaderScope maps a canonical scope key to models. The scope key is a sorted, comma-separated list of
+	// lowercased "name=value" pairs for all exact-match headers in a rule except x-ai-eg-model, e.g. "x-jwt-sub=client-a".
+	ModelsByHeaderScope map[string][]Model `json:"modelsByHeaderScope,omitempty"`
+	// UnscopedHeaderModels holds models from rules with no non-model exact-match headers. Visible to all header scopes
+	// on the same host; also returned when the request does not match any scoped rule.
+	UnscopedHeaderModels []Model `json:"unscopedHeaderModels,omitempty"`
 }
 
 // Model corresponds to the OpenAI model object in the OpenAI-compatible APIs

--- a/internal/filterapi/headerscope.go
+++ b/internal/filterapi/headerscope.go
@@ -1,0 +1,67 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package filterapi
+
+import (
+	"sort"
+	"strings"
+)
+
+// CanonicalHeaderScopeKey returns a stable key for exact-match scope header pairs.
+// Header names are lowercased per HTTP semantics. An empty map yields an empty string (no header scope).
+func CanonicalHeaderScopeKey(pairs map[string]string) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(pairs))
+	for name := range pairs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, name+"="+pairs[name])
+	}
+	return strings.Join(parts, ",")
+}
+
+// ScopeHeaderNamesFromKeys extracts the header names referenced in configured scope keys.
+func ScopeHeaderNamesFromKeys(modelsByHeaderScope map[string][]Model) map[string]struct{} {
+	names := make(map[string]struct{})
+	for key := range modelsByHeaderScope {
+		for _, part := range strings.Split(key, ",") {
+			if idx := strings.IndexByte(part, '='); idx > 0 {
+				names[part[:idx]] = struct{}{}
+			}
+		}
+	}
+	return names
+}
+
+// RequestHeaderScopeKey builds the canonical scope key from request headers, using only the header names
+// present in the configured scope keys.
+func RequestHeaderScopeKey(modelsByHeaderScope map[string][]Model, requestHeaders map[string]string) string {
+	if len(modelsByHeaderScope) == 0 {
+		return ""
+	}
+	names := ScopeHeaderNamesFromKeys(modelsByHeaderScope)
+	pairs := make(map[string]string, len(names))
+	for name := range names {
+		if value := headerValueCaseInsensitive(requestHeaders, name); value != "" {
+			pairs[name] = value
+		}
+	}
+	return CanonicalHeaderScopeKey(pairs)
+}
+
+func headerValueCaseInsensitive(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/filterapi/headerscope_test.go
+++ b/internal/filterapi/headerscope_test.go
@@ -1,0 +1,60 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package filterapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalHeaderScopeKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		pairs map[string]string
+		want  string
+	}{
+		{
+			name:  "empty",
+			pairs: nil,
+			want:  "",
+		},
+		{
+			name:  "single header",
+			pairs: map[string]string{"x-jwt-sub": "client-a"},
+			want:  "x-jwt-sub=client-a",
+		},
+		{
+			name: "multiple headers sorted",
+			pairs: map[string]string{
+				"x-tenant-id": "tenant-1",
+				"x-jwt-sub":   "client-a",
+			},
+			want: "x-jwt-sub=client-a,x-tenant-id=tenant-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, CanonicalHeaderScopeKey(tt.pairs))
+		})
+	}
+}
+
+func TestRequestHeaderScopeKey(t *testing.T) {
+	modelsByScope := map[string][]Model{
+		"x-jwt-sub=client-a": {{Name: "m1"}},
+		"x-jwt-sub=client-b": {{Name: "m2"}},
+	}
+
+	require.Equal(t, "x-jwt-sub=client-a", RequestHeaderScopeKey(modelsByScope, map[string]string{
+		"X-JWT-Sub": "client-a",
+	}))
+	require.Equal(t, "x-jwt-sub=unknown", RequestHeaderScopeKey(modelsByScope, map[string]string{
+		"x-jwt-sub": "unknown",
+	}))
+	require.Empty(t, RequestHeaderScopeKey(modelsByScope, nil))
+}

--- a/internal/filterapi/runtime.go
+++ b/internal/filterapi/runtime.go
@@ -43,6 +43,8 @@ type RuntimeConfig struct {
 	// UnscopedModels is the fallback returned for hosts that don't match any ModelsByHost entry. Populated from routes
 	// that did NOT declare hostnames; kept separate from DeclaredModels so we don't leak scoped models to unknown hosts.
 	UnscopedModels []Model
+	// ModelsByHostAndScope maps hostname to header-scoped model groups for per-header filtering of /v1/models.
+	ModelsByHostAndScope map[string]HeaderScopedModels
 	// Backends is the map of backends by name.
 	Backends map[string]*RuntimeBackend
 }
@@ -124,12 +126,13 @@ func NewRuntimeConfig(ctx context.Context, config *Config, fn NewBackendAuthHand
 	}
 
 	return &RuntimeConfig{
-		UUID:               config.UUID,
-		Backends:           backends,
-		GlobalRequestCosts: globalCosts,
-		RequestCosts:       costs,
-		DeclaredModels:     config.Models,
-		ModelsByHost:       config.ModelsByHost,
-		UnscopedModels:     config.UnscopedModels,
+		UUID:                 config.UUID,
+		Backends:             backends,
+		GlobalRequestCosts:   globalCosts,
+		RequestCosts:         costs,
+		DeclaredModels:       config.Models,
+		ModelsByHost:         config.ModelsByHost,
+		UnscopedModels:       config.UnscopedModels,
+		ModelsByHostAndScope: config.ModelsByHostAndScope,
 	}, nil
 }

--- a/site/docs/capabilities/llm-integrations/supported-endpoints.md
+++ b/site/docs/capabilities/llm-integrations/supported-endpoints.md
@@ -437,6 +437,12 @@ For OpenAI-compatible backends that natively support tokenization (e.g., vLLM), 
 - ✅ Returns models declared in AIGatewayRoute configurations
 - ✅ OpenAI-compatible response format
 - ✅ Model metadata (ID, owned_by, created timestamp)
+- ✅ Hostname scoping when routes declare `spec.hostnames` (see v0.7 release notes)
+- ✅ Header scoping when rules use exact-match headers other than `x-ai-eg-model` (e.g. `x-jwt-sub` for JWT tenant routing)
+
+When multiple `AIGatewayRoute` rules on a shared hostname match on different exact headers, `GET /v1/models` returns only models from rules whose scope headers match the incoming request. Rules without scope headers remain visible to all requests on that host. Header scoping composes with hostname scoping.
+
+Scope headers must be present on the request when the external processor runs (for example via JWT `claimToHeaders` with `recomputeRoute: true`, the same pattern used for chat routing).
 
 **Example:**
 

--- a/tests/e2e/models_header_scope_jwt_test.go
+++ b/tests/e2e/models_header_scope_jwt_test.go
@@ -1,0 +1,168 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
+	"github.com/envoyproxy/ai-gateway/tests/internal/e2elib"
+)
+
+// TestModelsHeaderScopeJWT reproduces envoyproxy/ai-gateway#2452 end-to-end:
+// JWT sub is projected to x-jwt-sub via Envoy Gateway SecurityPolicy (claimToHeaders +
+// recomputeRoute), and GET /v1/models returns only models for the matching tenant.
+func TestModelsHeaderScopeJWT(t *testing.T) {
+	const manifest = "testdata/models_header_scope_jwt.yaml"
+	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(context.Background(), manifest)
+	})
+
+	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=models-header-scope-jwt"
+	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
+
+	fwd := e2elib.RequireNewHTTPPortForwarder(t, e2elib.EnvoyGatewayNamespace, egSelector, e2elib.EnvoyGatewayDefaultServicePort)
+	defer fwd.Kill()
+
+	t.Run("client-a models only", func(t *testing.T) {
+		internaltesting.RequireEventuallyNoError(t, func() error {
+			got, err := listModelIDs(t, fwd, makeTenantJWT(t, "client-a"))
+			if err != nil {
+				return err
+			}
+			if !sameStringSet(got, []string{"model-a1", "model-a2"}) {
+				return fmt.Errorf("unexpected models for client-a: %v", got)
+			}
+			return nil
+		}, 60*time.Second, 3*time.Second)
+	})
+
+	t.Run("client-b models only", func(t *testing.T) {
+		internaltesting.RequireEventuallyNoError(t, func() error {
+			got, err := listModelIDs(t, fwd, makeTenantJWT(t, "client-b"))
+			if err != nil {
+				return err
+			}
+			if !sameStringSet(got, []string{"model-b1", "model-b2"}) {
+				return fmt.Errorf("unexpected models for client-b: %v", got)
+			}
+			return nil
+		}, 60*time.Second, 3*time.Second)
+	})
+
+	t.Run("missing jwt is denied", func(t *testing.T) {
+		internaltesting.RequireEventuallyNoError(t, func() error {
+			status, err := modelsListStatus(t, fwd, "")
+			if err != nil {
+				return err
+			}
+			if status != http.StatusUnauthorized {
+				return fmt.Errorf("expected 401 without JWT, got %d", status)
+			}
+			return nil
+		}, 60*time.Second, 3*time.Second)
+	})
+}
+
+func makeTenantJWT(t *testing.T, sub string) string {
+	t.Helper()
+	now := time.Now()
+	return makeSignedJWTWithClaims(t, jwt.MapClaims{
+		"iss": "https://auth-server.example.com",
+		"sub": sub,
+		"iat": now.Unix(),
+		"exp": now.Add(30 * time.Minute).Unix(),
+	})
+}
+
+func listModelIDs(t *testing.T, fwd e2elib.PortForwarder, token string) ([]string, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fwd.Address()+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET /v1/models returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var models openai.ModelList
+	if err := json.Unmarshal(body, &models); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(models.Data))
+	for _, model := range models.Data {
+		ids = append(ids, model.ID)
+	}
+	return ids, nil
+}
+
+func modelsListStatus(t *testing.T, fwd e2elib.PortForwarder, token string) (int, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fwd.Address()+"/v1/models", nil)
+	if err != nil {
+		return 0, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, nil
+}
+
+func sameStringSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(got))
+	for _, id := range got {
+		seen[id] = struct{}{}
+	}
+	for _, id := range want {
+		if _, ok := seen[id]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/e2e/testdata/models_header_scope_jwt.yaml
+++ b/tests/e2e/testdata/models_header_scope_jwt.yaml
@@ -1,0 +1,245 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: models-header-scope-jwt
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: models-header-scope-jwt
+  namespace: default
+spec:
+  gatewayClassName: models-header-scope-jwt
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: models-header-scope-jwt
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: models-header-scope-jwt
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          resources: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: models-header-scope-jwt-jwks
+  namespace: default
+data:
+  jwks: |
+    {
+      "keys": [
+        {
+          "alg": "RS256",
+          "e": "AQAB",
+          "key_ops": [
+            "verify"
+          ],
+          "kty": "RSA",
+          "n": "lQiREO6mH0tV14KjhSz02zNaJ1SExS1QjlGoMSbG2-NUeURmvnwg-eY95sDCFpWuH3_ovFyRBGTi0e3j79mrQhM53PZQys-gr-rYGz8LeHp8G6H3XmeDxTvyemhB6uiN4EZkjOo6xT2ipmPEN3u315xPCR60Pwac2E0t4vZGxtU4LGYatIFOYtUvDdMPBLfGMKVapHBzbx9Ll4INEic1fNrAIUVtOn6i3sxzGHj4iGWsMrEUIXDOWEHzioXgPuRjJDRjhHRuEeA9i_Y-a9hY92q6P-dcPnCDLNF3349WDyw7jIMlU6TLM8lQ5ci_TS_0avovXPNECsuOObtT78LJJKLg58ghTnqrihwvSccVgW4M43Ntv7TOAgOsRl-NKY7QQJIbkxemvh14-gzwA6LijMvb0Tjrh6NynKfCIO0ASsMp3K3uks4cYhBALLJ1E41V-cYqdwg0c6Jam0Y4OXxNv_0FfmcsOk8iXdroNgWjBs3KaObMiMvNOKHNWZ4PsEll",
+          "use": "sig",
+          "kid": "8b267675394d7786f98ae29d8fddf905"
+        }
+      ]
+    }
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIGatewayRoute
+metadata:
+  name: models-header-scope-jwt
+  namespace: default
+spec:
+  parentRefs:
+    - name: models-header-scope-jwt
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-jwt-sub
+              value: client-a
+            - type: Exact
+              name: x-ai-eg-model
+              value: model-a1
+      backendRefs:
+        - name: models-header-scope-jwt-backend
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-jwt-sub
+              value: client-a
+            - type: Exact
+              name: x-ai-eg-model
+              value: model-a2
+      backendRefs:
+        - name: models-header-scope-jwt-backend
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-jwt-sub
+              value: client-b
+            - type: Exact
+              name: x-ai-eg-model
+              value: model-b1
+      backendRefs:
+        - name: models-header-scope-jwt-backend
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-jwt-sub
+              value: client-b
+            - type: Exact
+              name: x-ai-eg-model
+              value: model-b2
+      backendRefs:
+        - name: models-header-scope-jwt-backend
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: models-header-scope-jwt-policy
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: models-header-scope-jwt
+  jwt:
+    providers:
+      - name: tenant-jwt
+        issuer: https://auth-server.example.com
+        recomputeRoute: true
+        claimToHeaders:
+          - claim: sub
+            header: x-jwt-sub
+        localJWKS:
+          type: ValueRef
+          valueRef:
+            group: ""
+            kind: ConfigMap
+            name: models-header-scope-jwt-jwks
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-tenant-clients
+        action: Allow
+        principal:
+          jwt:
+            provider: tenant-jwt
+            claims:
+              - name: sub
+                values:
+                  - client-a
+                  - client-b
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: models-header-scope-jwt-backend
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    name: models-header-scope-jwt-upstream
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: BackendSecurityPolicy
+metadata:
+  name: models-header-scope-jwt-backend-api-key
+  namespace: default
+spec:
+  type: APIKey
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: models-header-scope-jwt-backend
+  apiKey:
+    secretRef:
+      name: models-header-scope-jwt-backend-api-key
+      namespace: default
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: models-header-scope-jwt-backend-api-key
+  namespace: default
+type: Opaque
+stringData:
+  apiKey: dummy-token
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: models-header-scope-jwt-upstream
+  namespace: default
+spec:
+  endpoints:
+    - fqdn:
+        hostname: models-header-scope-jwt-upstream.default.svc.cluster.local
+        port: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: models-header-scope-jwt-upstream
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: models-header-scope-jwt-upstream
+  template:
+    metadata:
+      labels:
+        app: models-header-scope-jwt-upstream
+    spec:
+      containers:
+        - name: models-header-scope-jwt-upstream
+          image: docker.io/envoyproxy/ai-gateway-testupstream:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: models-header-scope-jwt-upstream
+  namespace: default
+spec:
+  selector:
+    app: models-header-scope-jwt-upstream
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
**Description**

When `AIGatewayRoute` rules match on exact headers other than `x-ai-eg-model` (for example `x-jwt-sub` injected from JWT `sub` via Envoy Gateway `SecurityPolicy` with `claimToHeaders` and `recomputeRoute: true`), `GET /v1/models` now returns only models from rules whose scope headers match the incoming request. This mirrors the hostname scoping behavior added in #2160.

Previously the controller indexed only `x-ai-eg-model` values into the global model catalog, so tenants on a shared hostname saw the union of all declared models even when chat/completions routing was correctly scoped.

Changes:
- Add `ModelsByHostAndScope` / `HeaderScopedModels` to the filter config and wire it through runtime.
- Index models by canonical header scope key in the gateway controller.
- Filter `/v1/models` responses in extproc using request scope headers.
- Add unit tests for controller and extproc selection.
- Add e2e coverage reproducing #2452 with Envoy Gateway `SecurityPolicy` JWT claim projection.
- Document header-scoped `/v1/models` in `supported-endpoints.md`.

**Related Issues/PRs (if applicable)**

Fixes #2452

Related: #2160 (hostname scoping pattern)

**Special notes for reviewers (if applicable)**

- Header scoping composes with hostname scoping: rules with both `hostnames` and scope headers are indexed under the host bucket and filtered by scope at runtime.
- Rules without scope headers remain visible to all requests on the same host (same opt-in pattern as unscoped hostnames).
- Scope headers must be present on the request when extproc runs (e.g. JWT `claimToHeaders` + `recomputeRoute`, same as chat routing).
- E2e fixture: `tests/e2e/testdata/models_header_scope_jwt.yaml` + `TestModelsHeaderScopeJWT`.
- AI tooling was used to assist with implementation and tests; changes were reviewed and validated locally with `make precommit` and unit tests.

**Test plan**

- [x] `make precommit`
- [x] Unit tests: `go test ./internal/controller/... -run HeaderScoped`
- [x] Unit tests: `go test ./internal/extproc/... -run selectModels`
- [x] Unit tests: `go test ./internal/filterapi/... -run HeaderScope`
- [x] `TestModelsHeaderScopeJWT` passed locally via `make test-e2e`