### PR TITLE
fix(openai): support Codex agent input items

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -3920,6 +3920,10 @@ type ResponseInputItemUnionParam struct {
 	OfCustomToolCallOutput *ResponseCustomToolCallOutputParam
 	OfCustomToolCall       *ResponseCustomToolCall
 	OfItemReference        *ResponseInputItemItemReferenceParam
+	// Codex-emitted item types whose schema is not yet part of the public Responses API.
+	// Preserve their raw JSON so OpenAI-compatible backends can handle them unchanged.
+	OfAgentMessage   *json.RawMessage
+	OfAgentReasoning *json.RawMessage
 }
 
 func (r ResponseInputItemUnionParam) MarshalJSON() ([]byte, error) { // nolint:gocritic
@@ -3976,6 +3980,10 @@ func (r ResponseInputItemUnionParam) MarshalJSON() ([]byte, error) { // nolint:g
 		return json.Marshal(r.OfCustomToolCall)
 	case r.OfItemReference != nil:
 		return json.Marshal(r.OfItemReference)
+	case r.OfAgentMessage != nil:
+		return json.Marshal(r.OfAgentMessage)
+	case r.OfAgentReasoning != nil:
+		return json.Marshal(r.OfAgentReasoning)
 	default:
 		return nil, errors.New("no input item to marshal")
 	}
@@ -4176,6 +4184,12 @@ func (r *ResponseInputItemUnionParam) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		r.OfItemReference = &ir
+	case "agent_message":
+		raw := json.RawMessage(append([]byte(nil), data...))
+		r.OfAgentMessage = &raw
+	case "agent_reasoning":
+		raw := json.RawMessage(append([]byte(nil), data...))
+		r.OfAgentReasoning = &raw
 	// Add other cases here for different input item types as needed.
 	default:
 		return errors.New("cannot unmarshal unknown input type: " + typ.String())

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -4572,6 +4572,20 @@ func TestResponseInputItemUnionParamMarshalJSON(t *testing.T) {
 			expRes: []byte(`{"type": "message", "role": "assistant", "status": "completed", "id": "resp-123", "content": [{"text": "Hello! How can I assist you ?", "type": "output_text"}]}`),
 		},
 		{
+			name: "marshal agent_message",
+			input: ResponseInputItemUnionParam{
+				OfAgentMessage: ptr.To(json.RawMessage(`{"type":"agent_message","role":"agent","content":[{"type":"text","text":"prior context"}]}`)),
+			},
+			expRes: []byte(`{"type":"agent_message","role":"agent","content":[{"type":"text","text":"prior context"}]}`),
+		},
+		{
+			name: "marshal agent_reasoning",
+			input: ResponseInputItemUnionParam{
+				OfAgentReasoning: ptr.To(json.RawMessage(`{"type":"agent_reasoning","summary":"prior reasoning"}`)),
+			},
+			expRes: []byte(`{"type":"agent_reasoning","summary":"prior reasoning"}`),
+		},
+		{
 			name: "marshal file_search_call",
 			input: ResponseInputItemUnionParam{
 				OfFileSearchCall: &ResponseFileSearchToolCall{
@@ -5372,6 +5386,20 @@ func TestResponseInputItemUnionParamUnmarshalJSON(t *testing.T) {
 				},
 			},
 			input: []byte(`{"type": "item_reference", "id": "id-123"}`),
+		},
+		{
+			name: "unmarshal agent_message",
+			expRes: ResponseInputItemUnionParam{
+				OfAgentMessage: ptr.To(json.RawMessage(`{"type":"agent_message","role":"agent","content":[{"type":"text","text":"prior context"}]}`)),
+			},
+			input: []byte(`{"type":"agent_message","role":"agent","content":[{"type":"text","text":"prior context"}]}`),
+		},
+		{
+			name: "unmarshal agent_reasoning",
+			expRes: ResponseInputItemUnionParam{
+				OfAgentReasoning: ptr.To(json.RawMessage(`{"type":"agent_reasoning","summary":"prior reasoning"}`)),
+			},
+			input: []byte(`{"type":"agent_reasoning","summary":"prior reasoning"}`),
 		},
 		{
 			name:   "unmarshal empty type string",


### PR DESCRIPTION
**Description**

Allow Responses API requests containing Codex-emitted agent_message and agent_reasoning input items to pass through OpenAI-compatible backends.

**Root cause**

The Responses input-item union rejected these types before the request reached the upstream provider.

**Fix**

Preserve the raw JSON for both types, so their evolving Codex-specific fields are forwarded unchanged without requiring an incomplete schema model.

**Related Issue**

Fixes #2442

**Testing**

- go test ./internal/apischema/openai -run '^TestResponseInputItemUnionParam(MarshalJSON|UnmarshalJSON)$' -count=1