### PR TITLE
docs: update Xunzhuo affiliation to AMD

### DIFF
--- a/site/blog/authors.yml
+++ b/site/blog/authors.yml
@@ -54,7 +54,7 @@ mathetake:
     linkedin: https://www.linkedin.com/in/mathetake/
 xunzhuo:
   name: Xunzhuo (Bit) Liu
-  title: Envoy AI Gateway Maintainer - Tencent
+  title: Envoy AI Gateway Maintainer - AMD
   url: https://github.com/Xunzhuo
   image_url: https://github.com/Xunzhuo.png
   page: true


### PR DESCRIPTION
**Description**

Update the current maintainer profile for Xunzhuo from Tencent to AMD following an employment change. Historical talks and release entries retain the affiliation that applied when they were published.

**Related Issues/PRs (if applicable)**

- CNCF affiliation update: https://github.com/cncf/gitdm/pull/1210

**Special notes for reviewers (if applicable)**

This intentionally changes only the current author profile.
