### PR TITLE
fix: accept SSE data lines without a space after the colon

### DIFF
--- a/internal/translator/anthropic_anthropic.go
+++ b/internal/translator/anthropic_anthropic.go
@@ -141,11 +141,12 @@ func (a *anthropicToAnthropicTranslator) extractUsageFromBufferEvent(s tracingap
 		}
 		line := a.buffered[:i]
 		a.buffered = a.buffered[i+1:]
-		if !bytes.HasPrefix(line, sseDataPrefix) {
+		data, ok := cutSSEDataPrefix(line)
+		if !ok {
 			continue
 		}
 		eventUnion := &anthropic.MessagesStreamChunk{}
-		if err := json.Unmarshal(bytes.TrimPrefix(line, sseDataPrefix), eventUnion); err != nil {
+		if err := json.Unmarshal(data, eventUnion); err != nil {
 			continue
 		}
 		if s != nil {

--- a/internal/translator/anthropic_anthropic_test.go
+++ b/internal/translator/anthropic_anthropic_test.go
@@ -307,3 +307,25 @@ func TestAnthropicToAnthropic_ResponseError(t *testing.T) {
 		})
 	}
 }
+
+// The space after "data:" is optional per the SSE specification, and some
+// Anthropic-compatible backends omit it. The stream must still yield usage.
+func TestAnthropicToAnthropic_ResponseBody_streaming_noSpaceAfterColon(t *testing.T) {
+	translator := NewAnthropicToAnthropicTranslator("", "")
+	require.NotNil(t, translator)
+	translator.(*anthropicToAnthropicTranslator).stream = true
+
+	const response = `event: message_start
+data:{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01","type":"message","role":"assistant","content":[],"usage":{"input_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":1,"output_tokens":0}}}
+
+event: message_delta
+data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":16}}
+
+event: message_stop
+data:{"type":"message_stop"}`
+
+	_, _, tokenUsage, responseModel, err := translator.ResponseBody(nil, strings.NewReader(response), true, nil)
+	require.NoError(t, err)
+	require.Equal(t, tokenUsageFrom(10, 1, 0, 16, 26, -1), tokenUsage)
+	require.Equal(t, "claude-sonnet-4-5-20250929", responseModel)
+}

--- a/internal/translator/anthropic_awsanthropic.go
+++ b/internal/translator/anthropic_awsanthropic.go
@@ -168,10 +168,10 @@ func (a *anthropicToAWSAnthropicTranslator) convertMessagesEventWrappedInAmazonE
 		}
 
 		a.reflectStreamingEvent(&event)
-		*out = append(*out, sseEventPrefix...)
+		*out = append(*out, sseEventPrefixSpace...)
 		*out = append(*out, event.Type...)
 		*out = append(*out, '\n')
-		*out = append(*out, sseDataPrefix...)
+		*out = append(*out, sseDataPrefixSpace...)
 		*out = append(*out, rawEvent.Bytes...)
 		*out = append(*out, '\n', '\n')
 		lastRead = r.Size() - int64(r.Len())

--- a/internal/translator/anthropic_awsbedrock.go
+++ b/internal/translator/anthropic_awsbedrock.go
@@ -747,10 +747,10 @@ func (a *anthropicToAWSBedrockTranslator) writeSSEEvent(eventType string, data a
 	if err != nil {
 		return
 	}
-	*out = append(*out, sseEventPrefix...)
+	*out = append(*out, sseEventPrefixSpace...)
 	*out = append(*out, eventType...)
 	*out = append(*out, '\n')
-	*out = append(*out, sseDataPrefix...)
+	*out = append(*out, sseDataPrefixSpace...)
 	*out = append(*out, jsonData...)
 	*out = append(*out, '\n', '\n')
 }

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -791,8 +791,9 @@ func anthropicToolUseToOpenAICalls(block *anthropic.ContentBlockUnion) ([]openai
 // following are streaming part
 
 var (
-	sseEventPrefix = []byte("event: ")
-	emptyStrPtr    = ptr.To("")
+	sseEventPrefixSpace = []byte("event: ")
+	sseEventPrefix      = []byte("event:")
+	emptyStrPtr         = ptr.To("")
 )
 
 // streamingToolCall holds the state for a single tool call that is being streamed.
@@ -995,7 +996,7 @@ func (p *anthropicStreamParser) Process(body io.Reader, endOfStream bool, span t
 			}
 		}
 		// Add the final [DONE] message to indicate the end of the stream.
-		newBody = append(newBody, sseDataPrefix...)
+		newBody = append(newBody, sseDataPrefixSpace...)
 		newBody = append(newBody, sseDoneMessage...)
 		newBody = append(newBody, '\n', '\n')
 	}
@@ -1009,9 +1010,9 @@ func (p *anthropicStreamParser) parseAndHandleEvent(eventBlock []byte) (*openai.
 
 	lines := bytes.SplitSeq(eventBlock, []byte("\n"))
 	for line := range lines {
-		if after, ok := bytes.CutPrefix(line, sseEventPrefix); ok {
+		if after, ok := cutSSEFieldPrefix(line, sseEventPrefix); ok {
 			eventType = bytes.TrimSpace(after)
-		} else if after, ok := bytes.CutPrefix(line, sseDataPrefix); ok {
+		} else if after, ok := cutSSEDataPrefix(line); ok {
 			// This handles JSON data that might be split across multiple 'data:' lines
 			// by concatenating them (Anthropic's format).
 			data := bytes.TrimSpace(after)

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -1742,3 +1742,31 @@ func TestOpenAIToAnthropicMessages_ToolResultCacheControl(t *testing.T) {
 		require.Equal(t, ephemeral, msgs[0].Content[0].OfToolResult.CacheControl)
 	})
 }
+
+// The space after the SSE field colon is optional per the specification, and some
+// Anthropic-compatible backends omit it on both "event:" and "data:" lines. The
+// parser must still recognize the events and yield usage.
+func TestAnthropicStreamParser_NoSpaceAfterColon(t *testing.T) {
+	p := newAnthropicStreamParser("claude-sonnet-4-5")
+
+	const stream = `event:message_start
+data:{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":9,"cache_read_input_tokens":1,"cache_creation_input_tokens":0,"output_tokens":0}}}
+
+event:message_delta
+data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":16}}
+
+event:message_stop
+data:{"type":"message_stop"}
+
+`
+
+	_, _, tokenUsage, _, err := p.Process(strings.NewReader(stream), true, nil)
+	require.NoError(t, err)
+
+	input, ok := tokenUsage.InputTokens()
+	require.True(t, ok, "input tokens were not extracted")
+	require.Equal(t, uint32(10), input)
+	output, ok := tokenUsage.OutputTokens()
+	require.True(t, ok, "output tokens were not extracted")
+	require.Equal(t, uint32(16), output)
+}

--- a/internal/translator/openai_completions.go
+++ b/internal/translator/openai_completions.go
@@ -154,10 +154,10 @@ func (o *openAIToOpenAITranslatorV1Completion) extractUsageFromBufferEvent(span 
 		}
 		line := o.buffered[:i]
 		o.buffered = o.buffered[i+1:]
-		if !bytes.HasPrefix(line, sseDataPrefix) {
+		data, ok := cutSSEDataPrefix(line)
+		if !ok {
 			continue
 		}
-		data := bytes.TrimPrefix(line, sseDataPrefix)
 		// Skip the [DONE] marker
 		if bytes.Equal(data, sseDoneMessage) {
 			continue

--- a/internal/translator/openai_gcpvertexai.go
+++ b/internal/translator/openai_gcpvertexai.go
@@ -314,8 +314,11 @@ func (o *openAIToGCPVertexAITranslatorV1ChatCompletion) parseGCPStreamingChunks(
 			continue
 		}
 
-		// Remove "data: " prefix from SSE format if present.
-		line := bytes.TrimPrefix(part, sseDataPrefix)
+		// Remove the "data:" field prefix from SSE format if present.
+		line, ok := cutSSEDataPrefix(part)
+		if !ok {
+			line = part
+		}
 
 		// Try to parse as JSON.
 		var chunk genai.GenerateContentResponse

--- a/internal/translator/openai_helper.go
+++ b/internal/translator/openai_helper.go
@@ -697,7 +697,7 @@ func (s *openAIStreamToAnthropicState) processBuffer(out *[]byte, endOfStream bo
 func (s *openAIStreamToAnthropicState) processEventBlock(block []byte, out *[]byte) error {
 	var eventData []byte
 	for line := range bytes.SplitSeq(block, []byte("\n")) {
-		if after, ok := bytes.CutPrefix(line, sseDataPrefix); ok {
+		if after, ok := cutSSEDataPrefix(line); ok {
 			data := bytes.TrimSpace(after)
 			if len(data) > 0 {
 				eventData = data

--- a/internal/translator/openai_openai.go
+++ b/internal/translator/openai_openai.go
@@ -190,11 +190,12 @@ func (o *openAIToOpenAITranslatorV1ChatCompletion) extractUsageFromBufferEvent(s
 		}
 		line := o.buffered[:i]
 		o.buffered = o.buffered[i+1:]
-		if !bytes.HasPrefix(line, sseDataPrefix) {
+		data, ok := cutSSEDataPrefix(line)
+		if !ok {
 			continue
 		}
 		event := &openai.ChatCompletionResponseChunk{}
-		if err := json.Unmarshal(bytes.TrimPrefix(line, sseDataPrefix), event); err != nil {
+		if err := json.Unmarshal(data, event); err != nil {
 			continue
 		}
 		if span != nil {

--- a/internal/translator/openai_openai_test.go
+++ b/internal/translator/openai_openai_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -699,4 +700,32 @@ func TestRedactBody(t *testing.T) {
 		require.Equal(t, originalContentCopy, *resp.Choices[0].Message.Content)
 		require.NotContains(t, *resp.Choices[0].Message.Content, "[REDACTED")
 	})
+}
+
+// The space after "data:" is optional per the SSE specification, and some
+// OpenAI-compatible backends omit it. The stream must still yield usage.
+func TestOpenAIToOpenAI_ResponseBody_streaming_noSpaceAfterColon(t *testing.T) {
+	translator := &openAIToOpenAITranslatorV1ChatCompletion{stream: true}
+
+	const response = `data:{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"hi"}}]}
+
+data:{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":16,"total_tokens":25}}
+
+data:[DONE]
+
+`
+
+	_, _, tokenUsage, responseModel, err := translator.ResponseBody(nil, strings.NewReader(response), true, nil)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-4o", responseModel)
+
+	input, ok := tokenUsage.InputTokens()
+	require.True(t, ok)
+	require.Equal(t, uint32(9), input)
+	output, ok := tokenUsage.OutputTokens()
+	require.True(t, ok)
+	require.Equal(t, uint32(16), output)
+	total, ok := tokenUsage.TotalTokens()
+	require.True(t, ok)
+	require.Equal(t, uint32(25), total)
 }

--- a/internal/translator/openai_responses.go
+++ b/internal/translator/openai_responses.go
@@ -169,12 +169,12 @@ func (o *openAIToOpenAITranslatorV1Responses) extractUsageFromBufferEvent(span t
 		event := o.buffered[:i]
 		o.buffered = o.buffered[i+2:]
 		for line := range bytes.SplitSeq(event, []byte("\n")) {
-			// Look for lines starting with "data: "
-			if !bytes.HasPrefix(line, sseDataPrefix) {
+			// Look for lines carrying the "data" field.
+			data, ok := cutSSEDataPrefix(line)
+			if !ok {
 				continue
 			}
 
-			data := bytes.TrimPrefix(line, sseDataPrefix)
 			if len(data) == 0 || bytes.Equal(data, sseDoneMessage) {
 				continue
 			}

--- a/internal/translator/openai_speech.go
+++ b/internal/translator/openai_speech.go
@@ -148,12 +148,12 @@ func (o *openAIToOpenAITranslatorV1Speech) recordSSEChunksToSpan(span tracingapi
 		event := o.buffered[:i]
 		o.buffered = o.buffered[i+2:]
 		for line := range bytes.SplitSeq(event, []byte("\n")) {
-			// Look for lines starting with "data: "
-			if !bytes.HasPrefix(line, sseDataPrefix) {
+			// Look for lines carrying the "data" field.
+			data, ok := cutSSEDataPrefix(line)
+			if !ok {
 				continue
 			}
 
-			data := bytes.TrimPrefix(line, sseDataPrefix)
 			if len(data) == 0 || bytes.Equal(data, sseDoneMessage) {
 				continue
 			}

--- a/internal/translator/openai_transcription.go
+++ b/internal/translator/openai_transcription.go
@@ -132,10 +132,10 @@ func (o *openAIToOpenAITranslatorV1Transcription) recordTranscriptionStreamChunk
 		o.sseBuffer = o.sseBuffer[i+1:]
 		// Some servers terminate SSE lines with \r\n; strip the trailing CR before JSON decode.
 		line = bytes.TrimRight(line, "\r")
-		if !bytes.HasPrefix(line, sseDataPrefix) {
+		payload, ok := cutSSEDataPrefix(line)
+		if !ok {
 			continue
 		}
-		payload := bytes.TrimPrefix(line, sseDataPrefix)
 		if len(payload) == 0 || bytes.Equal(payload, sseDoneMessage) {
 			continue
 		}

--- a/internal/translator/util.go
+++ b/internal/translator/util.go
@@ -6,6 +6,7 @@
 package translator
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"regexp"
@@ -25,10 +26,30 @@ const (
 )
 
 var (
-	sseDataPrefix   = []byte("data: ")
-	sseDoneMessage  = []byte("[DONE]")
-	sseDoneFullLine = append(append(sseDataPrefix, sseDoneMessage...), '\n')
+	// sseDataPrefixSpace is the canonical form the gateway emits; reads go through
+	// cutSSEDataPrefix, which also accepts the field without the space.
+	sseDataPrefixSpace = []byte("data: ")
+	sseDataPrefix      = []byte("data:")
+	sseDoneMessage     = []byte("[DONE]")
+	sseDoneFullLine    = append(append(sseDataPrefixSpace, sseDoneMessage...), '\n')
 )
+
+// cutSSEFieldPrefix strips an SSE field-name prefix such as "data:" from a line,
+// accepting the optional space after the colon:
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+func cutSSEFieldPrefix(line, fieldName []byte) ([]byte, bool) {
+	after, ok := bytes.CutPrefix(line, fieldName)
+	if !ok {
+		return nil, false
+	}
+	// Only one leading space belongs to the framing; anything beyond it is data.
+	return bytes.TrimPrefix(after, []byte{' '}), true
+}
+
+// cutSSEDataPrefix is cutSSEFieldPrefix for the "data" field.
+func cutSSEDataPrefix(line []byte) ([]byte, bool) {
+	return cutSSEFieldPrefix(line, sseDataPrefix)
+}
 
 // regDataURI follows the web uri regex definition.
 // https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data#syntax
@@ -77,7 +98,7 @@ func serializeOpenAIChatCompletionChunk(chunk *openai.ChatCompletionResponseChun
 	if err != nil {
 		return fmt.Errorf("failed to marshal stream chunk: %w", err)
 	}
-	*buf = append(*buf, sseDataPrefix...)
+	*buf = append(*buf, sseDataPrefixSpace...)
 	*buf = append(*buf, chunkBytes...)
 	*buf = append(*buf, '\n', '\n')
 	return nil

--- a/internal/translator/util_test.go
+++ b/internal/translator/util_test.go
@@ -87,3 +87,31 @@ func TestSystemMsgToDeveloperMsg(t *testing.T) {
 	require.Equal(t, openai.ChatMessageRoleDeveloper, developerMsg.Role)
 	require.Equal(t, openai.ContentUnion{Value: "You are a helpful assistant."}, developerMsg.Content)
 }
+
+func TestCutSSEDataPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		line     string
+		expected string
+		ok       bool
+	}{
+		{name: "space after colon", line: `data: {"a":1}`, expected: `{"a":1}`, ok: true},
+		{name: "no space after colon", line: `data:{"a":1}`, expected: `{"a":1}`, ok: true},
+		{name: "only the first space is framing", line: `data:  {"a":1}`, expected: ` {"a":1}`, ok: true},
+		{name: "empty value", line: "data:", expected: "", ok: true},
+		{name: "empty value with space", line: "data: ", expected: "", ok: true},
+		{name: "done marker without space", line: "data:[DONE]", expected: "[DONE]", ok: true},
+		{name: "other field", line: "event: message_start", ok: false},
+		{name: "comment", line: ": keep-alive", ok: false},
+		{name: "not a field", line: `{"a":1}`, ok: false},
+		{name: "empty line", line: "", ok: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, ok := cutSSEDataPrefix([]byte(tc.line))
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				require.Equal(t, tc.expected, string(data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

The space after `data:` is optional per the SSE specification, but the translators only matched the spaced form, so a stream sending `data:{...}` had every event silently skipped. 

The response bytes still reach the client untouched, but the gateway observes nothing: token usage, the resolved response model, and tracing chunks are all lost. In production this looks like requests succeeding while usage is recorded as zero, which breaks usage-based metrics and any downstream cost or quota logic.

This adds `cutSSEFieldPrefix`, which strips an SSE field name and removes at most one leading space, and uses it at every `data:` read site plus the `event:` read site in the Anthropic stream parser. Emitted streams are unchanged and keep the canonical spaced form.

**Related Issues/PRs (if applicable)**

Related to #2149

**Special notes for reviewers (if applicable)**

The new streaming regression tests fail without the fix: usage comes back all zeros while the response itself passes through normally.