### PR TITLE
fix: carry Anthropic tool input schemas as-is

### DIFF
--- a/internal/apischema/anthropic/anthropic.go
+++ b/internal/apischema/anthropic/anthropic.go
@@ -1033,9 +1033,12 @@ type (
 	// Tool represents a custom tool definition.
 	// https://platform.claude.com/docs/en/api/messages#tool
 	Tool struct {
-		Type         string          `json:"type"` // Always "custom".
-		Name         string          `json:"name"`
-		InputSchema  ToolInputSchema `json:"input_schema"`
+		Type string `json:"type"` // Always "custom".
+		Name string `json:"name"`
+		// InputSchema is the JSON schema of the tool input, carried as-is. Modeling its
+		// keywords would drop the ones left out, such as "additionalProperties", which
+		// backends require to enable strict schema adherence.
+		InputSchema  json.RawMessage `json:"input_schema"`
 		CacheControl *CacheControl   `json:"cache_control,omitempty"`
 		Description  string          `json:"description,omitempty"`
 	}
@@ -1092,12 +1095,6 @@ type (
 		Country  string `json:"country,omitempty"`
 		Region   string `json:"region,omitempty"`
 		Timezone string `json:"timezone,omitempty"`
-	}
-
-	ToolInputSchema struct {
-		Type       string         `json:"type"` // Always "object".
-		Properties map[string]any `json:"properties,omitempty"`
-		Required   []string       `json:"required,omitempty"`
 	}
 )
 

--- a/internal/apischema/anthropic/anthropic_test.go
+++ b/internal/apischema/anthropic/anthropic_test.go
@@ -706,7 +706,7 @@ func TestToolUnion_UnmarshalJSON(t *testing.T) {
 			jsonStr: `{"type":"custom","name":"my_tool","input_schema":{"type":"object"}}`,
 			want: ToolUnion{Tool: &Tool{
 				Type: "custom", Name: "my_tool",
-				InputSchema: ToolInputSchema{Type: "object"},
+				InputSchema: json.RawMessage(`{"type":"object"}`),
 			}},
 		},
 		{
@@ -739,7 +739,7 @@ func TestToolUnion_UnmarshalJSON(t *testing.T) {
 			jsonStr: `{"name":"my_tool","description":"A tool","input_schema":{"type":"object"}}`,
 			want: ToolUnion{Tool: &Tool{
 				Name: "my_tool", Description: "A tool",
-				InputSchema: ToolInputSchema{Type: "object"},
+				InputSchema: json.RawMessage(`{"type":"object"}`),
 			}},
 		},
 		{
@@ -747,7 +747,7 @@ func TestToolUnion_UnmarshalJSON(t *testing.T) {
 			jsonStr: `{"type":"","name":"my_tool","input_schema":{"type":"object"}}`,
 			want: ToolUnion{Tool: &Tool{
 				Type: "", Name: "my_tool",
-				InputSchema: ToolInputSchema{Type: "object"},
+				InputSchema: json.RawMessage(`{"type":"object"}`),
 			}},
 		},
 		{
@@ -780,7 +780,7 @@ func TestToolUnion_MarshalJSON(t *testing.T) {
 	}{
 		{
 			name: "custom tool",
-			tu:   ToolUnion{Tool: &Tool{Type: "custom", Name: "t", InputSchema: ToolInputSchema{Type: "object"}}},
+			tu:   ToolUnion{Tool: &Tool{Type: "custom", Name: "t", InputSchema: json.RawMessage(`{"type":"object"}`)}},
 			want: `{"type":"custom","name":"t","input_schema":{"type":"object"}}`,
 		},
 		{
@@ -1093,7 +1093,7 @@ func TestToolUnion_UnmarshalJSON_ErrorPaths(t *testing.T) {
 		name    string
 		jsonStr string
 	}{
-		{name: "custom invalid", jsonStr: `{"type":"custom","input_schema":"bad"}`},
+		{name: "custom invalid", jsonStr: `{"type":"custom","name":123}`},
 		{name: "bash invalid", jsonStr: `{"type":"bash_20250124","name":123}`},
 		{name: "text_editor_20250124 invalid", jsonStr: `{"type":"text_editor_20250124","name":123}`},
 		{name: "text_editor_20250429 invalid", jsonStr: `{"type":"text_editor_20250429","name":123}`},

--- a/internal/translator/anthropic_awsbedrock_test.go
+++ b/internal/translator/anthropic_awsbedrock_test.go
@@ -700,13 +700,7 @@ func TestAnthropicToAWSBedrockTranslator_RequestBody_Tools(t *testing.T) {
 					Type:        "custom",
 					Name:        "get_weather",
 					Description: "Get the weather",
-					InputSchema: anthropicschema.ToolInputSchema{
-						Type: "object",
-						Properties: map[string]any{
-							"location": map[string]any{"type": "string"},
-						},
-						Required: []string{"location"},
-					},
+					InputSchema: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
 				},
 			},
 		},
@@ -998,7 +992,7 @@ func TestAnthropicToAWSBedrockTranslator_RequestBody_ToolResultMessages(t *testi
 				Type:        "custom",
 				Name:        "get_weather",
 				Description: "Get weather",
-				InputSchema: anthropicschema.ToolInputSchema{Type: "object"},
+				InputSchema: json.RawMessage(`{"type":"object"}`),
 			}},
 		},
 		ToolChoice: &anthropicschema.ToolChoice{
@@ -1107,7 +1101,7 @@ func TestAnthropicToAWSBedrockTranslator_RequestBody_ToolResultMessagesWithSyste
 				Type:        "custom",
 				Name:        "get_weather",
 				Description: "Get weather",
-				InputSchema: anthropicschema.ToolInputSchema{Type: "object"},
+				InputSchema: json.RawMessage(`{"type":"object"}`),
 			}},
 		},
 		Messages: []anthropicschema.MessageParam{
@@ -1226,7 +1220,7 @@ func TestAnthropicToAWSBedrockTranslator_RequestBody_SingleToolResultNotCoalesce
 				Type:        "custom",
 				Name:        "get_weather",
 				Description: "Get weather",
-				InputSchema: anthropicschema.ToolInputSchema{Type: "object"},
+				InputSchema: json.RawMessage(`{"type":"object"}`),
 			}},
 		},
 		Messages: []anthropicschema.MessageParam{

--- a/internal/translator/anthropic_gcpanthropic_test.go
+++ b/internal/translator/anthropic_gcpanthropic_test.go
@@ -126,16 +126,7 @@ func TestAnthropicToGCPAnthropicTranslator_ComprehensiveMarshalling(t *testing.T
 			{Tool: &anthropic.Tool{
 				Name:        "get_weather",
 				Description: "Get current weather information",
-				InputSchema: anthropic.ToolInputSchema{
-					Type: "object",
-					Properties: map[string]any{
-						"location": map[string]any{
-							"type":        "string",
-							"description": "City name",
-						},
-					},
-					Required: []string{"location"},
-				},
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string","description":"City name"}},"required":["location"]}`),
 			}},
 		},
 		ToolChoice: &anthropic.ToolChoice{Auto: &anthropic.ToolChoiceAuto{Type: "auto"}},
@@ -350,12 +341,7 @@ func TestAnthropicToGCPAnthropicTranslator_RequestBody_FieldPassthrough(t *testi
 			{Tool: &anthropic.Tool{
 				Name:        "get_weather",
 				Description: "Get weather info",
-				InputSchema: anthropic.ToolInputSchema{
-					Type: "object",
-					Properties: map[string]any{
-						"location": map[string]any{"type": "string"},
-					},
-				},
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}}}`),
 			}},
 		},
 		ToolChoice: &anthropic.ToolChoice{Auto: &anthropic.ToolChoiceAuto{Type: "auto"}},

--- a/internal/translator/openai_helper_test.go
+++ b/internal/translator/openai_helper_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/json"
 )
 
 // sseEvent holds parsed Anthropic SSE event data.
@@ -169,10 +170,7 @@ func TestBuildOpenAIChatCompletionRequest(t *testing.T) {
 				{Tool: &anthropic.Tool{
 					Name:        "get_weather",
 					Description: "Retrieve current weather information",
-					InputSchema: anthropic.ToolInputSchema{
-						Type:     "object",
-						Required: []string{"location"},
-					},
+					InputSchema: json.RawMessage(`{"type":"object","required":["location"]}`),
 				}},
 			},
 		}
@@ -200,7 +198,7 @@ func TestBuildOpenAIChatCompletionRequest(t *testing.T) {
 		body := &anthropic.MessagesRequest{
 			Model:      "claude-3",
 			Messages:   []anthropic.MessageParam{{Role: anthropic.MessageRoleUser, Content: anthropic.MessageContent{Text: "Hi"}}},
-			Tools:      []anthropic.ToolUnion{{Tool: &anthropic.Tool{Name: "search", InputSchema: anthropic.ToolInputSchema{Type: "object"}}}},
+			Tools:      []anthropic.ToolUnion{{Tool: &anthropic.Tool{Name: "search", InputSchema: json.RawMessage(`{"type":"object"}`)}}},
 			ToolChoice: ptr.To(anthropic.ToolChoice{Auto: &anthropic.ToolChoiceAuto{Type: "auto"}}),
 		}
 		req := buildOpenAIChatCompletionRequest(body, "")
@@ -302,11 +300,7 @@ func TestAnthropicToolsToOpenAI(t *testing.T) {
 			{Tool: &anthropic.Tool{
 				Name:        "search",
 				Description: "Search the web",
-				InputSchema: anthropic.ToolInputSchema{
-					Type:       "object",
-					Properties: map[string]any{"query": map[string]any{"type": "string"}},
-					Required:   []string{"query"},
-				},
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`),
 			}},
 		}
 		result := anthropicToolsToOpenAI(tools)
@@ -319,13 +313,25 @@ func TestAnthropicToolsToOpenAI(t *testing.T) {
 
 	t.Run("multiple tools all converted", func(t *testing.T) {
 		tools := []anthropic.ToolUnion{
-			{Tool: &anthropic.Tool{Name: "tool1", InputSchema: anthropic.ToolInputSchema{Type: "object"}}},
-			{Tool: &anthropic.Tool{Name: "tool2", InputSchema: anthropic.ToolInputSchema{Type: "object"}}},
+			{Tool: &anthropic.Tool{Name: "tool1", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+			{Tool: &anthropic.Tool{Name: "tool2", InputSchema: json.RawMessage(`{"type":"object"}`)}},
 		}
 		result := anthropicToolsToOpenAI(tools)
 		require.Len(t, result, 2)
 		assert.Equal(t, "tool1", result[0].Function.Name)
 		assert.Equal(t, "tool2", result[1].Function.Name)
+	})
+
+	t.Run("schema reaches the backend as sent", func(t *testing.T) {
+		const inputSchema = `{"type":"object","properties":{},"additionalProperties":false,"$defs":{"unit":{"enum":["c","f"]}}}`
+		var tool anthropic.ToolUnion
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"get_time","input_schema":`+inputSchema+`}`), &tool))
+
+		result := anthropicToolsToOpenAI([]anthropic.ToolUnion{tool})
+		require.Len(t, result, 1)
+		parameters, err := json.Marshal(result[0].Function.Parameters)
+		require.NoError(t, err)
+		require.JSONEq(t, inputSchema, string(parameters))
 	})
 }
 


### PR DESCRIPTION
**Description**

An Anthropic tool declares its input as a JSON schema, but the gateway modeled that schema as a struct with only "type", "properties" and "required". 
Everything else a client sends is silently dropped on the way to the backend: "additionalProperties", which backends need to enable strict schema adherence, the per-property "description" the model relies on to call the tool correctly, "$defs", and so on.
We hit this with a tool that takes no arguments: its empty "properties" was dropped too, and the OpenAI-compatible backend rejected the whole request with 400 invalid_function_parameters, "object schema missing properties".

The schema is now carried as raw JSON, so tools reach the backend as the client declared them. This covers both the Anthropic-to-OpenAI and the Anthropic-to-Bedrock conversions, which shared the struct.

**Related Issues/PRs (if applicable)**

**Special notes for reviewers (if applicable)**
