### PR TITLE
fix: defensive fix on guided choice  for gemini models

### DIFF
--- a/internal/translator/gemini_helper.go
+++ b/internal/translator/gemini_helper.go
@@ -914,6 +914,13 @@ func extractTextAndThoughtSummaryFromGeminiParts(parts []*genai.Part, responseMo
 					part.Text = strings.TrimPrefix(part.Text, "\"")
 					part.Text = strings.TrimSuffix(part.Text, "\"")
 				}
+				if responseMode == responseModeEnum {
+					// GCP's ENUM response mode is expected to return  exactly one of the provided enum values.
+					//  However, sometimes, gemini models can emit surrounding whitespace (e.g. ` negative`
+					// instead of `negative`), which breaks exact-match consumers. Trim it so the
+					// output matches the requested choices verbatim.
+					part.Text = strings.TrimSpace(part.Text)
+				}
 				// ThoughtSignature is only appended with Thought as False
 				if part.ThoughtSignature != nil {
 					signatureBuilder.WriteString(base64.StdEncoding.EncodeToString(part.ThoughtSignature))

--- a/internal/translator/gemini_helper_test.go
+++ b/internal/translator/gemini_helper_test.go
@@ -2579,6 +2579,24 @@ func TestExtractTextAndThoughtSummaryFromGeminiParts(t *testing.T) {
 			expectedText:           `He said \"hello\" to me`,
 		},
 		{
+			name: "enum mode trims surrounding whitespace",
+			parts: []*genai.Part{
+				{Text: " negative"},
+			},
+			responseMode:           responseModeEnum,
+			expectedThoughtSummary: "",
+			expectedText:           "negative",
+		},
+		{
+			name: "non-enum mode preserves surrounding whitespace",
+			parts: []*genai.Part{
+				{Text: " negative"},
+			},
+			responseMode:           responseModeJSON,
+			expectedThoughtSummary: "",
+			expectedText:           " negative",
+		},
+		{
 			name: "test thought summary",
 			parts: []*genai.Part{
 				{Text: "Let me think step by step", Thought: true},


### PR DESCRIPTION
**Description**
Sometimes, gemini models return ` negative` with a leading space for `text/x.enum`, violating the enum contract that the output should be exactly one of the provided values. The gateway had trimming logic for `responseModeRegex` (strips wrapping quotes) but nothing for `responseModeEnum`, so just strip whitespaces for `responseModeEnum`.