### PR TITLE
fix(translator): emit bedrock tool cache point as its own tools[] element

### DIFF
--- a/internal/apischema/awsbedrock/awsbedrock.go
+++ b/internal/apischema/awsbedrock/awsbedrock.go
@@ -566,8 +566,9 @@ type ToolConfiguration struct {
 // information, see Tool use (function calling) (https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html)
 // in the Amazon Bedrock User Guide.
 type Tool struct {
-	// The specification for the tool.
-	ToolSpec *ToolSpecification `json:"toolSpec"`
+	// The specification for the tool. Omitted when this element only carries a cache point,
+	// as Bedrock rejects an element that sets more than one of the union's members.
+	ToolSpec *ToolSpecification `json:"toolSpec,omitempty"`
 
 	// Cache point for prompt caching. Enables caching of preceding content.
 	// See https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html for more information.

--- a/internal/translator/converse_helper.go
+++ b/internal/translator/converse_helper.go
@@ -46,9 +46,12 @@ func openAIToolsToBedrockToolConfig(tools []openai.Tool, toolChoice *openai.Chat
 						JSON: toolDefinition.Function.Parameters,
 					},
 				},
-				CachePoint: getCachePoint(toolDefinition.Function.AnthropicContentFields),
 			}
 			bedrockTools = append(bedrockTools, tool)
+			// Bedrock's Tool is a union: an element sets either toolSpec or cachePoint, never both.
+			if cachePointBlock := getCachePoint(toolDefinition.Function.AnthropicContentFields); cachePointBlock != nil {
+				bedrockTools = append(bedrockTools, &awsbedrock.Tool{CachePoint: cachePointBlock})
+			}
 		}
 	}
 	toolConfig.Tools = bedrockTools

--- a/internal/translator/converse_helper_test.go
+++ b/internal/translator/converse_helper_test.go
@@ -8,12 +8,15 @@ package translator
 import (
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/shared/constant"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	"github.com/envoyproxy/ai-gateway/internal/apischema/awsbedrock"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/json"
 )
 
 func TestOpenAIToolsToBedrockToolConfig(t *testing.T) {
@@ -159,6 +162,36 @@ func TestOpenAIToolsToBedrockToolConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "cache control on a tool appends a separate cache point element",
+			tools: []openai.Tool{
+				{
+					Type: openai.ToolTypeFunction,
+					Function: &openai.FunctionDefinition{
+						Name:        "get_current_weather",
+						Description: "Get the current weather in a given location",
+						Parameters:  map[string]any{"type": "object"},
+						AnthropicContentFields: &openai.AnthropicContentFields{
+							CacheControl: anthropic.CacheControlEphemeralParam{
+								Type: constant.ValueOf[constant.Ephemeral](),
+							},
+						},
+					},
+				},
+			},
+			expected: &awsbedrock.ToolConfiguration{
+				Tools: []*awsbedrock.Tool{
+					{
+						ToolSpec: &awsbedrock.ToolSpecification{
+							Name:        ptr.To("get_current_weather"),
+							Description: ptr.To("Get the current weather in a given location"),
+							InputSchema: &awsbedrock.ToolInputSchema{JSON: map[string]any{"type": "object"}},
+						},
+					},
+					{CachePoint: &awsbedrock.CachePointBlock{Type: "default"}},
+				},
+			},
+		},
+		{
 			name:  "unsupported tool_choice type returns an error",
 			tools: []openai.Tool{weatherTool},
 			toolChoice: &openai.ChatCompletionToolChoiceUnion{
@@ -178,6 +211,16 @@ func TestOpenAIToolsToBedrockToolConfig(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, got)
+			// Bedrock rejects a tools[] element that sets more than one of the union's members,
+			// and it rejects an explicit "toolSpec":null alongside a cache point.
+			for i, tool := range got.Tools {
+				require.False(t, tool.ToolSpec != nil && tool.CachePoint != nil, "tools[%d] sets both toolSpec and cachePoint", i)
+				raw, err := json.Marshal(tool)
+				require.NoError(t, err)
+				if tool.ToolSpec == nil {
+					require.NotContains(t, string(raw), "toolSpec", "tools[%d] marshals a toolSpec key without a spec", i)
+				}
+			}
 		})
 	}
 }

--- a/internal/translator/openai_awsbedrock_test.go
+++ b/internal/translator/openai_awsbedrock_test.go
@@ -2593,7 +2593,7 @@ func TestOpenAIToAWSBedrockTranslator_CacheControl(t *testing.T) {
 					},
 				},
 			},
-			expectedJSON: `{"inferenceConfig":{},"messages":[{"content":[{"text":"Test message"}],"role":"user"}],"toolConfig":{"tools":[{"toolSpec":{"description":"Get weather information","inputSchema":{"json":{"type":"object"}},"name":"get_weather"},"cachePoint":{"type":"default"}}]}}`,
+			expectedJSON: `{"inferenceConfig":{},"messages":[{"content":[{"text":"Test message"}],"role":"user"}],"toolConfig":{"tools":[{"toolSpec":{"description":"Get weather information","inputSchema":{"json":{"type":"object"}},"name":"get_weather"}},{"cachePoint":{"type":"default"}}]}}`,
 		},
 		{
 			name: "no cache control",


### PR DESCRIPTION
**Description**

`toolConfig.tools[]` in the Bedrock Converse API is a union: an element sets exactly one of
`toolSpec`, `systemTool`, `modelTool` or `cachePoint`. When an OpenAI request carried
`cache_control` on a tool definition, `openAIToolsToBedrockToolConfig` set both `toolSpec` and
`cachePoint` on the same element, and Bedrock rejected the whole request with a non-retryable 400:

```
The value at toolConfig.tools.11 can only set one of the following keys:
toolSpec, systemTool, modelTool, or cachePoint.
```

This blocks any client that caches tool definitions from using a Bedrock backend at all, since
every request carrying such a tool fails on the first inference call.

The cache point is now appended as its own `tools[]` element, which is how every content block
path already handles it — user text, image, assistant content and system content each append a
standalone cache point block. The tools path was the one place that folded it into the preceding
element, which is why this only surfaced for clients that cache tool definitions rather than only
system prompts and messages.

`Tool.ToolSpec` also needed `omitempty`. Without it a cache-point-only element marshals as
`{"toolSpec":null,"cachePoint":{"type":"default"}}`, which Bedrock rejects for the same reason.
`ContentBlock.CachePoint` and the tool result variant were already `omitempty`, so only the `Tool`
union needed the tag.

Tests: the existing "cache control on tool definition" case in
`TestOpenAIToAWSBedrockTranslator_CacheControl` asserted the rejected shape and is updated to the
two-element form. `TestOpenAIToolsToBedrockToolConfig` gains a cache control case, plus an
assertion across every case that no `tools[]` element sets both members and that a cache-point-only
element marshals without a `toolSpec` key. Both fail on `main` and pass with this change.

**Related Issues/PRs (if applicable)**

Fixes #2475

Related PR: #1717, which fixed the same union violation for message content blocks but did not
cover the tools path.

**Special notes for reviewers (if applicable)**

The Anthropic to Bedrock translator (`anthropic_awsbedrock.go`, `convertTools`) never sets a cache
point on tools, so it does not hit this 400, but it silently drops `cache_control` on tool
definitions. That looks like a separate gap and is left out of this change; happy to file it
separately if it is worth tracking.

Per the generative AI policy: an AI assistant was used while preparing this change. I have
reviewed it, understand it, and take full ownership of it.
